### PR TITLE
[feat] Add support for paste collapse  || [feat] Add support for paste collapse

### DIFF
--- a/src/kimi_cli/ui/shell/replay.py
+++ b/src/kimi_cli/ui/shell/replay.py
@@ -42,7 +42,8 @@ async def replay_recent_history(history: Sequence[Message]) -> None:
     for run in runs:
         wire = Wire()
         console.print(
-            f"{getpass.getuser()}{PROMPT_SYMBOL} {message_stringify(run.user_message, context='replay')}"
+            f"{getpass.getuser()}{PROMPT_SYMBOL} "
+            f"{message_stringify(run.user_message, context='replay')}"
         )
         ui_task = asyncio.create_task(
             visualize(wire.ui_side, initial_status=StatusSnapshot(context_usage=0.0))

--- a/src/kimi_cli/utils/message.py
+++ b/src/kimi_cli/utils/message.py
@@ -18,7 +18,7 @@ def message_stringify(message: Message, context: str = "default") -> str:
         """Collapse text if it exceeds threshold (except in replay context)."""
         if context == "replay":
             return text
-        line_count = text.count('\n') + 1
+        line_count = text.count("\n") + 1
         if line_count > LARGE_PASTE_LINE_THRESHOLD:
             return f"[pasted {line_count} lines]"
         return text

--- a/tests/test_message_utils.py
+++ b/tests/test_message_utils.py
@@ -103,7 +103,6 @@ def test_extract_text_from_empty_string():
     assert result == ""
 
 
-# New tests for large paste collapse feature
 def test_stringify_collapses_large_text_by_default():
     """Test that large text is collapsed in default context."""
     large_text = "\n".join(["line"] * 60)

--- a/tests/test_prompt_placeholders.py
+++ b/tests/test_prompt_placeholders.py
@@ -2,8 +2,6 @@
 
 import re
 
-from kimi_cli.utils.message import LARGE_PASTE_LINE_THRESHOLD
-
 # The regex pattern from prompt.py
 _ATTACHMENT_PLACEHOLDER_RE = re.compile(
     r"\[(?P<type>image|text):(?P<id>[a-zA-Z0-9_\-\.]+)"
@@ -18,6 +16,7 @@ class TestCursorBoundaryLogic:
         """Test backspace deletes when cursor is after placeholder, not before."""
         text = "prefix [text:abc12345,60 lines]"
         match = _ATTACHMENT_PLACEHOLDER_RE.search(text)
+        assert match is not None
         start, end = match.span()
 
         # Backspace with cursor right after placeholder should delete (the bug fix)
@@ -34,6 +33,7 @@ class TestCursorBoundaryLogic:
         """Test delete key deletes when cursor is before placeholder, not after."""
         text = "prefix [text:abc12345,60 lines]"
         match = _ATTACHMENT_PLACEHOLDER_RE.search(text)
+        assert match is not None
         start, end = match.span()
 
         # Delete with cursor before placeholder should delete


### PR DESCRIPTION
This PR collapse large text paste into a placeholder similar to what image is doing. It also makes backspace/delete behavior nicely w/ these placeholders, when backspace, it delete the whole placeholder instead each char.

fixes https://github.com/MoonshotAI/kimi-cli/issues/146 

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
This PR collapse large text paste into a placeholder similar to what image is doing. It also makes backspace/delete behavior nicely w/ these placeholders, when backspace, it delete the whole placeholder instead each char.

fixes https://github.com/MoonshotAI/kimi-cli/issues/146
