### PR TITLE
feat: kimi-for-coding model always thinking so user can not turn off (also not possible)

### DIFF
--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -146,6 +146,7 @@ def _derive_capabilities(provider: LLMProvider, model: LLMModel) -> set[ModelCap
     if provider.type != "kimi":
         return capabilities
 
+    # kimi-for-coding always thinking
     if model.model == "kimi-for-coding" or "thinking" in model.model:
         capabilities.add("thinking")
     return capabilities

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -48,7 +48,15 @@ class ShellApp:
         with CustomPromptSession(
             status_provider=lambda: self.soul.status,
             model_capabilities=self.soul.model_capabilities or set(),
-            initial_thinking=isinstance(self.soul, KimiSoul) and self.soul.thinking,
+            initial_thinking=(
+                isinstance(self.soul, KimiSoul)
+                and (
+                    self.soul.thinking
+                    # kimi-for-coding always thinking
+                    or (self.soul.model_name == "kimi-for-coding")
+                )
+            ),
+            model_name=self.soul.model_name,
         ) as prompt_session:
             while True:
                 try:

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -470,6 +470,7 @@ class CustomPromptSession:
         status_provider: Callable[[], StatusSnapshot],
         model_capabilities: set[ModelCapability],
         initial_thinking: bool,
+        model_name: str | None = None,
     ) -> None:
         history_dir = get_share_dir() / "user-history"
         history_dir.mkdir(parents=True, exist_ok=True)
@@ -477,6 +478,7 @@ class CustomPromptSession:
         self._history_file = (history_dir / work_dir_id).with_suffix(".jsonl")
         self._status_provider = status_provider
         self._model_capabilities = model_capabilities
+        self._model_name = model_name
         self._last_history_content: str | None = None
         self._mode: PromptMode = PromptMode.AGENT
         self._thinking = initial_thinking
@@ -560,6 +562,11 @@ class CustomPromptSession:
             if "thinking" not in self._model_capabilities:
                 console.print(
                     "[yellow]Thinking mode is not supported by the selected LLM model[/yellow]"
+                )
+                return
+            if self._thinking and self._model_name == "kimi-for-coding":
+                console.print(
+                    "[yellow]Thinking mode cannot be turned off for the kimi-for-coding model.[/yellow]"
                 )
                 return
             self._thinking = not self._thinking


### PR DESCRIPTION
## Related Issue

Resolve #238

## Description

This PR will set initial_thinking as `true` and prevent user press TAB to turn off because on `src/kimi_cli/llm.py:148` has below logic.

```python
    if model.model == "kimi-for-coding" or "thinking" in model.model:
        capabilities.add("thinking")
    return capabilities
``` 