### PR TITLE
Improve Shell File Completion and Navigation Experience

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -725,7 +725,7 @@ class CustomPromptSession:
                 buff.apply_completion(completion)
 
                 text = buff.text.strip()
-                if text.startswith("/") and not text.startswith("//") and "@" not in text[:1]:
+                if text.startswith("/") and not text.startswith("//"):
                     buff.validate_and_handle()
 
         @_kb.add("c-x", eager=True)


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Description
This PR enhances the user experience when using file completion ( @ ) in the shell UI, aligning it with modern CLI best practices (similar to Claude Code).

## Key Changes
1. Automatic Space Suffix :
   - Modified LocalFileMentionCompleter in prompt.py to automatically append a space after any file or directory completion is selected.
   - This streamlines the workflow, allowing users to immediately type the next argument without manual spacing.
2. No-Preview Navigation :
   - Overrode default up / down key bindings in CustomPromptSession .
   - Navigating the completion menu now only highlights the candidate without replacing the text in the input buffer.
   - The input buffer retains the user's original search query until Enter is pressed, resolving the issue where fuzzy search terms were lost during navigation.
3. Auto-execute slash commands:
   - Improves the shell UI experience by automatically executing slash commands when they are selected from the autocomplete menu.


## Related Issue

<!-- Please link to the issue here. -->

Resolve #749 #751 

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
