### PR TITLE
feat(llm): add support for _echo provider

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -107,7 +107,8 @@ class KimiCLI:
         assert model is not None
         env_overrides = augment_provider_with_env_vars(provider, model)
 
-        if not provider.base_url or not model.model:
+        provider_requires_base_url = provider.type not in {"_echo"}
+        if (provider_requires_base_url and not provider.base_url) or not model.model:
             llm = None
         else:
             logger.info("Using LLM provider: {provider}", provider=provider)

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -20,6 +20,7 @@ type ProviderType = Literal[
     "google_genai",  # for backward-compatibility, equals to `gemini`
     "gemini",
     "vertexai",
+    "_echo",
     "_chaos",
 ]
 
@@ -156,6 +157,10 @@ def create_llm(
                 api_key=provider.api_key.get_secret_value(),
                 vertexai=True,
             )
+        case "_echo":
+            from kosong.chat_provider.echo import EchoChatProvider
+
+            chat_provider = EchoChatProvider()
         case "_chaos":
             from kosong.chat_provider.chaos import ChaosChatProvider, ChaosConfig
             from kosong.chat_provider.kimi import Kimi

--- a/tests/test_create_llm.py
+++ b/tests/test_create_llm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from inline_snapshot import snapshot
+from kosong.chat_provider.echo import EchoChatProvider
 from kosong.chat_provider.kimi import Kimi
 from pydantic import SecretStr
 
@@ -74,3 +75,12 @@ def test_create_llm_kimi_model_parameters(monkeypatch):
             "max_tokens": 1234,
         }
     )
+
+
+def test_create_llm_echo_provider():
+    provider = LLMProvider(type="_echo", base_url="", api_key=SecretStr(""))
+    model = LLMModel(provider="_echo", model="echo", max_context_size=1234)
+
+    llm = create_llm(provider, model)
+    assert isinstance(llm.chat_provider, EchoChatProvider)
+    assert llm.max_context_size == 1234


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

None

## Description

Kimi CLI now supports end-to-end execution using the _echo provider. This enables basic validation of framework behaviors—such as tool invocation, reasoning, and frontend rendering—without requiring a real LLM.
You can perform a simple test as follows:

1. Take the `readfile` tool as an example: first, prepare a test file named `sample.txt`.
2. Then, create a DSL-compliant input and save it to a file called `prompt.txt`. For example:

```
think: I will read the file now.
tool_call: {"id": "call-1", "name": "ReadFile", "arguments": "{\"path\": \"/path/to/sample.txt\"}"}
text: File read complete.
```

3. Modify the default configuration file (`~/.kimi/config.toml`) as shown below:

```
1c1
< default_model = "kimi-k2-thinking-turbo"
---
> default_model = "echo-test"
2a3,13
> 
> [providers._echo]
> type = "_echo"
> base_url = ""
> api_key = ""
> 
> [models.echo-test]
> provider = "_echo"
> model = "echo"
> max_context_size = 100000
> 
81c92
< max_steps_per_run = 100
---
> max_steps_per_run = 1 
```

4. You can now use the content of `prompt.txt` as input for testing. Note that running this in chat mode will result in an error, which is expected:

```
LLM provider error: EchoChatProvider expects the last history message to be user.
```