### PR TITLE
fix: load MCP tools only for main agent

### DIFF
--- a/examples/kimi-psql/main.py
+++ b/examples/kimi-psql/main.py
@@ -280,7 +280,7 @@ async def create_psql_soul(llm: LLM, conninfo: str) -> KimiSoul:
 
     # Load agent from configuration
     agent_file = Path(__file__).parent / "agent.yaml"
-    agent = await load_agent(agent_file, runtime, mcp_configs=[])
+    agent = await load_agent(agent_file, runtime)
 
     # Add custom ExecuteSql tool to the loaded agent
     cast(KimiToolset, agent.toolset).add(ExecuteSql(conninfo))

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -14,7 +14,7 @@ from kimi_cli.soul.agent import Runtime
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Skipping test on Windows")
 async def test_default_agent(runtime: Runtime):
-    agent = await load_agent(DEFAULT_AGENT_FILE, runtime, mcp_configs=[])
+    agent = await load_agent(DEFAULT_AGENT_FILE, runtime)
     assert agent.system_prompt.replace(
         f"{runtime.builtin_args.KIMI_WORK_DIR}", "/path/to/work/dir"
     ) == snapshot(

--- a/tests/test_load_agent.py
+++ b/tests/test_load_agent.py
@@ -73,7 +73,7 @@ def test_load_tools_invalid(runtime: Runtime):
 async def test_load_agent_invalid_tools(agent_file_invalid_tools: Path, runtime: Runtime):
     """Test loading agent with invalid tools raises ValueError."""
     with pytest.raises(ValueError, match="Invalid tools"):
-        await load_agent(agent_file_invalid_tools, runtime, mcp_configs=[])
+        await load_agent(agent_file_invalid_tools, runtime)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Fix duplicate MCP server initialization when loading agents with subagents.

Closes #518

## Problem
When kimi-cli starts, it loads main agent + subagents. Both received the same `mcp_configs`, causing:
- Each MCP server initialized twice
- Duplicate startup logs  
- Resource waste

## Solution
Move MCP loading logic from `load_agent()` to `KimiCLI.create()`:
- `load_agent()` no longer handles MCP configs
- MCP tools loaded once after main agent is created
- Subagents don't trigger MCP initialization

This aligns with Claude Code's approach: MCP is a shared resource, configured once globally.

## Files Changed
- `src/kimi_cli/soul/agent.py` - Remove `mcp_configs` parameter
- `src/kimi_cli/app.py` - Add MCP loading after agent creation
- `tests/` and `examples/` - Update `load_agent()` calls

