### PR TITLE
Filter the `$schema` field in tool parameters of kosong genai provide…

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
@@ -354,9 +354,10 @@ def tool_to_google_genai(tool: KosongTool) -> Tool:
     """Convert a Kosong tool to GoogleGenAI tool format."""
     # Kosong already validates parameters as JSON Schema format via jsonschema
     # The google-genai SDK accepts dict format and internally converts to Schema
-    # Here we filter the `$schema` field in parameters since FunctionParameters is a BaseModel with `extra=forbid`
-    if '$schema' in tool.parameters:
-        del tool.parameters['$schema']
+    # Here we filter the `$schema` field in parameters since FunctionParameters is a BaseModel
+    # and has a restriction of `extra=forbid`
+    if "$schema" in tool.parameters:
+        del tool.parameters["$schema"]
     return Tool(
         function_declarations=[
             FunctionDeclaration(


### PR DESCRIPTION
Filter the `$schema` field in tool parameters of kosong genai provider so that kimi-cli can work properly when using gemini models with third-party mcp. (Tool parameters is a `BaseModel` with `extra=forbid` in genai sdk while `TypedDict` in anthropic and openai sdk)

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/713">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
