### PR TITLE
feat(cli): add further help section to --help output

### DIFF
--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -23,11 +23,9 @@ class Reload(Exception):
 
 
 cli = typer.Typer(
-    epilog=(
-        "Further help:\n"
-        "  Documentation:     https://moonshotai.github.io/kimi-cli/\n"
-        "  LLM friendly doc:  https://moonshotai.github.io/kimi-cli/llms.txt"
-    ),
+    epilog="""\b\
+Documentation:        https://moonshotai.github.io/kimi-cli/\n
+LLM friendly version: https://moonshotai.github.io/kimi-cli/llms.txt""",
     add_completion=False,
     context_settings={"help_option_names": ["-h", "--help"]},
     help="Kimi, your next CLI agent.",


### PR DESCRIPTION
Add epilog with documentation links to `--help` output:

- Documentation: https://moonshotai.github.io/kimi-cli/
- LLM friendly doc: https://moonshotai.github.io/kimi-cli/llms.txt

**Screenshot:**
```
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ term   Run Toad TUI backed by Kimi CLI ACP server.                           │
│ acp    Run Kimi CLI ACP server.                                              │
│ info   Show version and protocol information.                                │
│ mcp    Manage MCP server configurations.                                     │
╰──────────────────────────────────────────────────────────────────────────────╯
                                                                                
 Further help:   Documentation:     https://moonshotai.github.io/kimi-cli/      
 LLM friendly doc:  https://moonshotai.github.io/kimi-cli/llms.txt              
```