### PR TITLE
docs: recommend Python 3.13 for installation

### DIFF
--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -45,8 +45,12 @@ Due to macOS security checks, the first run of the `kimi` command may take longe
 If you already have uv installed, you can also run:
 
 ```sh
-uv tool install --python 3.14 kimi-cli
+uv tool install --python 3.13 kimi-cli
 ```
+
+::: tip
+Kimi Code CLI supports Python 3.12–3.14, with Python 3.13 recommended.
+:::
 
 ## Upgrade and uninstall
 

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -45,8 +45,12 @@ kimi --version
 如果你已经安装了 uv，也可以直接运行：
 
 ```sh
-uv tool install --python 3.14 kimi-cli
+uv tool install --python 3.13 kimi-cli
 ```
+
+::: tip 提示
+Kimi Code CLI 支持 Python 3.12-3.14，但建议使用 3.13 以获得最佳兼容性。
+:::
 
 ## 升级与卸载
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,4 +16,4 @@ if (-not (Get-Command $uvBin -ErrorAction SilentlyContinue)) {
   exit 1
 }
 
-& $uvBin tool install --python 3.14 kimi-cli
+& $uvBin tool install --python 3.13 kimi-cli

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,4 +28,4 @@ if ! command -v "$UV_BIN" >/dev/null 2>&1; then
   exit 1
 fi
 
-"$UV_BIN" tool install --python 3.14 kimi-cli
+"$UV_BIN" tool install --python 3.13 kimi-cli

--- a/src/kimi_cli/cli/toad.py
+++ b/src/kimi_cli/cli/toad.py
@@ -29,8 +29,7 @@ def _default_toad_command() -> list[str]:
         raise typer.Exit(code=1)
     if importlib.util.find_spec("toad") is None:
         typer.echo(
-            "Toad dependency is missing. Run `uv sync --python 3.14` or install kimi-cli with "
-            "Python 3.14.",
+            "Toad dependency is missing. Install kimi-cli with Python 3.14+ to use `kimi term`.",
             err=True,
         )
         raise typer.Exit(code=1)


### PR DESCRIPTION
## Summary

This PR updates the recommended Python version from 3.14 to 3.13 for installing Kimi Code CLI.

## Changes

- **Install scripts**: Update `scripts/install.sh` and `scripts/install.ps1` to use Python 3.13
- **Documentation**: Update getting-started guides (EN/ZH) to recommend Python 3.13
- **Docs tip**: Add a tip noting that Python 3.12–3.14 are supported, with 3.13 recommended
- **CLI**: Simplify the error message in `toad.py` for missing Toad dependency

## Rationale

Python 3.13 offers better compatibility and stability compared to 3.14 (which is still in development), making it a safer default for most users.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
