### PR TITLE
feat(approval): persist approve_for_session per session

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -116,7 +116,7 @@ class Runtime:
                 KIMI_SKILLS=skills_formatted or "No skills found.",
             ),
             denwa_renji=DenwaRenji(),
-            approval=Approval(yolo=yolo),
+            approval=Approval(yolo=yolo, state_file=session.dir / "approval_state.json"),
             labor_market=LaborMarket(),
             environment=environment,
             skills=skills_by_name,

--- a/tests/core/test_approval_state.py
+++ b/tests/core/test_approval_state.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from kimi_cli.soul.approval import ApprovalState
+
+
+def test_approval_state_persists(tmp_path: Path) -> None:
+    state_file = tmp_path / "approval_state.json"
+    state = ApprovalState(state_file=state_file)
+    assert state.auto_approve_actions == set()
+
+    state.add_auto_approve_action("WriteFile")
+    assert state_file.exists()
+
+    reloaded = ApprovalState(state_file=state_file)
+    assert reloaded.auto_approve_actions == {"WriteFile"}


### PR DESCRIPTION
## Related Issue

Issue: https://github.com/MoonshotAI/kimi-cli/issues/765

## Description

Persist `approve_for_session` across session resume by saving `auto_approve_actions`
in a session-scoped state file (e.g. `approval_state.json`) and loading it when a
session is restored. This keeps the safety scope limited to the same session while
removing repeated approvals.

Tests:
- Added `tests/core/test_approval_state.py` to verify state persistence.
- Ran: `uv run pytest tests/core/test_approval_state.py`

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue.
- [x] I have added tests that prove my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
