### PR TITLE
feat(makefile): add check-web target for web project linting and type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ format-web: ## Auto-format web sources with npm run format.
 		exit 1; \
 	fi
 
-.PHONY: check check-kimi-cli check-kosong check-pykaos check-kimi-sdk
-check: check-kimi-cli check-kosong check-pykaos check-kimi-sdk ## Run linting and type checks for all packages.
+.PHONY: check check-kimi-cli check-kosong check-pykaos check-kimi-sdk check-web
+check: check-kimi-cli check-kosong check-pykaos check-kimi-sdk check-web ## Run linting and type checks for all packages.
 check-kimi-cli: ## Run linting and type checks for Kimi Code CLI.
 	@echo "==> Checking Kimi Code CLI (ruff + pyright + ty; ty is non-blocking)"
 	@uv run ruff check
@@ -82,6 +82,14 @@ check-kimi-sdk: ## Run linting and type checks for kimi-sdk.
 	@uv run --project sdks/kimi-sdk --directory sdks/kimi-sdk ruff format --check
 	@uv run --project sdks/kimi-sdk --directory sdks/kimi-sdk pyright
 	@uv run --project sdks/kimi-sdk --directory sdks/kimi-sdk ty check || true
+check-web: ## Run linting and type checks for web.
+	@echo "==> Checking web (biome + tsc)"
+	@if command -v npm >/dev/null 2>&1; then \
+		npm --prefix web run lint && npm --prefix web run typecheck; \
+	else \
+		echo "npm not found. Install Node.js (npm) to run web checks."; \
+		exit 1; \
+	fi
 
 
 .PHONY: test test-kimi-cli test-kosong test-pykaos test-kimi-sdk

--- a/web/src/features/chat/components/chat-workspace-header.tsx
+++ b/web/src/features/chat/components/chat-workspace-header.tsx
@@ -128,12 +128,13 @@ export function ChatWorkspaceHeader({
           ) : sessionDescription ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <p
-                  className="truncate text-xs font-bold cursor-pointer hover:text-primary"
+                <button
+                  type="button"
+                  className="truncate text-xs font-bold cursor-pointer hover:text-primary text-left bg-transparent border-none p-0"
                   onDoubleClick={handleDoubleClick}
                 >
                   {shortenTitle(sessionDescription, 60)}
-                </p>
+                </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-md">
                 <div>{sessionDescription}</div>


### PR DESCRIPTION
## Description
- Add `check-web` target to Makefile that runs `biome check` and `tsc` for the web project
- Include `check-web` in the main `check` target for consistency with `format` and `build`
- Fix a11y lint error in `chat-workspace-header.tsx` by changing `<p>` to `<button>` for the session title element

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/892">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
