### PR TITLE
fix: module-name should be string not array in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = ["uv_build>=0.8.5,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_cli"]
+module-name = "kimi_cli"
 source-exclude = ["tests/**/*", "src/kimi_cli/deps/**/*"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
 Fixes a TOML syntax error in `pyproject.toml` that prevents `make
  prepare` from running.

  ## Issue
  The `module-name` field in `[tool.uv.build-backend]` was incorrectly
  defined as an array instead of a string, causing this error:
  error: Failed to parse: pyproject.toml
    Caused by: TOML parse error at line 43, column 15
     |
  43 | module-name = ["kimi_cli"]
     |               ^^^^^^^^^^^^
  invalid type: sequence, expected a string

  ## Changes
  - Changed `module-name = ["kimi_cli"]` to `module-name = "kimi_cli"` on
   line 43

  ## Testing
  Verified that `make prepare` now completes successfully without errors.