### PR TITLE
chore(prek): enable workspace hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ default_install_hook_types:
 repos:
   - repo: local
     hooks:
-      - id: make-format
-        name: make format
-        entry: make format
+      - id: make-format-kimi-cli
+        name: make format-kimi-cli
+        entry: make format-kimi-cli
         language: system
         pass_filenames: false
-      - id: make-check
-        name: make check
-        entry: make check
+      - id: make-check-kimi-cli
+        name: make check-kimi-cli
+        entry: make check-kimi-cli
         language: system
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,18 +7,21 @@ We welcome all kinds of contributions, including bug fixes, features, document i
 1. We only merge pull requests that aligns with our roadmap. For any pull request that introduces changes larger than 100 lines of code, we highly recommend discussing with us by [raising an issue](https://github.com/MoonshotAI/kimi-cli/issues) or in an existing issue before you start working on it. Otherwise your pull request may be closed or ignored without review.
 2. We insist on high code quality. Please ensure your code is as good as, if not better than, the code written by frontier coding agents. Changes may be requested before your pull request can be merged.
 
-## Pre-commit hooks
+## Prek hooks
 
-We run formatting and checks locally via [pre-commit](https://pre-commit.com/).
+We use [prek](https://github.com/j178/prek) to run formatting and checks via git hooks.
 
-1. Install pre-commit (pick one): `uv tool install pre-commit`, `pipx install pre-commit`, or
-   `pip install pre-commit`.
-2. Install the hooks in this repo: `pre-commit install`.
-3. Optionally run on all files before sending a PR: `pre-commit run --all-files`.
+Recommended setup:
+1. Run `make prepare` to sync dependencies and install the prek hooks.
+2. Optionally run on all files before sending a PR: `prek run --all-files`.
 
-After installation, formatting and checks run on every commit. You can skip for an intermediate
-commit with `git commit --no-verify`, or trigger all hooks manually with
-`pre-commit run --all-files`.
+Manual setup (if you do not want to use `make prepare`):
+1. Install prek (pick one): `uv tool install prek`, `pipx install prek`, or `pip install prek`.
+2. Install the hooks in this repo: `prek install`.
 
-The hooks execute `make format` and `make check`, so ensure `make prepare` (or `uv sync`) has been
-run and dependencies are available locally.
+After installation, the hooks run on every commit. The repo uses prek workspace mode, so only the
+projects with changed files run their hooks. You can skip them for an intermediate commit with
+`git commit --no-verify`, or run them manually with `prek run --all-files`.
+
+The hooks execute the relevant `make format-*` and `make check-*` targets, so ensure dependencies
+are installed (`make prepare` or `uv sync`).

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,15 @@ help: ## Show available make targets.
 	@echo "Available make targets:"
 	@awk 'BEGIN { FS = ":.*## " } /^[A-Za-z0-9_.-]+:.*## / { printf "  %-20s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
+.PHONY: install-prek
+install-prek: ## Install prek and repo git hooks.
+	@echo "==> Installing prek"
+	@uv tool install prek
+	@echo "==> Installing git hooks with prek"
+	@uv tool run prek install
+
 .PHONY: prepare
-prepare: download-deps ## Sync dependencies for all workspace packages.
+prepare: download-deps install-prek ## Sync dependencies for all workspace packages and install prek hooks.
 	@echo "==> Syncing dependencies for all workspace packages"
 	@uv sync --frozen --all-extras --all-packages
 

--- a/packages/kaos/.pre-commit-config.yaml
+++ b/packages/kaos/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+orphan: true
+
+repos:
+  - repo: local
+    hooks:
+      - id: make-format-pykaos
+        name: make format-pykaos
+        entry: make -C ../.. format-pykaos
+        language: system
+        pass_filenames: false
+      - id: make-check-pykaos
+        name: make check-pykaos
+        entry: make -C ../.. check-pykaos
+        language: system
+        pass_filenames: false

--- a/packages/kosong/.pre-commit-config.yaml
+++ b/packages/kosong/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+orphan: true
+
+repos:
+  - repo: local
+    hooks:
+      - id: make-format-kosong
+        name: make format-kosong
+        entry: make -C ../.. format-kosong
+        language: system
+        pass_filenames: false
+      - id: make-check-kosong
+        name: make check-kosong
+        entry: make -C ../.. check-kosong
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- split prek hooks by workspace project (root/kosong/kaos)
- install prek during make prepare and update docs

## Testing
- prek hooks (format/check for kimi-cli/kosong/kaos)