### PR TITLE
chore: bump kimi-cli to 0.77 and kosong to 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 0.77 (2026-01-15)
+
 - Shell: Fix line breaking in `/help` and `/changelog` fullscreen pager display
 - Shell: Use `/model` to toggle thinking mode instead of Tab key
 - Config: Add `default_thinking` config option (need to run `/model` to select thinking mode after upgrade)

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@ This page documents breaking changes in Kimi CLI releases and provides migration
 
 ## Unreleased
 
+## 0.77 - Thinking mode and CLI option changes
+
 ### Thinking mode setting migration change
 
 After upgrading from `0.76`, the thinking mode setting is no longer automatically preserved. The previous `thinking` state stored in `~/.kimi/kimi.json` is no longer used; instead, thinking mode is now managed via the `default_thinking` configuration option in `~/.kimi/config.toml`, but values are not automatically migrated from legacy `metadata`.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi CLI release.
 
 ## Unreleased
 
+## 0.77 (2026-01-15)
+
 - Shell: Fix line breaking in `/help` and `/changelog` fullscreen pager display
 - Shell: Use `/model` to toggle thinking mode instead of Tab key
 - Config: Add `default_thinking` config option (need to run `/model` to select thinking mode after upgrade)
@@ -11,7 +13,7 @@ This page documents the changes in each Kimi CLI release.
 - CLI: Rename `--command`/`-c` to `--prompt`/`-p`, keep `--command`/`-c` as alias, remove `--query`/`-q`
 - Wire: Fix approval requests not responding properly in Wire mode
 - CLI: Add `--prompt-flow` option to load a Mermaid flowchart file as a Prompt Flow
-- Core: Add `/begin` slash command if a Prompt Flow is loaded for starting the flow
+- Core: Add `/begin` slash command if a Prompt Flow is loaded to start the flow
 - Core: Replace Ralph Loop with Prompt Flow-based implementation
 
 ## 0.76 (2026-01-12)

--- a/docs/zh/release-notes/breaking-changes.md
+++ b/docs/zh/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 0.77 - Thinking 模式与 CLI 选项变更
+
 ### Thinking 模式设置迁移调整
 
 从 `0.76` 升级后，Thinking 模式设置不再自动保留。此前保存在 `~/.kimi/kimi.json` 中的 `thinking` 状态不再使用，改为通过 `~/.kimi/config.toml` 中的 `default_thinking` 配置项管理，但不会自动从旧版 `metadata` 迁移。

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.38.0 (2026-01-15)
+
 - Add `thinking_effort` property to `ChatProvider` protocol to query current thinking effort level
 
 ## 0.37.0 (2026-01-08)

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kosong"
-version = "0.37.0"
+version = "0.38.0"
 description = "The LLM abstraction layer for modern AI agent applications."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "0.76"
+version = "0.77"
 description = "Kimi CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1104,7 +1104,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "0.76"
+version = "0.77"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1217,7 +1217,7 @@ dev = [
 
 [[package]]
 name = "kosong"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "packages/kosong" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release Changes

### kimi-cli 0.77

- Shell: Fix line breaking in `/help` and `/changelog` fullscreen pager display
- Shell: Use `/model` to toggle thinking mode instead of Tab key
- Config: Add `default_thinking` config option (need to run `/model` to select thinking mode after upgrade)
- LLM: Add `always_thinking` capability for models that always use thinking mode
- CLI: Rename `--command`/`-c` to `--prompt`/`-p`, keep `--command`/`-c` as alias, remove `--query`/`-q`
- Wire: Fix approval requests not responding properly in Wire mode
- CLI: Add `--prompt-flow` option to load a Mermaid flowchart file as a Prompt Flow
- Core: Add `/begin` slash command if a Prompt Flow is loaded to start the flow
- Core: Replace Ralph Loop with Prompt Flow-based implementation

### kosong 0.38.0

- Add `thinking_effort` property to `ChatProvider` protocol to query current thinking effort level

---

After merging, tag with:
```bash
git tag 0.77
git tag kosong-0.38.0
git push --tags
```