### PR TITLE
fix: display error message when config.toml has duplicate keys

### DIFF
--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -535,7 +535,11 @@ def kimi(
                 continue
         await _post_run(last_session, succeeded)
 
-    asyncio.run(_reload_loop(session_id))
+    try:
+        asyncio.run(_reload_loop(session_id))
+    except ConfigError as e:
+        typer.secho(f"Error: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
 
 
 cli.add_typer(info_cli, name="info")

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -215,7 +215,7 @@ def load_config(config_file: Path | None = None) -> Config:
     except json.JSONDecodeError as e:
         raise ConfigError(f"Invalid JSON in configuration file: {e}") from e
     except TOMLKitError as e:
-        raise ConfigError(f"Invalid TOML in configuration file: {e}") from e
+        raise ConfigError(f"Invalid TOML in configuration file '{config_file}': {e}") from e
     except ValidationError as e:
         raise ConfigError(f"Invalid configuration file: {e}") from e
     config.is_from_default_location = is_default_config_file

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -73,3 +73,21 @@ def test_load_config_reserved_context_size():
 def test_load_config_reserved_context_size_too_low():
     with pytest.raises(ConfigError, match="reserved_context_size"):
         load_config_from_string('{"loop_control": {"reserved_context_size": 500}}')
+
+
+def test_load_config_duplicate_toml_key():
+    """Test that duplicate TOML keys raise ConfigError with descriptive message."""
+    duplicate_key_config = """
+[models.qwen]
+provider = "qwen"
+model = "qwen"
+max_context_size = 252144
+
+[models.qwen]
+provider = "deepseek"
+model = "deepseek"
+max_context_size = 252144
+"""
+    with pytest.raises(ConfigError, match="already exists"):
+        load_config_from_string(duplicate_key_config)
+


### PR DESCRIPTION
When config.toml contains duplicate keys (e.g., [models.qwen] section defined twice), the CLI would fail silently due to stderr being redirected to the log file during startup.

This fix:
- Catches ConfigError at the CLI level and displays a user-friendly error message before exiting
- Improves the error message to include the config file path
- Adds test coverage for duplicate key error handling

Fixes MoonshotAI/kimi-cli#809

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/818">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
