### PR TITLE
fix(kosong): handle string annotations in SimpleToolset return type check

### DIFF
--- a/src/kimi_cli/tools/file/__init__.py
+++ b/src/kimi_cli/tools/file/__init__.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 
 
 class FileOpsWindow:
@@ -7,7 +7,7 @@ class FileOpsWindow:
     pass
 
 
-class FileActions(str, Enum):
+class FileActions(StrEnum):
     READ = "read file"
     EDIT = "edit file"
     EDIT_OUTSIDE = "edit file outside of working directory"


### PR DESCRIPTION
When using `from __future__ import annotations`, type annotations are
stored as strings rather than actual types. This fix:

1. Uses `inspect.signature().return_annotation` to get the raw annotation
2. Handles string annotations by checking if it matches any suffix of
   `kosong.tooling.ToolReturnValue` (e.g., `ToolReturnValue`,
   `tooling.ToolReturnValue`, `kosong.tooling.ToolReturnValue`)
3. Falls back to strict type identity check for non-string annotations

Also add unit tests to cover:
- CallableTool with string annotations
- CallableTool2 with string annotations
- Tool execution with string annotations

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
