### PR TITLE
fix(acp): fix slash command in single-session acp mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Internal builds may append content to the Unreleased section.
 Only write entries that are worth mentioning to users.
 -->
 
+## [Unreleased]
+
+- ACP: Advertise slash commands in single-session ACP mode (`kimi --acp`)
+
 ## [0.66] - 2025-12-19
 
 - Lib: Provide `token_usage` and `message_id` in `StatusUpdate` Wire message

--- a/src/kimi_cli/ui/acp/__init__.py
+++ b/src/kimi_cli/ui/acp/__init__.py
@@ -98,6 +98,19 @@ class ACPServerSingleSession:
                 await soul_task
 
         self._session = ACPSession(str(uuid.uuid4()), prompt_fn, self._conn)
+        available_commands = [
+            acp.schema.AvailableCommand(name=cmd.name, description=cmd.description)
+            for cmd in self.soul.available_slash_commands
+        ]
+        asyncio.create_task(
+            self._conn.session_update(
+                session_id=self._session.id,
+                update=acp.schema.AvailableCommandsUpdate(
+                    session_update="available_commands_update",
+                    available_commands=available_commands,
+                ),
+            )
+        )
         return acp.NewSessionResponse(session_id=self._session.id)
 
     async def load_session(


### PR DESCRIPTION
Signed-off-by: Richard Chien <stdrc@outlook.com>

<!--
Thank you for your contribution to Kimi CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->
