### PR TITLE
chore: bump kimi-cli to 1.0 and kosong to 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.0 (2026-01-27)
+
 - Shell: Add `/login` and `/logout` slash commands for login and logout
 - CLI: Add `kimi login` and `kimi logout` subcommands
 - Core: Fix subagent approval request handling

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+## 1.0 (2026-01-27)
+
 - Shell: Add `/login` and `/logout` slash commands for login and logout
 - CLI: Add `kimi login` and `kimi logout` subcommands
 - Core: Fix subagent approval request handling

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 1.0 (2026-01-27)
+
 - Shell：添加 `/login` 和 `/logout` 斜杠命令，用于登录和登出
 - CLI：添加 `kimi login` 和 `kimi logout` 子命令
 - Core：修复子 Agent 审批请求处理问题

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "0.88"
+version = "1.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==0.88"]
+dependencies = ["kimi-cli==1.0"]
 
 [project.scripts]
 kimi = "kimi_cli.cli:cli"

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.41.0 (2026-01-27)
+
 - Remove default temperature setting in Kimi chat provider based on model name
 
 ## 0.40.0 (2026-01-24)

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kosong"
-version = "0.40.0"
+version = "0.41.0"
 description = "The LLM abstraction layer for modern AI agent applications."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "0.88"
+version = "1.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -9,7 +9,7 @@ dependencies = [
     "aiofiles>=24.0,<26.0",
     "aiohttp==3.13.3",
     "typer==0.21.1",
-    "kosong[contrib]==0.40.0",
+    "kosong[contrib]==0.41.0",
     # loguru stays >=0.6.0 because notify-py (via batrachian-toad) caps it at <=0.6.0 on 3.14+.
     "loguru>=0.6.0,<0.8",
     "prompt-toolkit==3.0.52",

--- a/uv.lock
+++ b/uv.lock
@@ -1155,7 +1155,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "0.88"
+version = "1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1237,7 +1237,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "0.88"
+version = "1.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },
@@ -1283,7 +1283,7 @@ dev = [
 
 [[package]]
 name = "kosong"
-version = "0.40.0"
+version = "0.41.0"
 source = { editable = "packages/kosong" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Release kimi-cli 1.0 and kosong 0.41.0.

### kimi-cli 1.0

- Shell: Add `/login` and `/logout` slash commands for login and logout
- CLI: Add `kimi login` and `kimi logout` subcommands
- Core: Fix subagent approval request handling

### kosong 0.41.0

- Remove default temperature setting in Kimi chat provider based on model name

## Changes

- Update `pyproject.toml` versions (kimi-cli 0.88 → 1.0, kosong 0.40.0 → 0.41.0)
- Sync `packages/kimi-code` version and dependency to 1.0
- Update CHANGELOG.md for both packages
- Sync documentation changelogs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
