### PR TITLE
style(web): adjust message padding and alignment for better layout

### DIFF
--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -43,7 +43,7 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
       "group flex w-full flex-col gap-1",
-      from === "user" ? "is-user" : "is-assistant",
+      from === "user" ? "is-user items-end" : "is-assistant",
       className,
     )}
     {...props}
@@ -79,7 +79,7 @@ export const UserMessageContent = ({
   return (
     <div
       className={cn(
-        "w-full rounded-2xl bg-secondary/50 px-4 py-3 text-sm",
+        "max-w-[calc(100%-68px)] rounded-2xl bg-secondary/50 px-4 py-3 text-sm sm:max-w-[calc(100%-88px)]",
         "dark:bg-secondary/30",
         className,
       )}
@@ -596,7 +596,7 @@ export function MessageAttachments({
   return (
     <div
       className={cn(
-        "ml-auto flex w-fit flex-wrap items-start gap-2",
+        "flex w-fit flex-wrap justify-end gap-2",
         className,
       )}
       {...props}

--- a/web/src/components/ai-elements/tool.tsx
+++ b/web/src/components/ai-elements/tool.tsx
@@ -34,7 +34,7 @@ const ToolContext = createContext<ToolContextValue>({ isOpen: false });
 export const Tool = ({ className, defaultOpen, ...props }: ToolProps) => (
   <ToolContext.Provider value={{ isOpen: defaultOpen ?? false }}>
     <Collapsible
-      className={cn("not-prose mb-1 w-full text-sm", className)}
+      className={cn("not-prose mb-1 w-full px-3 text-sm", className)}
       defaultOpen={defaultOpen}
       {...props}
     />
@@ -107,7 +107,7 @@ export const ToolHeader = ({
 
   return (
     <CollapsibleTrigger
-      className={cn("flex items-center gap-1.5 text-sm group", className)}
+      className={cn("flex w-full items-center gap-1.5 text-sm group", className)}
       {...props}
     >
       <span className="size-2 rounded-full bg-muted-foreground/60 shrink-0" />

--- a/web/src/features/chat/components/assistant-message.tsx
+++ b/web/src/features/chat/components/assistant-message.tsx
@@ -52,8 +52,8 @@ export type AssistantApprovalHandler = (
 ) => void | Promise<void>;
 
 const assistantContentClass =
-  "w-full max-w-full text-sm leading-relaxed";
-const assistantMetaTextClass = "text-xs text-muted-foreground";
+  "w-full max-w-full px-3 text-sm leading-relaxed";
+const assistantMetaTextClass = "px-3 text-xs text-muted-foreground";
 
 type AssistantMessageProps = {
   message: LiveMessage;

--- a/web/src/features/chat/components/virtualized-message-list.tsx
+++ b/web/src/features/chat/components/virtualized-message-list.tsx
@@ -75,7 +75,7 @@ function VirtuosoListComponent(
   return (
     <div
       ref={ref}
-      className={cn("flex flex-col px-3 py-4 sm:px-6 lg:px-8", className)}
+      className={cn("flex flex-col py-4 sm:px-3 lg:px-5", className)}
       {...rest}
     />
   );
@@ -287,7 +287,7 @@ function VirtualizedMessageListComponent(
           >
             {message.role === "user" ? (
               message.content ? (
-                <UserMessageContent>{message.content}</UserMessageContent>
+                <UserMessageContent className="mx-3">{message.content}</UserMessageContent>
               ) : null
             ) : (
               <AssistantMessage
@@ -302,7 +302,7 @@ function VirtualizedMessageListComponent(
               />
             )}
             {message.attachments && message.attachments.length > 0 ? (
-              <MessageAttachments>
+              <MessageAttachments className="mx-3">
                 {message.attachments.map((attachment, attIdx) => {
                   const key =
                     "kind" in attachment


### PR DESCRIPTION
This PR improves the message style in the web UI:

- Align user messages to the right with bubble widths match their content and related attachments layout.
- Fix ActivityStatusIndicator animation truncation by adding consistent px-3 padding to tool components and assistant messages.

**before**

desktop

<img width="1317" height="116" alt="image" src="https://github.com/user-attachments/assets/523a0205-e9f1-4f25-858c-7f0dda62164f" />

mobile

<img width="385" height="320" alt="image" src="https://github.com/user-attachments/assets/2d0937dc-cd55-40b5-b39c-6be7acea9218" />

**after**

desktop

<img width="2620" height="1292" alt="072f7c7553fc08aace05bdfcd28b8605" src="https://github.com/user-attachments/assets/73cc07af-d424-41b1-975f-408b2ff9b42d" />

mobile

<img width="373" height="339" alt="image" src="https://github.com/user-attachments/assets/f6d685eb-432d-48e4-9d12-d50b015e1e7d" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
