### PR TITLE
chore: bump version to 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.6 (2026-02-03)
+
 - Web: Add token-based authentication and access control for network mode (`--network`, `--lan-only`, `--public`)
 - Web: Add security options: `--auth-token`, `--allowed-origins`, `--restrict-sensitive-apis`, `--dangerously-omit-auth`
 - Web: Change `--host` option to bind to specific IP address; add automatic network address detection

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+## 1.6 (2026-02-03)
+
 - Web: Add token-based authentication and access control for network mode (`--network`, `--lan-only`, `--public`)
 - Web: Add security options: `--auth-token`, `--allowed-origins`, `--restrict-sensitive-apis`, `--dangerously-omit-auth`
 - Web: Change `--host` option to bind to specific IP address; add automatic network address detection

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 1.6 (2026-02-03)
+
 - Web：为网络模式添加基于 Token 的认证和访问控制（`--network`、`--lan-only`、`--public`）
 - Web：添加安全选项：`--auth-token`、`--allowed-origins`、`--restrict-sensitive-apis`、`--dangerously-omit-auth`
 - Web：变更 `--host` 选项，用于绑定到指定 IP 地址；添加自动网络地址检测

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.5"
+version = "1.6"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.5"]
+dependencies = ["kimi-cli==1.6"]
 
 [project.scripts]
 kimi = "kimi_cli.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.5"
+version = "1.6"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.5"
+version = "1.6"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1298,7 +1298,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.5"
+version = "1.6"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },


### PR DESCRIPTION
## Changes

Bump kimi-cli and kimi-code version to 1.6.

### Version 1.6 includes:

- **Web**: Token-based authentication and access control for network mode
- **Web**: Security options (`--auth-token`, `--allowed-origins`, `--restrict-sensitive-apis`, `--dangerously-omit-auth`)
- **Web**: `--host` option for binding to specific IP address
- **Web**: Fix WebSocket disconnect when creating new sessions
- **Web**: Increase maximum image dimension to 4096 pixels
- **Web**: UI responsiveness improvements
- **Wire**: `TurnEnd` event (protocol version 1.2)
- **Core**: Fix custom agent prompt files containing `$` causing silent startup failure

### Files changed:

- `pyproject.toml`: version 1.5 → 1.6
- `packages/kimi-code/pyproject.toml`: version 1.5 → 1.6, dependency kimi-cli==1.6
- `CHANGELOG.md`: Add 1.6 release section
- `docs/*/release-notes/changelog.md`: Sync changelog
- `uv.lock`: Updated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
