### PR TITLE
feat(ui): append space automatically after file completion

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -377,7 +377,18 @@ class LocalFileMentionCompleter(Completer):
                 return (cat,)
 
             candidates.sort(key=_rank)
-            yield from candidates
+            for candidate in candidates:
+                text = candidate.text
+                if not text.endswith("/"):
+                    text = text + " "
+                yield Completion(
+                    text=text,
+                    start_position=candidate.start_position,
+                    display=candidate.display,
+                    display_meta=candidate.display_meta,
+                    style=candidate.style,
+                    selected_style=candidate.selected_style,
+                )
         finally:
             self._fragment_hint = None
 

--- a/tests/ui_and_conv/test_file_completer.py
+++ b/tests/ui_and_conv/test_file_completer.py
@@ -29,7 +29,7 @@ def test_top_level_paths_skip_ignored_names(tmp_path: Path):
     texts = _completion_texts(completer, "@")
 
     assert "src/" in texts
-    assert "README.md" in texts
+    assert "README.md " in texts
     assert "node_modules/" not in texts
     assert ".DS_Store" not in texts
 
@@ -46,7 +46,22 @@ def test_directory_completion_continues_after_slash(tmp_path: Path):
     texts = _completion_texts(completer, "@src/")
 
     assert "src/" in texts
-    assert "src/module.py" in texts
+    assert "src/module.py " in texts
+
+
+def test_trailing_space_behavior(tmp_path: Path):
+    """Ensure directories have no trailing space, while files do."""
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "file.txt").write_text("")
+
+    completer = LocalFileMentionCompleter(tmp_path)
+    texts = _completion_texts(completer, "@")
+
+    assert "dir/" in texts
+    assert "dir/ " not in texts
+    assert "file.txt " in texts
+    assert "file.txt" not in texts
+
 
 
 def test_completed_file_short_circuits_completions(tmp_path: Path):
@@ -113,7 +128,7 @@ def test_basename_prefix_is_ranked_first(tmp_path: Path):
     # Snapshot the full candidate list to keep order/content deterministic
     assert texts == snapshot(
         [
-            "src/kimi_cli/tools/web/fetch.py",
-            "src/kimi_cli/tools/file/patch.py",
+            "src/kimi_cli/tools/web/fetch.py ",
+            "src/kimi_cli/tools/file/patch.py ",
         ]
     )


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

Description: 

This PR improves the shell autocomplete experience for file mentions.

Changes:

- UX Improvement : When a user selects a file from the @ mention list (e.g., README.md ), the completer now automatically appends a space (resulting in README.md ). This allows users to immediately continue typing their query without manually adding a separator.
- Logic : The logic checks if the candidate text ends with / . If not (implying it is a file), a space is appended.
- Tests : Updated test_top_level_paths_skip_ignored_names to match the new behavior.

## Related Issue

<!-- Please link to the issue here. -->

Resolve 

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/777">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
