### PR TITLE
feat(kaos): add E2B sandbox integration

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -10,5 +10,6 @@ flowchart TB
     B -- 有 --> D(["END"])
     B -- 没有 --> n1["确保当前分支是一个不同于 main 的独立分支"]
     n1 --> n2["根据当前分支相对于 main 分支的修改，push 并提交一个 PR（利用 gh 命令），用英文编写 PR 标题和 description，描述所做的更改。PR title 要符合先前的 commit message 规范（PR title 就是 squash merge 之后的 commit message）。"]
-    n2 --> D
+    n2 --> n3["等待 CI 通过（使用 gh pr checks --watch 监控 CI 状态）"]
+    n3 --> D
 ```

--- a/examples/kimi-cli-e2b-kaos/README.md
+++ b/examples/kimi-cli-e2b-kaos/README.md
@@ -1,0 +1,30 @@
+# Kimi CLI + E2B KAOS (external sandbox lifecycle)
+
+This example runs **KimiCLI** on an **E2B** sandbox as the KAOS backend. The sandbox lifecycle is managed **outside** of KimiCLI/KAOS.
+
+## Requirements
+
+- `E2B_API_KEY` in the environment.
+
+## Run
+
+```bash
+cd examples/kimi-cli-e2b-kaos
+
+# Required
+export E2B_API_KEY=...
+
+# Optional
+export E2B_SANDBOX_ID=...
+export KIMI_WORK_DIR=/home/user/kimi-workdir
+
+uv run python main.py
+```
+
+## Notes
+
+- On startup, the script asks whether to **create** a new sandbox or **connect** to an existing one.
+- This example **never kills** sandboxes; lifecycle remains external.
+- `KIMI_WORK_DIR` is created inside the sandbox if missing.
+- Defaults: template `base`, timeout `300s` (create mode).
+- Uses a custom agent file (`agent.yaml`) to disable the `Grep` tool, which only supports local KAOS.

--- a/examples/kimi-cli-e2b-kaos/agent.yaml
+++ b/examples/kimi-cli-e2b-kaos/agent.yaml
@@ -1,0 +1,7 @@
+version: 1
+agent:
+  extend: default
+  name: "e2b"
+  # Grep tool only supports local KAOS; disable it for E2B sandboxes.
+  exclude_tools:
+    - "kimi_cli.tools.file:Grep"

--- a/examples/kimi-cli-e2b-kaos/main.py
+++ b/examples/kimi-cli-e2b-kaos/main.py
@@ -1,0 +1,130 @@
+"""
+Example: Run Kimi CLI on top of an E2B sandbox.
+
+Docs:
+- E2B user/workdir defaults: https://e2b.dev/docs/template/user-and-workdir
+- E2B commands/filesystem: https://e2b.dev/docs/commands / https://e2b.dev/docs/filesystem
+- E2B API keys: https://e2b.dev/dashboard?tab=keys
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+from e2b import AsyncSandbox
+from kaos import reset_current_kaos, set_current_kaos
+from kaos.contrib.e2b import E2BKaos
+from kaos.path import KaosPath
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.table import Table
+from rich.text import Text
+
+from kimi_cli.app import KimiCLI, enable_logging
+from kimi_cli.session import Session
+from kimi_cli.ui.shell import Shell
+
+
+async def main() -> None:
+    enable_logging()
+    console = Console()
+    _render_banner(console)
+    _render_key_status(console)
+
+    work_dir_path = os.getenv("KIMI_WORK_DIR", DEFAULT_WORK_DIR)
+    sandbox: AsyncSandbox = await _select_sandbox(console)
+    console.print(f"[green]using sandbox:[/green] {sandbox.sandbox_id}")
+    e2b_kaos = E2BKaos(
+        sandbox,
+        cwd=work_dir_path,
+    )
+
+    token = set_current_kaos(e2b_kaos)
+    try:
+        work_dir = KaosPath(work_dir_path)
+        await work_dir.mkdir(parents=True, exist_ok=True)
+
+        session: Session = await Session.create(work_dir)
+        instance: KimiCLI = await KimiCLI.create(session, yolo=True, agent_file=AGENT_FILE)
+        ui = Shell(instance.soul)
+        await ui.run()
+    finally:
+        reset_current_kaos(token)
+
+
+async def _select_sandbox(console: Console) -> AsyncSandbox:
+    mode = _prompt_choice(console)
+    if mode == "create":
+        sandbox: AsyncSandbox = await AsyncSandbox.create(
+            template=DEFAULT_TEMPLATE,
+            timeout=DEFAULT_TIMEOUT_SEC,
+        )
+        return sandbox
+
+    sandbox_id = os.getenv("E2B_SANDBOX_ID")
+    if not sandbox_id:
+        sandbox_id = _prompt_text(console, "Sandbox ID", "Enter an existing E2B sandbox ID")
+        if not sandbox_id:
+            raise RuntimeError("Sandbox ID is required for connect mode")
+    sandbox = await AsyncSandbox.connect(sandbox_id)
+    return sandbox
+
+
+def _prompt_choice(console: Console) -> str:
+    default_mode = "connect" if os.getenv("E2B_SANDBOX_ID") else "create"
+    options = [
+        ("1", "create", "Create a new sandbox"),
+        ("2", "connect", "Connect to existing sandbox"),
+    ]
+    table = Table(title="Sandbox mode")
+    table.add_column("Key", style="cyan")
+    table.add_column("Action")
+    for key, _, label in options:
+        table.add_row(key, label)
+    console.print(table)
+    choice = Prompt.ask(
+        "Select option",
+        choices=[item[0] for item in options],
+        default="1" if default_mode == "create" else "2",
+        console=console,
+    )
+    for key, value, _ in options:
+        if choice == key:
+            return value
+    return default_mode
+
+
+def _prompt_text(console: Console, title: str, text: str) -> str:
+    console.print(f"[dim]{text}[/dim]")
+    return Prompt.ask(title, default="", console=console).strip()
+
+
+def _render_banner(console: Console) -> None:
+    title = Text("Kimi CLI + E2B KAOS", style="bold cyan")
+    subtitle = Text("interactive sandbox selector", style="dim")
+    console.print(Panel.fit(Text.assemble(title, "\n", subtitle)))
+
+
+def _render_key_status(console: Console) -> None:
+    api_key = os.getenv("E2B_API_KEY", "")
+    if api_key:
+        masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "set"
+        console.print(f"[green]E2B_API_KEY:[/green] {masked}")
+        return
+
+    message = Text.assemble(
+        ("E2B_API_KEY not set. Configure it at: ", "yellow"),
+        ("https://e2b.dev/dashboard?tab=keys", "bold"),
+    )
+    console.print(Panel.fit(message, title="Missing API Key", border_style="yellow"))
+
+
+DEFAULT_WORK_DIR = "/home/user/kimi-workdir"
+DEFAULT_TEMPLATE = "base"
+DEFAULT_TIMEOUT_SEC = 300
+AGENT_FILE = Path(__file__).resolve().with_name("agent.yaml")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/kimi-cli-e2b-kaos/pyproject.toml
+++ b/examples/kimi-cli-e2b-kaos/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "kimi-cli-e2b-kaos"
+version = "0.1.0"
+description = "Run Kimi CLI with E2B-backed KAOS"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "kimi-cli",
+    "e2b>=2.10.2",
+    "rich",
+]
+
+[tool.uv.sources]
+kimi-cli = { path = "../../" }

--- a/packages/kaos/CHANGELOG.md
+++ b/packages/kaos/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `E2BKaos` implementation in `kaos.contrib.e2b` for running on E2B sandboxes
+- Add `contrib` optional dependency group with `e2b>=2.10.2,<3.0.0`
+
 ## 0.6.0 (2026-01-09)
 
 - Add optional `n` parameter to `readbytes` to read only the first n bytes

--- a/packages/kaos/pyproject.toml
+++ b/packages/kaos/pyproject.toml
@@ -9,6 +9,11 @@ dependencies = [
     "asyncssh==2.21.1",
 ]
 
+[project.optional-dependencies]
+contrib = [
+    "e2b>=2.10.2,<3.0.0",
+]
+
 [dependency-groups]
 dev = [
     "inline-snapshot[black]>=0.31.1",

--- a/packages/kaos/src/kaos/contrib/__init__.py
+++ b/packages/kaos/src/kaos/contrib/__init__.py
@@ -1,0 +1,5 @@
+"""
+Contrib modules for KAOS.
+
+These integrations are optional and may require extra dependencies.
+"""

--- a/packages/kaos/src/kaos/contrib/e2b.py
+++ b/packages/kaos/src/kaos/contrib/e2b.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import asyncio
+import posixpath
+import shlex
+import stat
+from collections.abc import AsyncGenerator, Iterable
+from datetime import datetime
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Literal
+
+from e2b import (  # type: ignore[import-untyped]
+    AsyncCommandHandle,
+    AsyncSandbox,
+    CommandExitException,
+    CommandResult,
+    EntryInfo,
+    FileType,
+    NotFoundException,
+)
+from e2b.sandbox_async.commands.command import Commands  # type: ignore[import-untyped]
+
+from kaos import AsyncReadable, AsyncWritable, Kaos, KaosProcess, StatResult, StrOrKaosPath
+from kaos.path import KaosPath
+
+if TYPE_CHECKING:
+
+    def type_check(e2b_kaos: E2BKaos) -> None:
+        _: Kaos = e2b_kaos
+
+
+class _E2BStdin:
+    def __init__(self, commands: Commands, pid: int) -> None:
+        self._commands = commands
+        self._pid = pid
+        self._closed = False
+        self._eof_sent = False
+        self._lock = asyncio.Lock()
+        self._last_task: asyncio.Task[None] | None = None
+
+    def can_write_eof(self) -> bool:
+        return False
+
+    def close(self) -> None:
+        self._closed = True
+        self.write_eof()
+
+    async def drain(self) -> None:
+        if self._last_task is not None:
+            await self._last_task
+
+    def is_closing(self) -> bool:
+        return self._closed
+
+    async def wait_closed(self) -> None:
+        await self.drain()
+
+    def write(self, data: bytes) -> None:
+        if self._closed:
+            return
+        text = data.decode("utf-8", errors="replace")
+        self._last_task = asyncio.create_task(self._send(text))
+
+    def writelines(self, data: Iterable[bytes], /) -> None:
+        for chunk in data:
+            self.write(chunk)
+
+    def write_eof(self) -> None:
+        if self._eof_sent:
+            return None
+        self._eof_sent = True
+        self._last_task = asyncio.create_task(self._send("\x04"))
+        return None
+
+    async def _send(self, text: str) -> None:
+        async with self._lock:
+            await self._commands.send_stdin(self._pid, text)
+
+
+class _E2BProcess:
+    def __init__(self, handle: AsyncCommandHandle, commands: Commands) -> None:
+        self._handle = handle
+        self._stdout = asyncio.StreamReader()
+        self._stderr = asyncio.StreamReader()
+        self._stdin = _E2BStdin(commands, handle.pid)
+        self.stdin: AsyncWritable = self._stdin
+        self.stdout: AsyncReadable = self._stdout
+        self.stderr: AsyncReadable = self._stderr
+        self._returncode: int | None = None
+        self._exit_future: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+        self._monitor_task = asyncio.create_task(self._monitor())
+
+    @property
+    def pid(self) -> int:
+        return self._handle.pid
+
+    @property
+    def returncode(self) -> int | None:
+        return self._returncode
+
+    async def wait(self) -> int:
+        return await self._exit_future
+
+    async def kill(self) -> None:
+        await self._handle.kill()
+
+    def feed_stdout(self, chunk: str) -> None:
+        if chunk:
+            self._stdout.feed_data(chunk.encode("utf-8", "replace"))
+
+    def feed_stderr(self, chunk: str) -> None:
+        if chunk:
+            self._stderr.feed_data(chunk.encode("utf-8", "replace"))
+
+    async def _monitor(self) -> None:
+        exit_code = 1
+        try:
+            result: CommandResult = await self._handle.wait()
+            exit_code = result.exit_code
+        except CommandExitException as exc:
+            exit_code = exc.exit_code
+        except Exception as exc:
+            self.feed_stderr(f"[e2b command error] {exc}\n")
+        finally:
+            self._returncode = exit_code
+            self._stdout.feed_eof()
+            self._stderr.feed_eof()
+            if not self._exit_future.done():
+                self._exit_future.set_result(exit_code)
+
+
+class E2BKaos:
+    """
+    KAOS backend for an existing E2B AsyncSandbox.
+
+    Sandbox lifecycle is managed externally; this class never creates or kills sandboxes.
+
+    Docs:
+    - E2B user/workdir defaults: https://e2b.dev/docs/template/user-and-workdir
+    - E2B commands/filesystem: https://e2b.dev/docs/commands / https://e2b.dev/docs/filesystem
+    """
+
+    name: str = "e2b"
+
+    def __init__(
+        self,
+        sandbox: AsyncSandbox,
+        *,
+        home_dir: str = "/home/user",
+        cwd: str | None = None,
+        user: str | None = None,
+        request_timeout: float | None = None,
+    ) -> None:
+        self._sandbox = sandbox
+        self._home_dir = posixpath.normpath(home_dir)
+        self._cwd = posixpath.normpath(cwd) if cwd is not None else self._home_dir
+        self._user = user
+        self._request_timeout = request_timeout
+
+    def pathclass(self) -> type[PurePosixPath]:
+        return PurePosixPath
+
+    def normpath(self, path: StrOrKaosPath) -> KaosPath:
+        return KaosPath(posixpath.normpath(str(path)))
+
+    def gethome(self) -> KaosPath:
+        return KaosPath(self._home_dir)
+
+    def getcwd(self) -> KaosPath:
+        return KaosPath(self._cwd)
+
+    async def chdir(self, path: StrOrKaosPath) -> None:
+        abs_path = self._abs_path(path)
+        try:
+            info: EntryInfo = await self._sandbox.files.get_info(
+                abs_path,
+                user=self._user,
+                request_timeout=self._request_timeout,
+            )
+        except NotFoundException as exc:
+            raise FileNotFoundError(abs_path) from exc
+        if info.type != FileType.DIR:
+            raise NotADirectoryError(f"{abs_path} is not a directory")
+        self._cwd = abs_path
+
+    async def stat(self, path: StrOrKaosPath, *, follow_symlinks: bool = True) -> StatResult:
+        del follow_symlinks
+        abs_path = self._abs_path(path)
+        try:
+            info: EntryInfo = await self._sandbox.files.get_info(
+                abs_path,
+                user=self._user,
+                request_timeout=self._request_timeout,
+            )
+        except NotFoundException as exc:
+            raise FileNotFoundError(abs_path) from exc
+        mode = self._with_type_bits(info)
+        mtime = self._to_timestamp(info.modified_time)
+        return StatResult(
+            st_mode=mode,
+            st_ino=0,
+            st_dev=0,
+            st_nlink=1,
+            st_uid=0,
+            st_gid=0,
+            st_size=info.size,
+            st_atime=mtime,
+            st_mtime=mtime,
+            st_ctime=mtime,
+        )
+
+    async def iterdir(self, path: StrOrKaosPath) -> AsyncGenerator[KaosPath]:
+        abs_path = self._abs_path(path)
+        entries: list[EntryInfo] = await self._sandbox.files.list(
+            abs_path,
+            depth=1,
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+        for entry in entries:
+            if entry.path == abs_path:
+                continue
+            yield KaosPath(entry.path)
+
+    async def glob(
+        self, path: StrOrKaosPath, pattern: str, *, case_sensitive: bool = True
+    ) -> AsyncGenerator[KaosPath]:
+        if not case_sensitive:
+            raise ValueError("Case insensitive glob is not supported in current environment")
+        abs_path = self._abs_path(path)
+        entries: list[EntryInfo] = await self._sandbox.files.list(
+            abs_path,
+            depth=1,
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+        for entry in entries:
+            if entry.path == abs_path:
+                continue
+            if self._fnmatch(entry.name, pattern):
+                yield KaosPath(entry.path)
+
+    async def readbytes(self, path: StrOrKaosPath, n: int | None = None) -> bytes:
+        abs_path = self._abs_path(path)
+        data: bytes | bytearray = await self._sandbox.files.read(
+            abs_path,
+            format="bytes",
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+        payload = bytes(data)
+        return payload if n is None else payload[:n]
+
+    async def readtext(
+        self,
+        path: StrOrKaosPath,
+        *,
+        encoding: str = "utf-8",
+        errors: Literal["strict", "ignore", "replace"] = "strict",
+    ) -> str:
+        del encoding, errors
+        abs_path = self._abs_path(path)
+        result: str = await self._sandbox.files.read(
+            abs_path,
+            format="text",
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+        return result
+
+    async def readlines(
+        self,
+        path: StrOrKaosPath,
+        *,
+        encoding: str = "utf-8",
+        errors: Literal["strict", "ignore", "replace"] = "strict",
+    ) -> AsyncGenerator[str]:
+        text = await self.readtext(path, encoding=encoding, errors=errors)
+        for line in text.splitlines(keepends=True):
+            yield line
+
+    async def writebytes(self, path: StrOrKaosPath, data: bytes) -> int:
+        abs_path = self._abs_path(path)
+        await self._sandbox.files.write(  # type: ignore[reportUnknownMemberType]
+            abs_path,
+            data,
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+        return len(data)
+
+    async def writetext(
+        self,
+        path: StrOrKaosPath,
+        data: str,
+        *,
+        mode: Literal["w", "a"] = "w",
+        encoding: str = "utf-8",
+        errors: Literal["strict", "ignore", "replace"] = "strict",
+    ) -> int:
+        del encoding, errors
+        abs_path = self._abs_path(path)
+        if mode == "a":
+            data = await self._read_for_append(abs_path) + data
+        await self._sandbox.files.write(  # type: ignore[reportUnknownMemberType]
+            abs_path,
+            data,
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+        return len(data)
+
+    async def mkdir(
+        self, path: StrOrKaosPath, parents: bool = False, exist_ok: bool = False
+    ) -> None:
+        abs_path = self._abs_path(path)
+        existing = await self._get_info(abs_path)
+        if existing is not None:
+            if not exist_ok:
+                raise FileExistsError(f"{abs_path} already exists")
+            if existing.type != FileType.DIR:
+                raise FileExistsError(f"{abs_path} already exists and is not a directory")
+            return
+
+        if not parents:
+            parent = posixpath.dirname(abs_path) or "/"
+            parent_info = await self._get_info(parent)
+            if parent_info is None:
+                raise FileNotFoundError(f"Parent directory {parent} does not exist")
+            if parent_info.type != FileType.DIR:
+                raise NotADirectoryError(f"Parent path {parent} is not a directory")
+
+        await self._sandbox.files.make_dir(
+            abs_path,
+            user=self._user,
+            request_timeout=self._request_timeout,
+        )
+
+    async def exec(self, *args: str) -> KaosProcess:
+        if not args:
+            raise ValueError("At least one argument (the program to execute) is required.")
+        command = " ".join(shlex.quote(arg) for arg in args)
+        if self._cwd:
+            command = f"cd {shlex.quote(self._cwd)} && {command}"
+        process: _E2BProcess | None = None
+        stdout_buffer: list[str] = []
+        stderr_buffer: list[str] = []
+
+        def on_stdout(chunk: str) -> None:
+            if process is None:
+                stdout_buffer.append(chunk)
+            else:
+                process.feed_stdout(chunk)
+
+        def on_stderr(chunk: str) -> None:
+            if process is None:
+                stderr_buffer.append(chunk)
+            else:
+                process.feed_stderr(chunk)
+
+        handle: AsyncCommandHandle = await self._sandbox.commands.run(
+            command,
+            background=True,
+            envs=None,
+            user=self._user,
+            cwd=self._cwd,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            stdin=True,
+            timeout=None,
+            request_timeout=self._request_timeout,
+        )
+        process = _E2BProcess(handle, self._sandbox.commands)
+        for chunk in stdout_buffer:
+            process.feed_stdout(chunk)
+        for chunk in stderr_buffer:
+            process.feed_stderr(chunk)
+        return process
+
+    async def _read_for_append(self, path: str) -> str:
+        try:
+            existing: str = await self._sandbox.files.read(
+                path,
+                format="text",
+                user=self._user,
+                request_timeout=self._request_timeout,
+            )
+        except NotFoundException:
+            return ""
+        return existing
+
+    async def _get_info(self, path: str) -> EntryInfo | None:
+        try:
+            info: EntryInfo = await self._sandbox.files.get_info(
+                path,
+                user=self._user,
+                request_timeout=self._request_timeout,
+            )
+            return info
+        except NotFoundException:
+            return None
+
+    def _abs_path(self, path: StrOrKaosPath) -> str:
+        raw = str(path)
+        if posixpath.isabs(raw):
+            return posixpath.normpath(raw)
+        return posixpath.normpath(posixpath.join(self._cwd, raw))
+
+    @staticmethod
+    def _fnmatch(name: str, pattern: str) -> bool:
+        from fnmatch import fnmatchcase
+
+        return fnmatchcase(name, pattern)
+
+    @staticmethod
+    def _to_timestamp(value: datetime) -> float:
+        return value.timestamp()
+
+    @staticmethod
+    def _with_type_bits(info: EntryInfo) -> int:
+        mode = info.mode
+        type_mode = stat.S_IFDIR if info.type == FileType.DIR else stat.S_IFREG
+        if stat.S_IFMT(mode) == 0:
+            mode |= type_mode
+        return mode if mode else type_mode

--- a/uv.lock
+++ b/uv.lock
@@ -323,6 +323,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -579,6 +588,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -594,6 +612,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/89fe6215b443b919cb98a5002e107cb5026854ed1ccb6b5833e0768419d1/docutils-0.22.2.tar.gz", hash = "sha256:9fdb771707c8784c8f2728b67cb2c691305933d68137ef95a75db5f4dfbc213d", size = 2289092, upload-time = "2025-09-20T17:55:47.994Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/dd/f95350e853a4468ec37478414fc04ae2d61dad7a947b3015c3dcc51a09b9/docutils-0.22.2-py3-none-any.whl", hash = "sha256:b0e98d679283fc3bb0ead8a5da7f501baa632654e7056e9c5846842213d674d8", size = 632667, upload-time = "2025-09-20T17:55:43.052Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/16/afd0b78b12bc50570ec3a3cd6d668e3c112aa250e02a7cc10fd7fc717142/e2b-2.10.2.tar.gz", hash = "sha256:b77ecd620fd057b81a9610da18141811c003cc6f446c39c7ec7b9e9dc147d864", size = 114601, upload-time = "2026-01-15T16:44:44.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/ab/54d17995ef09436120464fc997b5399c0920c95bc007efc315ba5518349d/e2b-2.10.2-py3-none-any.whl", hash = "sha256:c719291fc9b3006b286809f6e820b803a1aab9a6f5ae4fe0140ead17efbce821", size = 213497, upload-time = "2026-01-15T16:44:43.067Z" },
 ]
 
 [[package]]
@@ -2070,6 +2109,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/b8/cda15d9d46d03d4aa3a67cb6bffe05173440ccf86a9541afaf7ac59a1b6b/protobuf-6.33.4.tar.gz", hash = "sha256:dc2e61bca3b10470c1912d166fe0af67bfc20eb55971dcef8dfa48ce14f0ed91", size = 444346, upload-time = "2026-01-12T18:33:40.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/be/24ef9f3095bacdf95b458543334d0c4908ccdaee5130420bf064492c325f/protobuf-6.33.4-cp310-abi3-win32.whl", hash = "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d", size = 425612, upload-time = "2026-01-12T18:33:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ad/e5693e1974a28869e7cd244302911955c1cebc0161eb32dfa2b25b6e96f0/protobuf-6.33.4-cp310-abi3-win_amd64.whl", hash = "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc", size = 436962, upload-time = "2026-01-12T18:33:31.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/15/6ee23553b6bfd82670207ead921f4d8ef14c107e5e11443b04caeb5ab5ec/protobuf-6.33.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2fe67f6c014c84f655ee06f6f66213f9254b3a8b6bda6cda0ccd4232c73c06f0", size = 427612, upload-time = "2026-01-12T18:33:32.646Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/48/d301907ce6d0db75f959ca74f44b475a9caa8fcba102d098d3c3dd0f2d3f/protobuf-6.33.4-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:757c978f82e74d75cba88eddec479df9b99a42b31193313b75e492c06a51764e", size = 324484, upload-time = "2026-01-12T18:33:33.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1c/e53078d3f7fe710572ab2dcffd993e1e3b438ae71cfc031b71bae44fcb2d/protobuf-6.33.4-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c7c64f259c618f0bef7bee042075e390debbf9682334be2b67408ec7c1c09ee6", size = 339256, upload-time = "2026-01-12T18:33:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8e/971c0edd084914f7ee7c23aa70ba89e8903918adca179319ee94403701d5/protobuf-6.33.4-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:3df850c2f8db9934de4cf8f9152f8dc2558f49f298f37f90c517e8e5c84c30e9", size = 323311, upload-time = "2026-01-12T18:33:36.305Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b1/1dc83c2c661b4c62d56cc081706ee33a4fc2835bd90f965baa2663ef7676/protobuf-6.33.4-py3-none-any.whl", hash = "sha256:1fe3730068fcf2e595816a6c34fe66eeedd37d51d0400b72fabc848811fdc1bc", size = 170532, upload-time = "2026-01-12T18:33:39.199Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2263,6 +2317,11 @@ dependencies = [
     { name = "asyncssh" },
 ]
 
+[package.optional-dependencies]
+contrib = [
+    { name = "e2b" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "inline-snapshot", extra = ["black"] },
@@ -2277,7 +2336,9 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.0,<26.0" },
     { name = "asyncssh", specifier = "==2.21.1" },
+    { name = "e2b", marker = "extra == 'contrib'", specifier = ">=2.10.2,<3.0.0" },
 ]
+provides-extras = ["contrib"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3412,6 +3473,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add E2B sandbox integration to kaos, enabling execution of kaos operations in E2B cloud sandboxes.

To run:
```
uv run examples/kimi-cli-e2b-kaos/main.py
```

## Changes

- **E2BKaos implementation**: Add `E2BKaos` class in `kaos.contrib.e2b` that implements the `Kaos` interface for E2B sandboxes, supporting:
  - File operations (read/write text and bytes, stat, exists, mkdir, rm, glob, etc.)
  - Process execution with streaming output
  - Path manipulation for sandbox environments

- **New optional dependency**: Add `contrib` optional dependency group with `e2b>=2.10.2,<3.0.0`

- **Example project**: Add `kimi-cli-e2b-kaos` example demonstrating how to use E2BKaos with kimi-cli

- **Skill update**: Update pull-request skill to wait for CI after PR submission
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
