### PR TITLE
Fixing the issue where circular dependencies cause a Reload exception that cannot be caught

### DIFF
--- a/src/kimi_cli/cli.py
+++ b/src/kimi_cli/cli.py
@@ -15,12 +15,6 @@ from kimi_cli.ui.print import InputFormat, OutputFormat
 from kimi_cli.utils.logging import logger
 
 
-class Reload(Exception):
-    """Reload configuration."""
-
-    pass
-
-
 UIMode = Literal["shell", "print", "acp"]
 
 
@@ -230,6 +224,8 @@ def kimi(
                 if command is not None:
                     logger.warning("ACP server ignores command argument")
                 return await instance.run_acp_server()
+
+    from kimi_cli.exception import Reload
 
     while True:
         try:

--- a/src/kimi_cli/exception.py
+++ b/src/kimi_cli/exception.py
@@ -14,3 +14,9 @@ class AgentSpecError(KimiCLIException):
     """Agent specification error."""
 
     pass
+
+
+class Reload(Exception):
+    """Reload configuration."""
+
+    pass

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -99,7 +99,7 @@ class ShellApp:
             loop.remove_signal_handler(signal.SIGINT)
 
     async def _run_meta_command(self, command_str: str):
-        from kimi_cli.cli import Reload
+        from kimi_cli.exception import Reload
 
         parts = command_str.split(" ")
         command_name = parts[0]

--- a/src/kimi_cli/ui/shell/setup.py
+++ b/src/kimi_cli/ui/shell/setup.py
@@ -77,7 +77,7 @@ async def setup(app: "ShellApp", args: list[str]):
     await asyncio.sleep(1)
     console.clear()
 
-    from kimi_cli.cli import Reload
+    from kimi_cli.exception import Reload
 
     raise Reload
 
@@ -185,6 +185,6 @@ async def _prompt_text(prompt: str, *, is_password: bool = False) -> str | None:
 @meta_command
 def reload(app: "ShellApp", args: list[str]):
     """Reload configuration"""
-    from kimi_cli.cli import Reload
+    from kimi_cli.exception import Reload
 
     raise Reload


### PR DESCRIPTION
## 🔄 问题
循环依赖导致异常无法捕获，最终在执行 reload 时程序异常退出。

## ✅修复
将 Reload 相关异常提取到独立的 exception.py 模块中，解除循环依赖，确保异常可被正常捕获。


## 🔄 Issue Description
Circular import dependency prevents exceptions from being caught, causing the program to exit unexpectedly during reload.
## ✅ Fix
Refactored by moving Reload exceptions into a separate exception.py module to break the circular dependency and ensure proper exception handling.

![20251027-225621](https://github.com/user-attachments/assets/6d96555d-05e7-44a8-afdf-e12ff217b82f)
