### PR TITLE
fix(auth): switch from sessionStorage to localStorage for authentication token management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Web: Fix authentication token persistence by switching from sessionStorage to localStorage with 24-hour expiry
 - Web: Add server-side pagination for session list with virtualized scrolling for better performance
 - Web: Improve session and work directories loading with smarter caching and invalidation
 - Web: Fix WebSocket errors during history replay by checking connection state before sending

--- a/web/src/features/chat/components/git-diff-status-bar.tsx
+++ b/web/src/features/chat/components/git-diff-status-bar.tsx
@@ -176,8 +176,8 @@ export const GitDiffStatusBar = memo(function GitDiffStatusBarComponent({
 }: GitDiffStatusBarProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  // Don't render if not a git repo, no changes, or loading
-  if (!((stats?.isGitRepo) && stats.hasChanges) || stats.error) {
+  // Don't render if not a git repo, no changes, no files, or has error
+  if (!((stats?.isGitRepo) && stats.hasChanges && stats.files) || stats.error) {
     return null;
   }
 

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -12,7 +12,13 @@ export function getAuthToken(): string | null {
   // Check if token has expired
   const timestamp = localStorage.getItem(AUTH_TOKEN_TIMESTAMP_KEY);
   if (timestamp) {
-    const age = Date.now() - parseInt(timestamp, 10);
+    const storedAt = parseInt(timestamp, 10);
+    if (Number.isNaN(storedAt)) {
+      // Treat non-parsable timestamps as expired/corrupted
+      clearAuthToken();
+      return null;
+    }
+    const age = Date.now() - storedAt;
     if (age > TOKEN_EXPIRY_MS) {
       clearAuthToken();
       return null;
@@ -48,7 +54,7 @@ export function getAuthHeader(): Record<string, string> {
   // Fallback: try reading from URL if localStorage is empty
   if (!token) {
     const url = new URL(window.location.href);
-    token = url.searchParams.get("token");
+    token = url.searchParams.get(AUTH_TOKEN_PARAM);
   }
   if (!token) {
     return {};


### PR DESCRIPTION
## Description

fix(auth): switch from sessionStorage to localStorage for authentication token management

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
