### PR TITLE
feat: add Windows support for directory listing

### DIFF
--- a/src/kimi_cli/__init__.py
+++ b/src/kimi_cli/__init__.py
@@ -301,8 +301,13 @@ async def kimi_run(
         stream = ui != "print"  # use non-streaming mode only for print UI
         llm = create_llm(provider, model, stream=stream, session_id=session.id)
 
-    # TODO: support Windows
-    ls = subprocess.run(["ls", "-la"], capture_output=True, text=True)
+    # Get directory listing
+    if sys.platform == "win32":
+        ls = subprocess.run(
+            ["cmd", "/c", "dir"], capture_output=True, text=True, encoding="utf-8", errors="replace"
+        )
+    else:
+        ls = subprocess.run(["ls", "-la"], capture_output=True, text=True)
     agents_md = load_agents_md(work_dir) or ""
     if agents_md:
         echo(f"✓ Loaded agents.md: {textwrap.shorten(agents_md, width=100)}")

--- a/src/kimi_cli/agent.py
+++ b/src/kimi_cli/agent.py
@@ -51,7 +51,7 @@ class BuiltinSystemPromptArgs(NamedTuple):
     KIMI_WORK_DIR: Path
     """The current working directory."""
     KIMI_WORK_DIR_LS: str
-    """The `ls -la` output of current working directory."""
+    """The directory listing of current working directory."""
     KIMI_AGENTS_MD: str  # TODO: move to first message from system prompt
     """The content of AGENTS.md."""
 

--- a/src/kimi_cli/agents/koder/system.md
+++ b/src/kimi_cli/agents/koder/system.md
@@ -47,7 +47,7 @@ The operating environment is not in a sandbox. Any action especially mutation yo
 
 The current working directory is `${KIMI_WORK_DIR}`. This should be considered as the project root if you are instructed to perform tasks on the project. Every file system operation will be relative to the working directory if you do not explicitly specify the absolute path. Tools may require absolute paths for some parameters, if so, you should strictly follow the requirements.
 
-The `ls -la` output of current working directory is:
+The directory listing of current working directory is:
 
 ```
 ${KIMI_WORK_DIR_LS}

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -61,7 +61,7 @@ The operating environment is not in a sandbox. Any action especially mutation yo
 
 The current working directory is `/path/to/work/dir`. This should be considered as the project root if you are instructed to perform tasks on the project. Every file system operation will be relative to the working directory if you do not explicitly specify the absolute path. Tools may require absolute paths for some parameters, if so, you should strictly follow the requirements.
 
-The `ls -la` output of current working directory is:
+The directory listing of current working directory is:
 
 ```
 Test ls content

--- a/tests/test_task_subagents.py
+++ b/tests/test_task_subagents.py
@@ -70,7 +70,7 @@ The operating environment is not in a sandbox. Any action especially mutation yo
 
 The current working directory is `/path/to/work/dir`. This should be considered as the project root if you are instructed to perform tasks on the project. Every file system operation will be relative to the working directory if you do not explicitly specify the absolute path. Tools may require absolute paths for some parameters, if so, you should strictly follow the requirements.
 
-The `ls -la` output of current working directory is:
+The directory listing of current working directory is:
 
 ```
 Test ls content


### PR DESCRIPTION
Adding Windows support for the directory listing feature by using the `dir` command on Windows while maintaining `ls -la` on Unix-like systems (macOS/Linux).
I also update the system prompt in order to make the model not be confused by the output of the directory listing.
