### PR TITLE
fix(acp): asyncio stream reader over limit

### DIFF
--- a/src/kimi_cli/acp/__init__.py
+++ b/src/kimi_cli/acp/__init__.py
@@ -2,12 +2,34 @@ def acp_main() -> None:
     """Entry point for the multi-session ACP server."""
     import asyncio
 
-    import acp
+    from acp.agent.connection import AgentSideConnection
+    from acp.stdio import stdio_streams
 
     from kimi_cli.acp.server import ACPServer
     from kimi_cli.app import enable_logging
     from kimi_cli.utils.logging import logger
 
-    enable_logging()
-    logger.info("Starting ACP server on stdio")
-    asyncio.run(acp.run_agent(ACPServer(), use_unstable_protocol=True))
+    # Maximum buffer size for the asyncio StreamReader used for stdio.
+    # A 100MB limit is large enough for typical interactive use while still
+    # protecting the process from unbounded memory growth.
+    STDIO_BUFFER_LIMIT = 100 * 1024 * 1024
+
+    async def _run() -> None:
+        enable_logging()
+        logger.info("Starting ACP server on stdio")
+
+        # Create stdio streams with increased buffer limit
+        output_stream, input_stream = await stdio_streams(limit=STDIO_BUFFER_LIMIT)
+
+        # Create and run the agent connection
+        server = ACPServer()
+        conn = AgentSideConnection(
+            server,
+            input_stream,
+            output_stream,
+            listening=False,
+            use_unstable_protocol=True,
+        )
+        await conn.listen()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Related Issue

Resolve #758 #831

## Description

As @ZENOTME in #831 said, we should increase the buffer limit to 100MB when creating stdio streams like wire. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
> I have read the [CONTRIBUTING], however, due to kimi cli 1.7 using Python 3.14, it caused some compatibility issues in my local environment, so I didn't execute make prepare.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/904">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
