### PR TITLE
fix(shell): preserve context when switching models via /model command

### DIFF
--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -230,7 +230,7 @@ async def model(app: Shell, args: str):
         return
 
     console.print(f"[green]Switched to model {model_name}. Reloading...[/green]")
-    raise Reload()
+    raise Reload(session_id=soul.runtime.session.id)
 
 
 @registry.command(aliases=["release-notes"])


### PR DESCRIPTION
## Summary

Fix `/model` command clearing conversation context when switching models.

Fixes https://github.com/MoonshotAI/kimi-cli/issues/606

## Problem

When using `/model` to switch between models, the `Reload()` exception was raised without passing the current `session_id`, causing a new session to be created and all conversation context to be lost.

## Solution

Pass `session_id=soul.runtime.session.id` to `Reload()` so the same session is restored after reloading, preserving the conversation context.

## Changes

- `src/kimi_cli/ui/shell/slash.py`: Pass session_id when raising Reload in /model command

