### PR TITLE
fix(web): align bullet points

### DIFF
--- a/web/src/components/ai-elements/reasoning.tsx
+++ b/web/src/components/ai-elements/reasoning.tsx
@@ -157,12 +157,12 @@ export const ReasoningTrigger = memo(
 
     return (
       <CollapsibleTrigger
-        className={cn("flex items-start gap-2 text-sm text-muted-foreground", className)}
+        className={cn("flex items-center gap-2 text-sm text-muted-foreground", className)}
         {...props}
       >
         {children ?? (
           <>
-            <span className="mt-1.5 size-2 shrink-0 rounded-full bg-warning" />
+            <span className="size-2 shrink-0 rounded-full bg-warning" />
             <span className="italic">
               {getThinkingMessage(isStreaming, duration)}
             </span>

--- a/web/src/features/chat/components/assistant-message.tsx
+++ b/web/src/features/chat/components/assistant-message.tsx
@@ -91,7 +91,7 @@ const renderAssistantText = (message: LiveMessage) => (
     <div className="flex items-start gap-2">
       <span
         className={cn(
-          "mt-1.5 size-2 shrink-0 rounded-full bg-muted-foreground/60",
+          "mt-2 size-2 shrink-0 rounded-full bg-muted-foreground/60",
           message.isStreaming &&
             "bg-green-500 animate-[glow-pulse_1.5s_ease-in-out_infinite]",
         )}


### PR DESCRIPTION
Fix vertical alignment issues between status bullet points and text content.

**Before:**
<img width="850" height="130" alt="image" src="https://github.com/user-attachments/assets/16347d99-f147-4a86-a6b5-492d9d15967c" />

**After:**
<img width="856" height="128" alt="image" src="https://github.com/user-attachments/assets/6f9632db-d95a-4e8a-9156-168a0e1c4b7f" />