### PR TITLE
fix: fix the dependency conflict between kimi-cli/pykaos and gradio

### DIFF
--- a/packages/kaos/pyproject.toml
+++ b/packages/kaos/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "aiofiles==25.1.0",
+    "aiofiles>=24.0,<25.0",
     "asyncssh==2.21.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "agent-client-protocol==0.7.0",
-    "aiofiles==25.1.0",
+    "aiofiles>=24.0,<25.0",
     "aiohttp==3.13.2",
     "typer==0.21.0",
     "kosong[contrib]==0.36.1",

--- a/uv.lock
+++ b/uv.lock
@@ -27,11 +27,11 @@ wheels = [
 
 [[package]]
 name = "aiofiles"
-version = "25.1.0"
+version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
 ]
 
 [[package]]
@@ -1143,7 +1143,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", specifier = "==0.7.0" },
-    { name = "aiofiles", specifier = "==25.1.0" },
+    { name = "aiofiles", specifier = ">=24.0,<25.0" },
     { name = "aiohttp", specifier = "==3.13.2" },
     { name = "batrachian-toad", marker = "python_full_version >= '3.14'", specifier = "==0.5.18" },
     { name = "fastmcp", specifier = "==2.12.5" },
@@ -2224,7 +2224,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = "==25.1.0" },
+    { name = "aiofiles", specifier = ">=24.0,<25.0" },
     { name = "asyncssh", specifier = "==2.21.1" },
 ]
 


### PR DESCRIPTION
degrade the version of `aiofiles` from **25.1.0** to **24.0~25.0** in order to resolve the dependency conflict between `gradio` and `kimi-cli/pykaos`

<!--
Thank you for your contribution to Kimi CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->
