### PR TITLE
  fix(makefile): use defined RUFF and PYRIGHT variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ prepare: download-deps ## Sync dependencies using locked versions.
 
 .PHONY: format
 format: ## Auto-format Python sources with ruff.
-	uv run ruff check --fix
-	uv run ruff format
+	$(RUFF) check --fix
+	$(RUFF) format
 
 .PHONY: check
 check: ## Run linting and type checks.
-	uv run ruff check
-	uv run ruff format --check
-	uv run pyright
+	$(RUFF) check
+	$(RUFF) format --check
+	$(PYRIGHT)
 
 
 .PHONY: test


### PR DESCRIPTION
Replace hardcoded "uv run ruff" and "uv run pyright" commands with the defined $(RUFF) and $(PYRIGHT) variables in format and check targets.