### PR TITLE
fix: an event loop never await warning

### DIFF
--- a/src/kimi_cli/tools/task/__init__.py
+++ b/src/kimi_cli/tools/task/__init__.py
@@ -69,13 +69,11 @@ class Task(CallableTool2[Params]):
 
         try:
             loop = asyncio.get_running_loop()
+            self._load_task = loop.create_task(self._load_subagents(agent_spec.subagents))
         except RuntimeError:
-            # No running loop: run synchronously
+            # In case there's no running event loop, e.g., during synchronous tests
             self._load_task = None
             asyncio.run(self._load_subagents(agent_spec.subagents))
-        else:
-            # There's a running loop: schedule a background task
-            self._load_task = loop.create_task(self._load_subagents(agent_spec.subagents))
 
     async def _load_subagents(self, subagent_specs: dict[str, SubagentSpec]) -> None:
         """Load all subagents specified in the agent spec."""


### PR DESCRIPTION
when run `make test`

a warning error
========================================================== warnings summary ==========================================================
tests/test_task_subagents.py::test_task_subagents
tests/test_tool_descriptions.py::test_task_description
tests/test_tool_schemas.py::test_task_params_schema
  /Users/hyi/prs/kimi-cli/src/kimi_cli/tools/task/__init__.py:75: RuntimeWarning: coroutine 'Task._load_subagents' was never awaited
    asyncio.run(self._load_subagents(agent_spec.subagents))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html