### PR TITLE
fix: handle None input_other in token usage to stop cli from crashing

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Sequence
 from functools import partial
 from typing import TYPE_CHECKING
-
+from dataclasses import replace
 import kosong
 import tenacity
 from kosong import StepResult
@@ -233,6 +233,12 @@ class KimiSoul(Soul):
         logger.debug("Got step result: {result}", result=result)
         if result.usage is not None:
             # mark the token count for the context before the step
+            if result.usage.input_other is None:
+                logger.warning("input_other is None in token usage, setting to 0")
+                # Create new usage with input_other=0
+                new_usage = replace(result.usage, input_other=0)
+                # Create new StepResult with updated usage
+                result = replace(result, usage=new_usage)
             await self._context.update_token_count(result.usage.input)
             wire_send(StatusUpdate(status=self.status))
 


### PR DESCRIPTION
Add defensive handling for cases where result.usage.input_other is None by setting it to 0. This prevents potential issues when provider returns token counts as None and ensures the app does not crash.

<!--
Thank you for your contribution to Kimi CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue
#264 
<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

Added a check if the input_other field is None it gets replaced by 0
