### PR TITLE
chore: bump kimi-cli 0.82, kosong 0.39.0, kimi-sdk 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 0.82 (2026-01-21)
+
 - Tool: Allow `WriteFile` and `StrReplaceFile` tools to edit/write files outside the working directory when using absolute paths
 - Tool: Upload videos to Kimi files API when using Kimi provider, replacing inline data URLs with `ms://` references
 - Config: Add `reserved_context_size` setting to customize auto-compaction trigger threshold (default: 50000 tokens)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi CLI release.
 
 ## Unreleased
 
+## 0.82 (2026-01-21)
+
 - Tool: Allow `WriteFile` and `StrReplaceFile` tools to edit/write files outside the working directory when using absolute paths
 - Tool: Upload videos to Kimi files API when using Kimi provider, replacing inline data URLs with `ms://` references
 - Config: Add `reserved_context_size` setting to customize auto-compaction trigger threshold (default: 50000 tokens)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 0.82 (2026-01-21)
+
 - Tool：`WriteFile` 和 `StrReplaceFile` 工具支持使用绝对路径编辑/写入工作目录外的文件
 - Tool：使用 Kimi 供应商时，视频文件上传到 Kimi Files API，使用 `ms://` 引用替代 inline data URL
 - Config：添加 `reserved_context_size` 配置项，自定义自动压缩触发阈值（默认 50000 tokens）

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "0.81"
+version = "0.82"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==0.81"]
+dependencies = ["kimi-cli==0.82"]
 
 [project.scripts]
 kimi = "kimi_cli.cli:cli"

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.39.0 (2026-01-21)
+
 - Control thinking mode via `extra_body` parameter instead of legacy `reasoning_effort`
 - Add `files` property to `Kimi` provider that returns a `KimiFiles` object
 - Add `KimiFiles.upload_video()` method for uploading videos to Kimi files API, returning `VideoURLPart`

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kosong"
-version = "0.38.0"
+version = "0.39.0"
 description = "The LLM abstraction layer for modern AI agent applications."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "0.81"
+version = "0.82"
 description = "Kimi CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -9,7 +9,7 @@ dependencies = [
     "aiofiles>=24.0,<26.0",
     "aiohttp==3.13.3",
     "typer==0.21.1",
-    "kosong[contrib]==0.38.0",
+    "kosong[contrib]==0.39.0",
     # loguru stays >=0.6.0 because notify-py (via batrachian-toad) caps it at <=0.6.0 on 3.14+.
     "loguru>=0.6.0,<0.8",
     "prompt-toolkit==3.0.52",

--- a/sdks/kimi-sdk/CHANGELOG.md
+++ b/sdks/kimi-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2 (2026-01-21)
+
+- Update kosong dependency upper bound to support kosong 0.39.x
+
 ## 0.1.1 (2026-01-16)
 
 - Fix kosong dependency version constraint to support kosong 0.38.x

--- a/sdks/kimi-sdk/pyproject.toml
+++ b/sdks/kimi-sdk/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "A lightweight Python SDK for the Kimi API."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kosong>=0.37.0,<0.39.0"]
+dependencies = ["kosong>=0.37.0,<0.40.0"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1105,7 +1105,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "0.81"
+version = "0.82"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1183,7 +1183,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "0.81"
+version = "0.82"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },
@@ -1194,7 +1194,7 @@ requires-dist = [{ name = "kimi-cli", editable = "." }]
 
 [[package]]
 name = "kimi-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "sdks/kimi-sdk" }
 dependencies = [
     { name = "kosong" },
@@ -1229,7 +1229,7 @@ dev = [
 
 [[package]]
 name = "kosong"
-version = "0.38.0"
+version = "0.39.0"
 source = { editable = "packages/kosong" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Release version bumps for multiple packages:

### kimi-cli 0.82
- Tool: Allow `WriteFile` and `StrReplaceFile` tools to edit/write files outside the working directory when using absolute paths
- Tool: Upload videos to Kimi files API when using Kimi provider, replacing inline data URLs with `ms://` references
- Config: Add `reserved_context_size` setting to customize auto-compaction trigger threshold (default: 50000 tokens)

### kosong 0.39.0
- Control thinking mode via `extra_body` parameter instead of legacy `reasoning_effort`
- Add `files` property to `Kimi` provider that returns a `KimiFiles` object
- Add `KimiFiles.upload_video()` method for uploading videos to Kimi files API, returning `VideoURLPart`

### kimi-sdk 0.1.2
- Update kosong dependency upper bound to support kosong 0.39.x

### kimi-code 0.82
- Sync version with kimi-cli

## Changes
- Updated `pyproject.toml` versions for all packages
- Updated `CHANGELOG.md` for kimi-cli, kosong, and kimi-sdk
- Synced documentation changelogs
- Updated `uv.lock`