### PR TITLE
fix(config): prevent config save from overwriting unrelated settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Shell: Use `/model` to toggle thinking mode instead of Tab key
-- Config: Add `default_thinking` config option (auto-migrated from metadata)
+- Config: Add `default_thinking` config option (need to run `/model` to select thinking mode after upgrade)
 - LLM: Add `always_thinking` capability for models that always use thinking mode
 - CLI: Rename `--command`/`-c` to `--prompt`/`-p`, keep `--command`/`-c` as alias, remove `--query`/`-q`
 

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,19 @@ This page documents breaking changes in Kimi CLI releases and provides migration
 
 ## Unreleased
 
+### Thinking mode setting migration change
+
+After upgrading from `0.76`, the thinking mode setting is no longer automatically preserved. The previous `thinking` state stored in `~/.kimi/kimi.json` is no longer used; instead, thinking mode is now managed via the `default_thinking` configuration option in `~/.kimi/config.toml`, but values are not automatically migrated from legacy `metadata`.
+
+- **Affected**: Users who previously had thinking mode enabled
+- **Migration**: Reconfigure thinking mode after upgrading:
+  - Use the `/model` command to select model and set thinking mode (interactive)
+  - Or manually add to `~/.kimi/config.toml`:
+
+    ```toml
+    default_thinking = true  # Set to true if you want thinking mode enabled by default
+    ```
+
 ### `--query` option removed
 
 The `--query` (`-q`) option has been removed. Use `--prompt` as the primary option, with `--command` as an alias.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -5,7 +5,7 @@ This page documents the changes in each Kimi CLI release.
 ## Unreleased
 
 - Shell: Use `/model` to toggle thinking mode instead of Tab key
-- Config: Add `default_thinking` config option (auto-migrated from metadata)
+- Config: Add `default_thinking` config option (need to run `/model` to select thinking mode after upgrade)
 - LLM: Add `always_thinking` capability for models that always use thinking mode
 - CLI: Rename `--command`/`-c` to `--prompt`/`-p`, keep `--command`/`-c` as alias, remove `--query`/`-q`
 

--- a/docs/zh/release-notes/breaking-changes.md
+++ b/docs/zh/release-notes/breaking-changes.md
@@ -4,6 +4,19 @@
 
 ## 未发布
 
+### Thinking 模式设置迁移调整
+
+从 `0.76` 升级后，Thinking 模式设置不再自动保留。此前保存在 `~/.kimi/kimi.json` 中的 `thinking` 状态不再使用，改为通过 `~/.kimi/config.toml` 中的 `default_thinking` 配置项管理，但不会自动从旧版 `metadata` 迁移。
+
+- **受影响**：此前启用 Thinking 模式的用户
+- **迁移**：升级后需重新设置 Thinking 模式：
+  - 使用 `/model` 命令选择模型时设置 Thinking 模式（交互式）
+  - 或手动在 `~/.kimi/config.toml` 中添加：
+
+    ```toml
+    default_thinking = true  # 如需默认启用 Thinking 模式
+    ```
+
 ### `--query` 选项移除
 
 `--query`（`-q`）已移除，改用 `--prompt` 作为主推参数，`--command` 作为别名。

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -5,7 +5,7 @@
 ## 未发布
 
 - Shell：使用 `/model` 命令切换 Thinking 模式，取代 Tab 键
-- Config：添加 `default_thinking` 配置项（从 metadata 自动迁移）
+- Config：添加 `default_thinking` 配置项（升级后需运行 `/model` 选择 Thinking 模式）
 - LLM：为始终使用 Thinking 模式的模型添加 `always_thinking` 能力
 - CLI：将 `--command`/`-c` 重命名为 `--prompt`/`-p`，保留 `--command`/`-c` 作为别名，移除 `--query`/`-q`
 

--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -15,7 +15,7 @@ from kimi_cli.acp.session import ACPSession
 from kimi_cli.acp.tools import replace_tools
 from kimi_cli.acp.types import ACPContentBlock, MCPServer
 from kimi_cli.app import KimiCLI
-from kimi_cli.config import LLMModel, save_config
+from kimi_cli.config import LLMModel, load_config, save_config
 from kimi_cli.constant import NAME, VERSION
 from kimi_cli.llm import create_llm, derive_model_capabilities
 from kimi_cli.session import Session
@@ -256,7 +256,10 @@ class ACPServer:
         config.default_model = model_id_conv.model_key
         config.default_thinking = model_id_conv.thinking
         assert config.is_from_default_location, "`kimi acp` must use the default config location"
-        save_config(cli_instance.soul.runtime.config)
+        config_for_save = load_config()
+        config_for_save.default_model = model_id_conv.model_key
+        config_for_save.default_thinking = model_id_conv.thinking
+        save_config(config_for_save)
 
     async def authenticate(self, method_id: str, **kwargs: Any) -> acp.AuthenticateResponse | None:
         raise NotImplementedError

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -201,48 +201,7 @@ def load_config(config_file: Path | None = None) -> Config:
     except ValidationError as e:
         raise ConfigError(f"Invalid configuration file: {e}") from e
     config.is_from_default_location = is_default_config_file
-
-    # Migrate thinking setting from metadata to config (one-time migration)
-    if is_default_config_file:
-        _migrate_thinking_from_metadata(config, config_file)
-
     return config
-
-
-def _migrate_thinking_from_metadata(config: Config, config_file: Path) -> None:
-    """Migrate thinking setting from metadata.json to config.toml (one-time migration)."""
-    from kimi_cli.share import get_share_dir
-
-    metadata_file = get_share_dir() / "kimi.json"
-    if not metadata_file.exists():
-        return
-
-    try:
-        with open(metadata_file, encoding="utf-8") as f:
-            metadata = json.load(f)
-    except (json.JSONDecodeError, OSError):
-        return
-
-    try:
-        if "thinking" not in metadata:
-            return
-        thinking_value = metadata.pop("thinking")
-    except (KeyError, TypeError):
-        return
-
-    logger.info(
-        "Migrating thinking setting from metadata to config: {thinking}",
-        thinking=thinking_value,
-    )
-
-    config.default_thinking = bool(thinking_value)
-    save_config(config, config_file)
-
-    try:
-        with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=2, ensure_ascii=False)
-    except OSError as e:
-        logger.warning("Failed to update metadata after migration: {error}", error=e)
 
 
 def load_config_from_string(config_string: str) -> Config:

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any
 from prompt_toolkit.shortcuts.choice_input import ChoiceInput
 
 from kimi_cli.cli import Reload
-from kimi_cli.config import save_config
+from kimi_cli.config import load_config, save_config
+from kimi_cli.exception import ConfigError
 from kimi_cli.platforms import get_platform_name_for_provider, refresh_managed_models
 from kimi_cli.session import Session
 from kimi_cli.soul.kimisoul import KimiSoul
@@ -244,8 +245,11 @@ async def model(app: Shell, args: str):
     config.default_model = selected_model_name
     config.default_thinking = new_thinking
     try:
-        save_config(config)
-    except OSError as exc:
+        config_for_save = load_config()
+        config_for_save.default_model = selected_model_name
+        config_for_save.default_thinking = new_thinking
+        save_config(config_for_save)
+    except (ConfigError, OSError) as exc:
         config.default_model = prev_model
         config.default_thinking = prev_thinking
         console.print(f"[red]Failed to save config: {exc}[/red]")


### PR DESCRIPTION
## Summary

Fix config saving to prevent accidentally overwriting user settings or saving unintended runtime state.

## Problem

When saving configuration changes (e.g., model selection), the code was directly saving the runtime config object. This could overwrite other user settings that were modified externally or save runtime-modified state that shouldn't be persisted.

## Solution

Changed config saving pattern across the codebase:
- Load a fresh config from disk before saving
- Apply only the specific changes that need to be saved
- Then save the config

This ensures that:
1. Only intended changes are persisted
2. Other user settings remain intact
3. Runtime-only modifications are not accidentally saved

## Changes

- **`src/kimi_cli/config.py`**: Removed the one-time thinking migration code (`_migrate_thinking_from_metadata`) which is no longer needed
- **`src/kimi_cli/acp/server.py`**: Load fresh config before saving model/thinking changes
- **`src/kimi_cli/platforms.py`**: Load fresh config before saving model updates
- **`src/kimi_cli/ui/shell/slash.py`**: Load fresh config before saving from `/model` command
- **`docs/`**: Added breaking changes notice about thinking mode migration

## Breaking Changes

The automatic thinking mode migration from `~/.kimi/kimi.json` to `config.toml` has been removed. Users upgrading from 0.76 who had thinking mode enabled will need to reconfigure it manually via `/model` command or by adding `default_thinking = true` to their config file.