### PR TITLE
fix: ruff issue with make check

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -266,7 +266,7 @@ class KimiSoul:
 
     @staticmethod
     def _is_retryable_error(exception: BaseException) -> bool:
-        if isinstance(exception, (APIConnectionError, APITimeoutError)):
+        if isinstance(exception, APIConnectionError | APITimeoutError):
             return True
         return isinstance(exception, APIStatusError) and exception.status_code in (
             429,  # Too Many Requests

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -291,7 +291,7 @@ async def test_grep_invalid_pattern(grep_tool: Grep):
     """Test with invalid regex pattern."""
     result = await grep_tool(Params(pattern="[invalid", path=".", output_mode="files_with_matches"))
     # Should handle the error gracefully
-    assert isinstance(result, (ToolOk, ToolError))  # Either way should not crash
+    assert isinstance(result, ToolOk | ToolError)  # Either way should not crash
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
run `make check`


➜  kimi-cli git:(main) ruff check .
src/kimi_cli/soul/kimisoul.py:269:12: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
    |
267 |     @staticmethod
268 |     def _is_retryable_error(exception: BaseException) -> bool:
269 |         if isinstance(exception, (APIConnectionError, APITimeoutError)):
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP038
270 |             return True
271 |         return isinstance(exception, APIStatusError) and exception.status_code in (
    |
    = help: Convert to `X | Y`

tests/test_grep.py:294:12: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
    |
292 |     result = await grep_tool(Params(pattern="[invalid", path=".", output_mode="files_with_matches"))
293 |     # Should handle the error gracefully
294 |     assert isinstance(result, (ToolOk, ToolError))  # Either way should not crash
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP038
    |
    = help: Convert to `X | Y`

Found 2 errors.
No fixes available (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
➜  kimi-cli git:(main) ruff check . --unsafe-fixes
src/kimi_cli/soul/kimisoul.py:269:12: UP038 [*] Use `X | Y` in `isinstance` call instead of `(X, Y)`
    |
267 |     @staticmethod
268 |     def _is_retryable_error(exception: BaseException) -> bool:
269 |         if isinstance(exception, (APIConnectionError, APITimeoutError)):
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP038
270 |             return True
271 |         return isinstance(exception, APIStatusError) and exception.status_code in (
    |
    = help: Convert to `X | Y`

tests/test_grep.py:294:12: UP038 [*] Use `X | Y` in `isinstance` call instead of `(X, Y)`
    |
292 |     result = await grep_tool(Params(pattern="[invalid", path=".", output_mode="files_with_matches"))
293 |     # Should handle the error gracefully
294 |     assert isinstance(result, (ToolOk, ToolError))  # Either way should not crash
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP038
    |
    = help: Convert to `X | Y`

Found 2 errors.
[*] 2 fixable with the --fix option.

my ruff version

```cli
➜  kimi-cli git:(hy/fix_make_check_issue) ruff --version
ruff 0.11.0
```