### PR TITLE
feat: support skill allowed-tools auto-approval

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -285,7 +285,8 @@ class KimiSoul:
             extra = args.strip()
             if extra:
                 skill_text = f"{skill_text}\n\nUser request:\n{extra}"
-            await soul._turn(Message(role="user", content=skill_text))
+            with soul.runtime.approval.scoped_tool_approvals(_skill.allowed_tools):
+                await soul._turn(Message(role="user", content=skill_text))
 
         _run_skill.__doc__ = skill.description
         return _run_skill

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -68,12 +68,19 @@ description: Beta description
                 Skill(
                     name="alpha-skill",
                     description="Alpha description",
+                    allowed_tools=[],
                     dir=Path("/path/to/alpha"),
                 ),
-                Skill(name="beta", description="Beta description", dir=Path("/path/to/beta")),
+                Skill(
+                    name="beta",
+                    description="Beta description",
+                    allowed_tools=[],
+                    dir=Path("/path/to/beta"),
+                ),
                 Skill(
                     name="gamma",
                     description="No description provided.",
+                    allowed_tools=[],
                     dir=Path("/path/to/gamma"),
                 ),
             ]
@@ -118,7 +125,14 @@ description: OK
         for skill in skills:
             skill.dir = Path("/path/to") / (skill.dir.relative_to(tmpdir))
         assert skills == snapshot(
-            [Skill(name="valid", description="OK", dir=Path("/path/to/valid"))]
+            [
+                Skill(
+                    name="valid",
+                    description="OK",
+                    allowed_tools=[],
+                    dir=Path("/path/to/valid"),
+                )
+            ]
         )
 
 
@@ -160,7 +174,47 @@ description: Beta description
             skill.dir = Path("/path/to") / (skill.dir.relative_to(tmpdir))
         assert skills == snapshot(
             [
-                Skill(name="beta", description="Beta description", dir=Path("/path/to/user/beta")),
-                Skill(name="shared", description="User version", dir=Path("/path/to/user/shared")),
+                Skill(
+                    name="beta",
+                    description="Beta description",
+                    allowed_tools=[],
+                    dir=Path("/path/to/user/beta"),
+                ),
+                Skill(
+                    name="shared",
+                    description="User version",
+                    allowed_tools=[],
+                    dir=Path("/path/to/user/shared"),
+                ),
+            ]
+        )
+
+
+def test_discover_skills_parses_allowed_tools():
+    with TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+
+        skill_dir = root / "tooling"
+        _write_skill(
+            skill_dir,
+            """---
+name: tooling
+description: Tooling skill
+allowed-tools: "Shell WriteFile StrReplaceFile"
+---
+""",
+        )
+
+        skills = discover_skills(root)
+        for skill in skills:
+            skill.dir = Path("/path/to") / (skill.dir.relative_to(tmpdir))
+        assert skills == snapshot(
+            [
+                Skill(
+                    name="tooling",
+                    description="Tooling skill",
+                    allowed_tools=["Shell", "WriteFile", "StrReplaceFile"],
+                    dir=Path("/path/to/tooling"),
+                )
             ]
         )


### PR DESCRIPTION
## Summary
- parse skill frontmatter `allowed-tools` into `Skill.allowed_tools`
- auto-approve tool calls for allowed tools while running a skill
- cover allowed-tools parsing in skill discovery tests

## Motivation
Other major agents already support this field, we should follow:
https://github.com/vercel-labs/add-skill#compatibility

## Spec
https://agentskills.io/specification#allowed-tools-field

## Testing
- uv run pytest tests/test_skill.py
