### PR TITLE
feat(docs): add local search provider to theme configuration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -177,6 +177,7 @@ export default withMermaid(defineConfig({
 
   themeConfig: {
     outline: [2, 3],
+    search: { provider: 'local' },
     socialLinks: [
       { icon: 'github', link: 'https://github.com/MoonshotAI/kimi-cli' },
     ],


### PR DESCRIPTION
## Summary

Add local search functionality to the VitePress documentation site.

## Changes

- Enable VitePress built-in local search by adding `search: { provider: 'local' }` to the theme configuration

## Benefits

- Users can now search through documentation content directly on the site
- No external search service required
- Works offline once the site is loaded