### PR TITLE
feat(shell): add pseudo-cwd for shell mode

### DIFF
--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -153,7 +153,11 @@ class Shell:
                 console.print("[red]Usage: cd <dir>[/red]")
                 return
             target = split_cmd[1] if len(split_cmd) == 2 else "~"
-            new_cwd = Path(target).expanduser()
+            try:
+                new_cwd = Path(target).expanduser()
+            except RuntimeError:
+                console.print(f"[red]Invalid path: {target}[/red]")
+                return
             if not new_cwd.is_absolute():
                 new_cwd = self._shell_cwd / new_cwd
             new_cwd = new_cwd.resolve()


### PR DESCRIPTION
## Related Issue

Resolves #766

## Description

Add a pseudo‑cwd for shell mode. The shell now tracks a current directory, updates
it on `cd`, and passes it as `cwd` when running subsequent shell commands. This
keeps agent workdir unchanged while making shell usage feel consistent.

Tests:
- Manual verification via a small script: `cd` then `pwd` outputs the new directory.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue.
- [ ] I have added tests that prove my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/768">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
