### PR TITLE
fix(ui): center align reasoning trigger component

### DIFF
--- a/web/src/features/chat/components/assistant-message.tsx
+++ b/web/src/features/chat/components/assistant-message.tsx
@@ -349,7 +349,7 @@ const renderThinkingMessage = (
         defaultOpen={blocksExpanded}
         disableAutoClose
       >
-        <ReasoningTrigger />
+        <ReasoningTrigger className="items-center [&>span:first-child]:mt-0" />
         <ReasoningContent>{thinkingContent}</ReasoningContent>
       </Reasoning>
     </MessageContent>


### PR DESCRIPTION
Adjust styling in AssistantMessage to vertically center the ReasoningTrigger content and reset the margin of the status indicator for better alignment.

Before: 

<img width="157" height="44" alt="before" src="https://github.com/user-attachments/assets/a2eb6ff4-a370-4cc9-867d-0e3978fddb57" />

After:

<img width="153" height="56" alt="after" src="https://github.com/user-attachments/assets/4a6c1845-ad7d-4c3f-9d7e-c02f684bd52d" />


<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/870">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
