### PR TITLE
chore(release): bump version to 0.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 0.81 (2026-01-21)
+
 - Skills: Add flow skill type with embedded Agent Flow (Mermaid/D2) in SKILL.md, invoked via `/flow:<skill-name>` commands
 - CLI: Remove `--prompt-flow` option; use flow skills instead
 - Core: Replace `/begin` command with `/flow:<skill-name>` commands for flow skills

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,22 @@ This page documents breaking changes in Kimi CLI releases and provides migration
 
 ## Unreleased
 
+## 0.81 - Prompt Flow replaced by Flow Skills
+
+### `--prompt-flow` option removed
+
+The `--prompt-flow` CLI option has been removed. Use flow skills instead.
+
+- **Affected**: Scripts and automation using `--prompt-flow` to load Mermaid/D2 flowcharts
+- **Migration**: Create a flow skill with embedded Agent Flow in `SKILL.md` and invoke via `/flow:<skill-name>`
+
+### `/begin` command replaced
+
+The `/begin` slash command has been replaced with `/flow:<skill-name>` commands.
+
+- **Affected**: Users who used `/begin` to start a loaded Prompt Flow
+- **Migration**: Use `/flow:<skill-name>` to invoke flow skills directly
+
 ## 0.77 - Thinking mode and CLI option changes
 
 ### Thinking mode setting migration change

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi CLI release.
 
 ## Unreleased
 
+## 0.81 (2026-01-21)
+
 - Skills: Add flow skill type with embedded Agent Flow (Mermaid/D2) in SKILL.md, invoked via `/flow:<skill-name>` commands
 - CLI: Remove `--prompt-flow` option; use flow skills instead
 - Core: Replace `/begin` command with `/flow:<skill-name>` commands for flow skills

--- a/docs/zh/release-notes/breaking-changes.md
+++ b/docs/zh/release-notes/breaking-changes.md
@@ -4,6 +4,22 @@
 
 ## 未发布
 
+## 0.81 - Prompt Flow 被 Flow Skills 取代
+
+### `--prompt-flow` 选项移除
+
+`--prompt-flow` CLI 选项已移除，请改用 flow skills。
+
+- **受影响**：使用 `--prompt-flow` 加载 Mermaid/D2 流程图的脚本和自动化
+- **迁移**：创建包含嵌入式 Agent Flow 的 flow skill（在 `SKILL.md` 中），并通过 `/flow:<skill-name>` 调用
+
+### `/begin` 命令被替换
+
+`/begin` 斜杠命令已被 `/flow:<skill-name>` 命令替换。
+
+- **受影响**：使用 `/begin` 启动已加载 Prompt Flow 的用户
+- **迁移**：使用 `/flow:<skill-name>` 直接调用 flow skills
+
 ## 0.77 - Thinking 模式与 CLI 选项变更
 
 ### Thinking 模式设置迁移调整

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 0.81 (2026-01-21)
+
 - Skills：添加 Flow Skill 类型，在 SKILL.md 中内嵌 Agent Flow（Mermaid/D2），通过 `/flow:<skill-name>` 命令调用
 - CLI：移除 `--prompt-flow` 选项，改用 Flow Skills
 - Core：用 `/flow:<skill-name>` 命令替代原来的 `/begin` 命令

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "0.80"
+version = "0.81"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==0.80"]
+dependencies = ["kimi-cli==0.81"]
 
 [project.scripts]
 kimi = "kimi_cli.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "0.80"
+version = "0.81"
 description = "Kimi CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1105,7 +1105,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "0.80"
+version = "0.81"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1183,7 +1183,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "0.80"
+version = "0.81"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },


### PR DESCRIPTION
## Summary

Bump kimi-cli and kimi-code to version 0.81.

## Changes

### Version Updates
- `pyproject.toml`: 0.80 → 0.81
- `packages/kimi-code/pyproject.toml`: 0.80 → 0.81 (version + dependency)
- `uv.lock`: synced

### Changelog Updates
- `CHANGELOG.md`: Added 0.81 (2026-01-21) release notes
- `docs/en/release-notes/changelog.md`: Synced via script
- `docs/zh/release-notes/changelog.md`: Added 0.81 release notes

### Breaking Changes Documentation
- `docs/en/release-notes/breaking-changes.md`: Added 0.81 section
- `docs/zh/release-notes/breaking-changes.md`: Added 0.81 section

## Release Notes (0.81)

- Skills: Add flow skill type with embedded Agent Flow (Mermaid/D2) in SKILL.md, invoked via `/flow:<skill-name>` commands
- CLI: Remove `--prompt-flow` option; use flow skills instead
- Core: Replace `/begin` command with `/flow:<skill-name>` commands for flow skills

## Breaking Changes

- `--prompt-flow` CLI option removed → use flow skills instead
- `/begin` slash command replaced → use `/flow:<skill-name>` commands