### PR TITLE
fix(wire): increase stdio buffer limit to 100MB

### DIFF
--- a/src/kimi_cli/ui/wire/__init__.py
+++ b/src/kimi_cli/ui/wire/__init__.py
@@ -30,6 +30,12 @@ from .jsonrpc import (
     Statuses,
 )
 
+# Maximum buffer size for the asyncio StreamReader used for stdio.
+# Passed as the `limit` argument to `acp.stdio_streams`, this caps how much
+# data can be buffered when reading from stdin (e.g., large tool or model
+# outputs sent over JSON-RPC). A 100MB limit is large enough for typical
+# interactive use while still protecting the process from unbounded memory
+# growth or buffer-overrun errors when peers send unexpectedly large payloads.
 STDIO_BUFFER_LIMIT = 100 * 1024 * 1024
 
 


### PR DESCRIPTION
## Summary
- Increase stdio buffer limit from default 64KB to 100MB for WireOverStdio
- This prevents buffer overflow errors when handling large tool results

The `acp.stdio_streams()` now supports a `limit` parameter, so we can pass it directly instead of monkey-patching.

## Test plan
- [x] Verify large tool results (e.g., reading large files) work without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)