### PR TITLE
fix: improve approval task cleanup in agent loop

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from contextlib import suppress
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -225,6 +226,11 @@ class KimiSoul:
                 raise
             finally:
                 approval_task.cancel()  # stop piping approval requests to the wire
+                with suppress(asyncio.CancelledError):
+                    try:
+                        await approval_task
+                    except Exception:
+                        logger.exception("Approval piping task failed")
 
             if finished:
                 return


### PR DESCRIPTION
   - Add proper error handling for approval_task cancellation
   - Suppress CancelledError during task cleanup to avoid warnings
   - Log unexpected exceptions from approval task during shutdown
   - Prevent potential asyncio task leaks

   Changes:
   - Import suppress from contextlib
   - Add try-except block in finally clause to gracefully handle task cancellation
   - Use logger.exception to capture any unexpected errors during cleanup

<!--
Thank you for your contribution to Kimi CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->
