### PR TITLE
fix(print): flush after printing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Only write entries that are worth mentioning to users.
 - Wire: Reimplement Wire server mode (which is enabled with `--wire` option)
 - Lib: Rename `ShellApp` to `Shell`, `PrintApp` to `Print`, `ACPServer` to `ACP` and `WireServer` to `WireOverStdio` for better consistency
 - Lib: Rename `KimiCLI.run_shell_mode` to `run_shell`, `run_print_mode` to `run_print`, `run_acp_server` to `run_acp`, and `run_wire_server` to `run_wire_stdio` for better consistency
-- Lib: Add `KimiCLI.run` method to run a turn given user input and yield Wire messages
+- Lib: Add `KimiCLI.run` method to run a turn with given user input and yield Wire messages
+- Print: Fix stream-json print mode not flushing output properly
 
 ## [0.58] - 2025-11-21
 

--- a/src/kimi_cli/ui/print/visualize.py
+++ b/src/kimi_cli/ui/print/visualize.py
@@ -82,12 +82,12 @@ class JsonPrinter(Printer):
             content=self._content_buffer,
             tool_calls=tool_calls or None,
         )
-        print(message.model_dump_json(exclude_none=True))
+        print(message.model_dump_json(exclude_none=True), flush=True)
 
         for result in tool_results:
             # FIXME: this assumes the way how the soul convert `ToolResult` to `Message`
             message = tool_result_to_message(result)
-            print(message.model_dump_json(exclude_none=True))
+            print(message.model_dump_json(exclude_none=True), flush=True)
 
         self._content_buffer.clear()
         self._tool_call_buffer.clear()


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->
