### PR TITLE
feat(flow): add D2 prompt flow support in --prompt-flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- CLI: Support D2 prompt flow diagrams via `--prompt-flow`
+
 ## 0.77 (2026-01-15)
 
 - Shell: Fix line breaking in `/help` and `/changelog` fullscreen pager display

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -87,11 +87,11 @@ Ralph Loop is mutually exclusive with the `--prompt-flow` option and cannot be u
 
 | Option | Description |
 |--------|-------------|
-| `--prompt-flow PATH` | Load a Mermaid flowchart file as a Prompt Flow |
+| `--prompt-flow PATH` | Load a Mermaid flowchart or D2 file as a Prompt Flow |
 
-Prompt Flow is a workflow description method based on Mermaid flowcharts, where each node corresponds to one conversation turn. After loading, you can start the flow execution with the `/begin` command.
+Prompt Flow is a workflow description method based on Mermaid flowcharts or D2 diagrams, where each node corresponds to one conversation turn. After loading, you can start the flow execution with the `/begin` command.
 
-Flowchart example (`example.mmd` file):
+Mermaid flowchart example (`example.mmd` file):
 
 ```
 flowchart TD
@@ -112,6 +112,23 @@ flowchart TD
 ```
 
 During node processing, decision nodes (`{}`) require the agent to output `<choice>branch name</choice>` to select the next node.
+
+D2 example (`example.d2` file):
+
+```d2
+BEGIN: BEGIN
+END: END
+
+TASK: Analyze existing code, write design doc for XXX feature in design.md
+DECISION: Review design.md, is it detailed enough?
+
+BEGIN -> TASK
+TASK -> DECISION
+DECISION -> END: Yes
+DECISION -> TASK: No
+```
+
+In D2, a node becomes a decision node if it has multiple outgoing edges (or you explicitly set `<node>.shape: diamond`). Decision nodes require labeled outgoing edges, and the agent must output `<choice>branch name</choice>` to select the next node.
 
 ::: info Note
 `--prompt-flow` is mutually exclusive with Ralph Loop mode and cannot be used together.

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -138,7 +138,7 @@ YOLO mode skips all confirmations. Make sure you understand the potential risks.
 
 Start Prompt Flow execution.
 
-This command is only available when a flowchart has been loaded via `--prompt-flow`. After execution, the agent will start from the `BEGIN` node and process each node according to the flowchart definition until reaching the `END` node. See [`kimi` command](./kimi-command.md#prompt-flow) for details.
+This command is only available when a Prompt Flow has been loaded via `--prompt-flow` (Mermaid or D2). After execution, the agent will start from the `BEGIN` node and process each node according to the flow definition until reaching the `END` node. See [`kimi` command](./kimi-command.md#prompt-flow) for details.
 
 ## Command completion
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi CLI release.
 
 ## Unreleased
 
+- CLI: Support D2 prompt flow diagrams via `--prompt-flow`
+
 ## 0.77 (2026-01-15)
 
 - Shell: Fix line breaking in `/help` and `/changelog` fullscreen pager display

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -87,11 +87,11 @@ Ralph 循环与 `--prompt-flow` 选项互斥，不能同时使用。
 
 | 选项 | 说明 |
 |------|------|
-| `--prompt-flow PATH` | 加载 Mermaid 流程图文件作为 Prompt Flow |
+| `--prompt-flow PATH` | 加载 Mermaid 流程图或 D2 文件作为 Prompt Flow |
 
-Prompt Flow 是一种基于 Mermaid 流程图的工作流描述方式，每个节点对应一次对话轮次。加载后，可以通过 `/begin` 命令启动流程执行。
+Prompt Flow 是一种基于 Mermaid 流程图或 D2 图表的工作流描述方式，每个节点对应一次对话轮次。加载后，可以通过 `/begin` 命令启动流程执行。
 
-流程图示例（`example.mmd` 文件）：
+Mermaid 流程图示例（`example.mmd` 文件）：
 
 ```
 flowchart TD
@@ -112,6 +112,23 @@ flowchart TD
 ```
 
 在节点处理过程中，分支节点（`{}`）会要求 Agent 输出 `<choice>分支名</choice>` 来选择下一个节点。
+
+D2 示例（`example.d2` 文件）：
+
+```d2
+BEGIN: BEGIN
+END: END
+
+TASK: 分析现有代码，为 XXX 功能编写设计文档，写在 design.md 文件中
+DECISION: Review 一遍 design.md，看看是否足够详细
+
+BEGIN -> TASK
+TASK -> DECISION
+DECISION -> END: 是
+DECISION -> TASK: 否
+```
+
+在 D2 中，节点在拥有多条出边时会被视为分支节点（也可以显式设置 `<node>.shape: diamond`）。分支节点要求所有出边都带有 label，Agent 需要输出 `<choice>分支名</choice>` 来选择下一个节点。
 
 ::: info 注意
 `--prompt-flow` 与 Ralph 循环模式互斥，不能同时使用。

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -138,7 +138,7 @@ YOLO 模式会跳过所有确认，请确保你了解可能的风险。
 
 启动 Prompt Flow 执行。
 
-此命令仅在通过 `--prompt-flow` 加载了流程图时可用。执行后，Agent 会从 `BEGIN` 节点开始，按照流程图的定义依次处理每个节点，直到达到 `END` 节点。详见 [`kimi` 命令](./kimi-command.md#提示词流)。
+此命令仅在通过 `--prompt-flow` 加载了 Prompt Flow（Mermaid 或 D2）时可用。执行后，Agent 会从 `BEGIN` 节点开始，按照流程定义依次处理每个节点，直到达到 `END` 节点。详见 [`kimi` 命令](./kimi-command.md#提示词流)。
 
 ## 命令补全
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- CLI：`--prompt-flow` 支持加载 D2 格式的 Prompt Flow
+
 ## 0.77 (2026-01-15)
 
 - Shell：修复 `/help` 和 `/changelog` 全屏分页显示中的换行问题

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -159,7 +159,7 @@ def kimi(
             file_okay=True,
             dir_okay=False,
             readable=True,
-            help="Mermaid flowchart file to run as a prompt flow.",
+            help="Prompt flow file (Mermaid flowchart or D2) to run as a prompt flow.",
         ),
     ] = None,
     print_mode: Annotated[
@@ -389,7 +389,7 @@ def kimi(
 
     flow = None
     if prompt_flow is not None:
-        from kimi_cli.flow import PromptFlowError, parse_flowchart
+        from kimi_cli.flow import PromptFlowError, PromptFlowFormat, parse_prompt_flow
 
         if max_ralph_iterations != 0:
             raise typer.BadParameter(
@@ -403,7 +403,15 @@ def kimi(
                 f"Failed to read prompt flow file: {e}", param_hint="--prompt-flow"
             ) from e
         try:
-            flow = parse_flowchart(flow_text)
+            flow_format: PromptFlowFormat = "auto"
+            match prompt_flow.suffix.lower():
+                case ".d2":
+                    flow_format = "d2"
+                case ".mmd" | ".mermaid":
+                    flow_format = "mermaid"
+                case _:
+                    pass
+            flow = parse_prompt_flow(flow_text, format=flow_format)
         except PromptFlowError as e:
             raise typer.BadParameter(str(e), param_hint="--prompt-flow") from e
 


### PR DESCRIPTION
Support both Mermaid flowchart and D2 diagram formats for prompt flows.

## D2 subset support:
- Line comments (`# ...`) and block comments (`""" ... """`)
- Shape declarations: `ID`, `ID: label`, `ID.shape: diamond`
- Directed connections: `A -> B`, `A -> B: label`, `A -> B <- C: label`
- Auto-detect format (falls back to D2 if no `flowchart`/`graph` header)

## CLI changes:
- `--prompt-flow` auto-detects format by extension (`.d2` vs `.mmd`/`.mermaid`)
- Same `PromptFlow` data model and `/begin` execution logic

## Example D2 flow:
```d2
BEGIN
END
TASK: Search stdrc
DECISION: Enough?
DECISION.shape: diamond
BEGIN -> TASK
TASK -> DECISION
DECISION -> END: yes
DECISION -> TASK: no
```

## Tests added:
- `test_parse_d2_basic`
- `test_parse_d2_connection_chaining_label_applies`
- `test_parse_prompt_flow_auto_detects_d2`