### PR TITLE
docs: fix config directory path in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ uv run pyinstaller kimi.spec
 
 ### Configuration
 
-Configuration file: `~/.config/kimi/config.json`
+Configuration file: `~/.kimi/config.json`
 
 Default configuration includes:
 - LLM provider settings (Kimi API by default)
@@ -174,7 +174,7 @@ Builtin variables available in system prompts:
 - **PyPI Package**: Distributed as `kimi-cli`
 - **Standalone Binary**: Built with PyInstaller
 - **Entry Point**: `kimi` command-line tool
-- **Configuration**: User-specific config in `~/.config/kimi/`
+- **Configuration**: User-specific config in `~/.kimi/`
 
 ## Version History
 


### PR DESCRIPTION
Update config directory path from ~/.config/kimi/ to ~/.kimi/ to match the actual implementation.

The config directory was changed to ~/.kimi/, but AGENTS.md was not updated accordingly.