### PR TITLE
chore: add pre-commit hooks for format/check/test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 default_install_hook_types:
   - pre-commit
-  - pre-push
 
 repos:
   - repo: local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,12 @@ We run formatting and checks locally via [pre-commit](https://pre-commit.com/).
 
 1. Install pre-commit (pick one): `uv tool install pre-commit`, `pipx install pre-commit`, or
    `pip install pre-commit`.
-2. Install the hooks in this repo (commit + push): `pre-commit install --hook-type pre-commit --hook-type pre-push`.
+2. Install the hooks in this repo: `pre-commit install`.
 3. Optionally run on all files before sending a PR: `pre-commit run --all-files`.
 
 After installation, formatting and checks run on every commit. You can skip for an intermediate
 commit with `git commit --no-verify`, or trigger all hooks manually with
-`pre-commit run --all-files --hook-stage push`.
+`pre-commit run --all-files`.
 
 The hooks execute `make format` and `make check`, so ensure `make prepare` (or `uv sync`) has been
 run and dependencies are available locally.


### PR DESCRIPTION
This pull request introduces pre-commit hook support to help automate formatting, checks, and tests before code is committed. It adds a `.pre-commit-config.yaml` configuration for local hooks and updates the contribution guidelines to instruct contributors on setting up and using pre-commit.

Pre-commit automation:

* Added a `.pre-commit-config.yaml` file that defines local hooks for running `make format`, `make check`, and `make test`, ensuring consistent formatting and code checks before commits.

Documentation updates:

* Updated `CONTRIBUTING.md` with a new section explaining how to install and use pre-commit hooks, including setup instructions and commands to run the hooks locally before submitting a pull request.
<img width="892" height="171" alt="image" src="https://github.com/user-attachments/assets/005eadd0-9576-4a41-ac29-63c7dc1a46cf" />

