### PR TITLE
fix(mcp): wait for MCP tools before command loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Skills: Add built-in skill-creator skill shipped with the package
-- Tool: Expand `~` to the home directory in `ReadFile` paths.
+- Tool: Expand `~` to the home directory in `ReadFile` paths
+- MCP: Ensure MCP tools finish loading before starting the agent loop
 
 ## 0.72 (2026-01-04)
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -5,7 +5,8 @@ This page documents the changes in each Kimi CLI release.
 ## Unreleased
 
 - Skills: Add built-in skill-creator skill shipped with the package
-- Tool: Expand `~` to the home directory in `ReadFile` paths.
+- Tool: Expand `~` to the home directory in `ReadFile` paths
+- MCP: Ensure MCP tools finish loading before starting the agent loop
 
 ## 0.72 (2026-01-04)
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,6 +6,7 @@
 
 - Skills：添加随软件包发布的内置 skill-creator Skill
 - Tool：在 `ReadFile` 路径中将 `~` 展开为用户主目录
+- MCP：确保 MCP 工具加载完成后再开始 Agent 循环
 
 ## 0.72 (2026-01-04)
 

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -36,6 +36,7 @@ from kimi_cli.soul.compaction import SimpleCompaction
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.message import check_message, system, tool_result_to_message
 from kimi_cli.soul.slash import registry as soul_slash_registry
+from kimi_cli.soul.toolset import KimiToolset
 from kimi_cli.tools.dmail import NAME as SendDMail_NAME
 from kimi_cli.tools.utils import ToolRejectedError
 from kimi_cli.utils.logging import logger
@@ -236,6 +237,8 @@ class KimiSoul:
     async def _agent_loop(self):
         """The main agent loop for one run."""
         assert self._runtime.llm is not None
+        if isinstance(self._agent.toolset, KimiToolset):
+            await self._agent.toolset.wait_for_mcp_tools()
 
         async def _pipe_approval_to_wire():
             while True:

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -308,6 +308,17 @@ class KimiToolset:
         else:
             await _connect()
 
+    async def wait_for_mcp_tools(self) -> None:
+        """Wait for background MCP tool loading to finish."""
+        task = self._mcp_loading_task
+        if not task:
+            return
+        try:
+            await task
+        finally:
+            if self._mcp_loading_task is task and task.done():
+                self._mcp_loading_task = None
+
     async def cleanup(self) -> None:
         """Cleanup any resources held by the toolset."""
         if self._mcp_loading_task:


### PR DESCRIPTION
## Summary
- wait for MCP tool loading task before entering the agent loop (fixes --command mode race)
- add MCP changelog entry

## Testing
- not run (not requested)