### PR TITLE
feat: add a clear button to the message search input & disable close button

### DIFF
--- a/web/src/features/chat/message-search-dialog.tsx
+++ b/web/src/features/chat/message-search-dialog.tsx
@@ -14,6 +14,7 @@ import {
   UserIcon,
   BotIcon,
   WrenchIcon,
+  X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
@@ -161,11 +162,16 @@ export function MessageSearchDialog({
     [matches, selectedIndex, onJumpToMessage, onOpenChange],
   );
 
+  const handleClear = () => {
+    setQuery("");
+    inputRef.current?.focus();
+  };
+
   const selectedMatch = matches[selectedIndex];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex h-[70vh] max-w-6xl flex-col gap-0 p-0 sm:max-w-6xl">
+      <DialogContent showCloseButton={false} className="flex h-[70vh] max-w-6xl flex-col gap-0 p-0 sm:max-w-6xl">
         <DialogHeader className="border-b px-4 py-3">
           <DialogTitle className="sr-only">Search Messages</DialogTitle>
           <div className="flex items-center gap-2">
@@ -178,6 +184,16 @@ export function MessageSearchDialog({
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleKeyDown}
             />
+            {query ? (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="cursor-pointer rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <X className="size-3.5" />
+              </button>
+            ) : null}
             <span className="text-xs text-muted-foreground">
               {query
                 ? matches.length > 0


### PR DESCRIPTION
## Related Issue

None

## Description
It seems the original intention was to create a search modal for a command palette, so we shouldn't display the modal's close button, just like GitHub or Raycast. 

Additionally, I added a clear button, similar to what search boxes typically have.

current 
<img width="1201" height="885" alt="image" src="https://github.com/user-attachments/assets/41a9839c-b2ea-4278-a314-9b89e71046cb" />

after this PR

<img width="1160" height="865" alt="image" src="https://github.com/user-attachments/assets/a48bdb89-9864-4a91-9f6a-861444deaf3e" />


<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
