### PR TITLE
docs: clarify KIMI_SHARE_DIR does not affect Skills paths

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -100,7 +100,14 @@ JetBrains IDE terminology (Chinese UI translations):
   - ✗ 详见\[配置文件\](./config.md)。
 - **Full-width punctuation**: Use full-width punctuation in Chinese text: `，。；：？！（）` not `, . ; : ? ! ( )`.
 - **Code block language**: Always specify language for fenced code blocks (e.g., ` ```sh `, ` ```toml `, ` ```json `). Exception: natural language examples (user prompts) may omit the language.
-- **Version info blocks**: Use `::: info` blocks to indicate version changes. The title should be a category (Added/Changed/Removed in English; 新增/变更/移除 in Chinese), and the content should be a complete sentence describing the change.
+- **Callout titles**: Use short category titles for callout blocks (`::: tip`, `::: warning`, `::: info`, `::: danger`). Put the detailed description in the block content, not the title.
+  - Chinese: use `提示` for tip, `注意` for warning, `说明` for info, `警告` for danger.
+  - English: use no title or short words like `Note` for warning.
+  - ✓ `::: tip 提示` + content starting with the key point
+  - ✓ `::: warning 注意` + content `\`KIMI_SHARE_DIR\` 不影响 Skills 的搜索路径。...`
+  - ✗ `::: warning 不影响 Skills` (title too long, should be in content)
+  - ✗ `::: tip Skills 路径独立于 KIMI_SHARE_DIR` (title too long)
+- **Version info blocks**: For version change callouts, use `::: info` with a category title (Added/Changed/Removed in English; 新增/变更/移除 in Chinese). The content should be a complete sentence.
   - ✓ `::: info 新增` + content `新增于 Wire 1.2。`
   - ✗ `::: info 新增于 Wire 1.2` (title too long)
   - ✓ `::: info Changed` + content `Renamed in Wire 1.1. ...`

--- a/docs/en/configuration/data-locations.md
+++ b/docs/en/configuration/data-locations.md
@@ -2,8 +2,10 @@
 
 Kimi Code CLI stores all data in the `~/.kimi/` directory under the user's home directory. This page describes the locations and purposes of various data files.
 
-::: tip Custom path
+::: tip
 You can customize the share directory path by setting the `KIMI_SHARE_DIR` environment variable. See [Environment Variables](./env-vars.md#kimi-share-dir) for details.
+
+Note: `KIMI_SHARE_DIR` only affects the storage location of the runtime data listed above, not the [Agent Skills](../customization/skills.md) search paths. Skills, as cross-tool shared capability extensions, are a different type of data from application runtime data.
 :::
 
 ## Directory structure

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -117,13 +117,17 @@ export OPENAI_API_KEY="sk-xxx"
 
 ### `KIMI_SHARE_DIR`
 
-Customize the share directory path for Kimi Code CLI. The default path is `~/.kimi`, where all configuration, sessions, logs, and other data are stored.
+Customize the share directory path for Kimi Code CLI. The default path is `~/.kimi`, where configuration, sessions, logs, and other runtime data are stored.
 
 ```sh
 export KIMI_SHARE_DIR="/path/to/custom/kimi"
 ```
 
 See [Data Locations](./data-locations.md) for details.
+
+::: warning Note
+`KIMI_SHARE_DIR` does not affect [Agent Skills](../customization/skills.md) search paths. Skills are cross-tool shared capability extensions (compatible with Claude, Codex, etc.), which is a different type of data from application runtime data. To override Skills paths, use the `--skills-dir` flag.
+:::
 
 ### `KIMI_CLI_NO_AUTO_UPDATE`
 

--- a/docs/en/customization/skills.md
+++ b/docs/en/customization/skills.md
@@ -41,6 +41,10 @@ You can also specify other directories with the `--skills-dir` flag, which skips
 kimi --skills-dir /path/to/my-skills
 ```
 
+::: tip
+Skills paths are independent of [`KIMI_SHARE_DIR`](../configuration/env-vars.md#kimi-share-dir). `KIMI_SHARE_DIR` customizes the storage location for configuration, sessions, logs, and other runtime data, but does not affect Skills search paths. Skills are cross-tool shared capability extensions (compatible with Kimi CLI, Claude, Codex, and others), which is a different type of data from application runtime data. To override Skills paths, use the `--skills-dir` flag.
+:::
+
 ## Built-in skills
 
 Kimi Code CLI includes the following built-in skills:

--- a/docs/zh/configuration/data-locations.md
+++ b/docs/zh/configuration/data-locations.md
@@ -2,8 +2,10 @@
 
 Kimi Code CLI 将所有数据存储在用户主目录下的 `~/.kimi/` 目录中。本页介绍各类数据文件的位置和用途。
 
-::: tip 自定义路径
+::: tip 提示
 可以通过设置 `KIMI_SHARE_DIR` 环境变量来自定义共享目录路径。详见 [环境变量](./env-vars.md#kimi-share-dir)。
+
+注意：`KIMI_SHARE_DIR` 仅影响上述运行时数据的存储位置，不影响 [Agent Skills](../customization/skills.md) 的搜索路径。Skills 作为跨工具共享的能力扩展，与运行时数据是不同类型的数据。
 :::
 
 ## 目录结构

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -117,13 +117,17 @@ export OPENAI_API_KEY="sk-xxx"
 
 ### `KIMI_SHARE_DIR`
 
-自定义 Kimi Code CLI 的共享目录路径。默认路径为 `~/.kimi`，所有配置、会话、日志等数据都存储在此目录下。
+自定义 Kimi Code CLI 的共享目录路径。默认路径为 `~/.kimi`，配置、会话、日志等运行时数据存储在此目录下。
 
 ```sh
 export KIMI_SHARE_DIR="/path/to/custom/kimi"
 ```
 
 详见 [数据路径](./data-locations.md)。
+
+::: warning 注意
+`KIMI_SHARE_DIR` 不影响 [Agent Skills](../customization/skills.md) 的搜索路径。Skills 是跨工具共享的能力扩展（与 Claude、Codex 等兼容），与应用运行时数据是不同类型的数据。如需覆盖 Skills 路径，请使用 `--skills-dir` 参数。
+:::
 
 ### `KIMI_CLI_NO_AUTO_UPDATE`
 

--- a/docs/zh/customization/skills.md
+++ b/docs/zh/customization/skills.md
@@ -41,6 +41,10 @@ Kimi Code CLI 采用分层加载机制发现 Skills，按以下优先级加载�
 kimi --skills-dir /path/to/my-skills
 ```
 
+::: tip 提示
+Skills 路径独立于 [`KIMI_SHARE_DIR`](../configuration/env-vars.md#kimi-share-dir)。`KIMI_SHARE_DIR` 用于自定义配置、会话、日志等运行时数据的存储位置，不影响 Skills 的搜索路径。Skills 是跨工具共享的能力扩展（支持 Kimi CLI、Claude、Codex 等多个工具共用），与应用运行时数据是不同类型的数据。如需覆盖 Skills 路径，请使用 `--skills-dir` 参数。
+:::
+
 ## 内置 Skills
 
 Kimi Code CLI 内置了以下 Skills：


### PR DESCRIPTION
## Summary

Clarify that `KIMI_SHARE_DIR` only affects runtime data storage, not Skills search paths.

## Changes

- **docs/AGENTS.md**: Add callout title conventions (use short titles like `提示`/`注意`, put details in content)
- **docs/{en,zh}/configuration/data-locations.md**: Note that `KIMI_SHARE_DIR` doesn't affect Skills
- **docs/{en,zh}/configuration/env-vars.md**: Add warning block explaining Skills are independent
- **docs/{en,zh}/customization/skills.md**: Add tip explaining Skills paths are independent of `KIMI_SHARE_DIR`

## Why

Skills are cross-tool shared capability extensions (compatible with Kimi CLI, Claude, Codex, etc.), which is a different type of data from application runtime data (config, sessions, logs). This distinction was not documented and could cause confusion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/849">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
