### PR TITLE
fix: correct module-name type in pyproject.toml

### DIFF
--- a/packages/kaos/pyproject.toml
+++ b/packages/kaos/pyproject.toml
@@ -24,7 +24,7 @@ requires = ["uv_build>=0.8.5,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kaos"]
+module-name = "kaos"
 source-exclude = ["tests/**/*"]
 
 [tool.ruff]

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -15,4 +15,4 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_code"]
+module-name = "kimi_code"

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -39,7 +39,7 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kosong"]
+module-name = "kosong"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_cli"]
+module-name = "kimi_cli"
 source-exclude = ["examples/**/*", "tests/**/*", "src/kimi_cli/deps/**/*"]
 
 [tool.uv.workspace]

--- a/sdks/kimi-sdk/pyproject.toml
+++ b/sdks/kimi-sdk/pyproject.toml
@@ -23,7 +23,7 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_sdk"]
+module-name = "kimi_sdk"
 source-exclude = ["tests/**/*"]
 
 [tool.ruff]


### PR DESCRIPTION
## Problem

  Running `make prepare` fails with a TOML parse error:

  error: Failed to parse: pyproject.toml
    Caused by: TOML parse error at line 52, column 15
     |
  52 | module-name = ["kimi_cli"]
     |               ^^^^^^^^^^^^
  invalid type: sequence, expected a string

  The uv build backend expects `module-name` to be a string, not a sequence.
  This error was present in all workspace packages.

  ## Related Issue

  N/A - This is a straightforward configuration bug fix discovered during setup.

  ## Description

  Changed `module-name` in `[tool.uv.build-backend]` section from array format to string format across all workspace packages.

  **Changes:**
  - `pyproject.toml`: `module-name = ["kimi_cli"]` → `module-name = "kimi_cli"`
  - `packages/kaos/pyproject.toml`: `module-name = ["kaos"]` → `module-name = "kaos"`
  - `packages/kimi-code/pyproject.toml`: `module-name = ["kimi_code"]` → `module-name = "kimi_code"`
  - `packages/kosong/pyproject.toml`: `module-name = ["kosong"]` → `module-name = "kosong"`
  - `sdks/kimi-sdk/pyproject.toml`: `module-name = ["kimi_sdk"]` → `module-name = "kimi_sdk"`

  ## Testing

  After this fix, `make prepare` completes successfully without TOML parse errors.

  ```bash
  $ make prepare
  ==> Ensuring ripgrep is installed
  ...
  ==> Syncing dependencies for all workspace packages
  ✓ Successfully synced dependencies

  Checklist

  - I have read the https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md document.
  - I have linked the related issue, if any. (N/A - direct bug fix)
  - I have added tests that prove my fix is effective or that my feature works. (N/A - configuration fix, verified by running make prepare)
  - I have run make gen-changelog to update the changelog. (Will defer to maintainers)
  - I have run make gen-docs to update the user documentation. (N/A - internal configuration fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
