### PR TITLE
feat: improve SetTodoList rendering with Markdown styles

### DIFF
--- a/src/kimi_cli/tools/todo/__init__.py
+++ b/src/kimi_cli/tools/todo/__init__.py
@@ -25,5 +25,11 @@ class SetTodoList(CallableTool2[Params]):
     async def __call__(self, params: Params) -> ToolReturnType:
         rendered = ""
         for todo in params.todos:
-            rendered += f"- {todo.title} [{todo.status}]\n"
+            match todo.status:
+                case "Done":
+                    rendered += f"- ~~{todo.title}~~ [{todo.status}]\n"
+                case "In Progress":
+                    rendered += f"- **{todo.title}** [{todo.status}]\n"
+                case _:
+                    rendered += f"- {todo.title} [{todo.status}]\n"
         return ToolOk(output="", message="Todo list updated", brief=rendered)


### PR DESCRIPTION
## Description

This PR introduces a small improvement to the rendering of todo items in the `SetTodoList` tool. The formatting now visually distinguishes items based on their status, making the todo list easier to read and understand. 

* Todo items marked as `"Done"` are now displayed with strikethrough formatting, while items `"In Progress"` are bolded; all other statuses retain the default formatting.

Now, It looks like below image
<img width="533" height="161" alt="image" src="https://github.com/user-attachments/assets/1e4796c5-3059-4bfa-8555-2fc4e7e22b7b" />





