### PR TITLE
feat(provider): Add ZenMux

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ For example, to use Kimi CLI with [Zed](https://zed.dev/), add the following con
 
 Then you can create Kimi CLI threads in Zed's agent panel.
 
+### ZenMux support
+
+You can route requests through [ZenMux](https://zenmux.ai/) using the OpenAI-compatible API. Add an `zenmux` provider to your config:
+
+```json
+{
+  "providers": {
+    "zenmux": {
+      "type": "zenmux",
+      "base_url": "https://zenmux.ai/api/v1",
+      "api_key": "YOUR_ZENMUX_API_KEY"
+    }
+  },
+  "models": {
+    "anthropic/claude-sonnet-4.5": {
+      "provider": "zenmux",
+      "model": "anthropic/claude-sonnet-4.5",
+      "max_context_size": 200000
+    }
+  }
+}
+```
+
 ### Using MCP tools
 
 Kimi CLI supports the well-established MCP config convention. For example:

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -11,7 +11,7 @@ from kimi_cli.utils.logging import logger
 class LLMProvider(BaseModel):
     """LLM provider configuration."""
 
-    type: Literal["kimi", "openai_legacy", "_chaos"]
+    type: Literal["kimi", "openai_legacy", "zenmux", "_chaos"]
     """Provider type"""
     base_url: str
     """API base URL"""

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -32,6 +32,15 @@ def augment_provider_with_env_vars(provider: LLMProvider, model: LLMModel):
                 provider.base_url = base_url
             if api_key := os.getenv("OPENAI_API_KEY"):
                 provider.api_key = SecretStr(api_key)
+        case "zenmux":
+            if base_url := os.getenv("ZENMUX_BASE_URL"):
+                provider.base_url = base_url
+            if api_key := os.getenv("ZENMUX_API_KEY"):
+                provider.api_key = SecretStr(api_key)
+            if model_name := os.getenv("ZENMUX_MODEL_NAME"):
+                model.model = model_name
+            if max_context_size := os.getenv("ZENMUX_MODEL_MAX_CONTEXT_SIZE"):
+                model.max_context_size = int(max_context_size)
         case _:
             pass
 
@@ -62,6 +71,16 @@ def create_llm(
                 base_url=provider.base_url,
                 api_key=provider.api_key.get_secret_value(),
                 stream=stream,
+            )
+        case "zenmux":
+            chat_provider = OpenAILegacy(
+                model=model.model,
+                base_url=provider.base_url,
+                api_key=provider.api_key.get_secret_value(),
+                stream=stream,
+                default_headers={
+                    "X-Title": "kimi-cli",
+                },
             )
         case "_chaos":
             chat_provider = ChaosChatProvider(


### PR DESCRIPTION
[ZenMux](https://zenmux.ai/) is the world’s first enterprise-grade large model aggregation platform with an insurance payout mechanism. The platform provides one-stop access to the latest models across providers. 

Add ZenMux as a provider to allow users to access ZenMux OpenAI-Compatible models(60+) in the cli. Support configurations of:
- Base URL
- API key
- Model
- Context size