### PR TITLE
fix(shell): enhance shell completion navigation and tab handling

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -693,6 +693,44 @@ class CustomPromptSession:
                     completion = buff.complete_state.completions[0]
                 buff.apply_completion(completion)
 
+                text = buff.text.strip()
+                if text.startswith("/") and not text.startswith("//"):
+                    buff.validate_and_handle()
+
+        @_kb.add("tab", filter=has_completions)
+        def _(event: KeyPressEvent) -> None:
+            """Accept completion and add a space."""
+            buff = event.current_buffer
+            if buff.complete_state and buff.complete_state.completions:
+                completion = buff.complete_state.current_completion
+                if not completion:
+                    completion = buff.complete_state.completions[0]
+                buff.apply_completion(completion)
+                buff.insert_text(" ")
+
+        @_kb.add("down", filter=has_completions)
+        def _(event: KeyPressEvent) -> None:
+            """Navigate completion menu down without updating the buffer."""
+            buff = event.current_buffer
+            if buff.complete_state:
+                state = buff.complete_state
+                if state.complete_index is None:
+                    state.complete_index = 0
+                else:
+                    state.complete_index = (state.complete_index + 1) % len(state.completions)
+
+        @_kb.add("up", filter=has_completions)
+        def _(event: KeyPressEvent) -> None:
+            """Navigate completion menu up without updating the buffer."""
+            buff = event.current_buffer
+            if buff.complete_state:
+                state = buff.complete_state
+                count = len(state.completions)
+                if state.complete_index is None:
+                    state.complete_index = count - 1
+                else:
+                    state.complete_index = (state.complete_index - 1) % count
+
         @_kb.add("c-x", eager=True)
         def _(event: KeyPressEvent) -> None:
             self._mode = self._mode.toggle()


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

Description: 

This PR improves the interactive shell experience ( src/kimi_cli/ui/shell/prompt.py ) by refining how completions are navigated and accepted.

Changes:

1. Tab Key Behavior :
   
   - Added a specific listener for the Tab key when completions are active.
   - Effect : Pressing Tab now accepts the selected completion (or the first one if none is selected) and immediately appends a space . This removes the friction of manually typing a space after autocompleting commands like /review or /help .
2. Menu Navigation (Up/Down) :
   
   - Overrode the default Up and Down key bindings when the completion menu is visible.
   - Effect : These keys now only change the selection index in the dropdown menu without updating the text in the input buffer. This allows users to browse through fuzzy-matched options without losing their partially typed keyword/filter.
Impact:

- Better UX : Users can type /rev -> Tab -> arguments seamlessly.
- Non-destructive Navigation : Browsing the list no longer destroys the user's typed context.

## Related Issue

<!-- Please link to the issue here. -->

Resolve #751 

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
