### PR TITLE
fix(tools): improve ReadFile description to clarify directory handling

### DIFF
--- a/src/kimi_cli/tools/file/read.md
+++ b/src/kimi_cli/tools/file/read.md
@@ -5,7 +5,7 @@ Read text content from a file.
 - A `<system>` tag will be given before the read file content.
 - The system will notify you when there is anything wrong when reading the file.
 - This tool is a tool that you typically want to use in parallel. Always read multiple files in one response when possible.
-- This tool can only read text files. To read images or videos, use other appropriate tools. To list directories, use the Glob tool or `ls` command via the Shell tool. To read other file types, use appropriate commands via the Shell tool.
+- This tool can only read text files, not directories. To read images or videos, use other appropriate tools. To list directories, use the Glob tool or `ls` command via the Shell tool. To read other file types, use appropriate commands via the Shell tool.
 - If the file doesn't exist or path is invalid, an error will be returned.
 - If you want to search for a certain content/pattern, prefer Grep tool over ReadFile.
 - Content will be returned with a line number before each line like `cat -n` format.

--- a/tests/tools/test_tool_descriptions.py
+++ b/tests/tools/test_tool_descriptions.py
@@ -180,7 +180,7 @@ Read text content from a file.
 - A `<system>` tag will be given before the read file content.
 - The system will notify you when there is anything wrong when reading the file.
 - This tool is a tool that you typically want to use in parallel. Always read multiple files in one response when possible.
-- This tool can only read text files. To read images or videos, use other appropriate tools. To list directories, use the Glob tool or `ls` command via the Shell tool. To read other file types, use appropriate commands via the Shell tool.
+- This tool can only read text files, not directories. To read images or videos, use other appropriate tools. To list directories, use the Glob tool or `ls` command via the Shell tool. To read other file types, use appropriate commands via the Shell tool.
 - If the file doesn't exist or path is invalid, an error will be returned.
 - If you want to search for a certain content/pattern, prefer Grep tool over ReadFile.
 - Content will be returned with a line number before each line like `cat -n` format.


### PR DESCRIPTION
AI 模型有时会用 ReadFile 读取目录路径，导致 Invalid path 错误。

在工具描述开头添加明确声明：只能读取文件，不能读取目录。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
AI models sometimes use ReadFile to read directory paths, causing Invalid path errors.

Add an explicit statement at the beginning of the tool description: only files can be read, not directories.
