### PR TITLE
feat(config): add reasoning_key field to LLMProvider for reasoning mo…

### DIFF
--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -57,6 +57,26 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-xxx"
 ```
 
+#### Reasoning Content Support
+
+Some OpenAI-compatible APIs (like DeepSeek, Venice AI) return reasoning/thinking content in a custom field alongside the regular response. Use `reasoning_key` to specify the field name so it's preserved across multi-turn conversations:
+
+```toml
+[providers.venice]
+type = "openai_legacy"
+base_url = "https://api.venice.ai/api/v1"
+api_key = "xxx"
+reasoning_key = "reasoning_content"
+
+[providers.deepseek]
+type = "openai_legacy"
+base_url = "https://api.deepseek.com/v1"
+api_key = "sk-xxx"
+reasoning_key = "reasoning_content"
+```
+
+When configured, reasoning content from the model's response will be properly extracted and included in subsequent API requests, which is required for multi-turn tool calling with reasoning models.
+
 ### `openai_responses`
 
 For OpenAI Responses API (newer API format).

--- a/docs/zh/configuration/providers.md
+++ b/docs/zh/configuration/providers.md
@@ -57,6 +57,26 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-xxx"
 ```
 
+#### 推理内容支持
+
+一些兼容 OpenAI 的 API（如 DeepSeek、Venice AI）会在响应中返回推理/思考内容。使用 `reasoning_key` 指定字段名，以便在多轮对话中正确保留：
+
+```toml
+[providers.venice]
+type = "openai_legacy"
+base_url = "https://api.venice.ai/api/v1"
+api_key = "xxx"
+reasoning_key = "reasoning_content"
+
+[providers.deepseek]
+type = "openai_legacy"
+base_url = "https://api.deepseek.com/v1"
+api_key = "sk-xxx"
+reasoning_key = "reasoning_content"
+```
+
+配置后，模型响应中的推理内容将被正确提取，并包含在后续的 API 请求中。这是使用推理模型进行多轮工具调用所必需的。
+
 ### `openai_responses`
 
 用于 OpenAI Responses API（较新的 API 格式）。

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -38,6 +38,8 @@ class LLMProvider(BaseModel):
     """Custom headers to include in API requests"""
     oauth: OAuthRef | None = None
     """OAuth credential reference (do not store tokens here)."""
+    reasoning_key: str | None = None
+    """Field name for reasoning content in API messages (for openai_legacy provider)."""
 
     @field_serializer("api_key", when_used="json")
     def dump_secret(self, v: SecretStr):

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -152,6 +152,7 @@ def create_llm(
                 model=model.model,
                 base_url=provider.base_url,
                 api_key=resolved_api_key,
+                reasoning_key=provider.reasoning_key,
             )
         case "openai_responses":
             from kosong.contrib.chat_provider.openai_responses import OpenAIResponses

--- a/tests/core/test_create_llm.py
+++ b/tests/core/test_create_llm.py
@@ -93,3 +93,44 @@ def test_create_llm_requires_base_url_for_kimi():
     model = LLMModel(provider="kimi", model="kimi-base", max_context_size=4096)
 
     assert create_llm(provider, model) is None
+
+
+def test_create_llm_openai_legacy_with_reasoning_key():
+    from kosong.contrib.chat_provider.openai_legacy import OpenAILegacy
+
+    provider = LLMProvider(
+        type="openai_legacy",
+        base_url="https://api.venice.ai/api/v1",
+        api_key=SecretStr("test-key"),
+        reasoning_key="reasoning_content",
+    )
+    model = LLMModel(
+        provider="venice",
+        model="kimi-k2-5",
+        max_context_size=131072,
+    )
+
+    llm = create_llm(provider, model)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, OpenAILegacy)
+    assert llm.chat_provider._reasoning_key == "reasoning_content"
+
+
+def test_create_llm_openai_legacy_without_reasoning_key():
+    from kosong.contrib.chat_provider.openai_legacy import OpenAILegacy
+
+    provider = LLMProvider(
+        type="openai_legacy",
+        base_url="https://api.openai.com/v1",
+        api_key=SecretStr("test-key"),
+    )
+    model = LLMModel(
+        provider="openai",
+        model="gpt-4o",
+        max_context_size=128000,
+    )
+
+    llm = create_llm(provider, model)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, OpenAILegacy)
+    assert llm.chat_provider._reasoning_key is None


### PR DESCRIPTION
Add reasoning_key field to LLMProvider configuration class to enable preservation of reasoning_content in multi-turn tool calling with reasoning models through third party APIs such as DeepSeek, Venice AI, etc.

This makes Kimi-K2.5 work through venice.ai for example.

Changes:
- config.py: Add reasoning_key: str | None = None field to LLMProvider
- llm.py: Pass reasoning_key parameter when instantiating OpenAILegacy provider
- docs: Document the new configuration option in English and Chinese docs
- tests: Add unit tests for the new functionality

This fixes 400 errors like 'thinking is enabled but reasoning_content is missing in assistant tool call message' when using reasoning models with openai_legacy provider.

- [X] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [X] I have linked the related issue, if any.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
