### PR TITLE
fix(cli/web): allow binding to all addresses if not lan_only

### DIFF
--- a/src/kimi_cli/cli/web.py
+++ b/src/kimi_cli/cli/web.py
@@ -62,7 +62,7 @@ def web(
     # Determine bind address
     if host:
         bind_host = host
-    elif network:
+    elif network or not lan_only:
         bind_host = "0.0.0.0"
     else:
         bind_host = "127.0.0.1"


### PR DESCRIPTION
`--public` 逻辑有点乱，直接 `kimi-web --public` 还是 bind local

from kimi-cli:

```bash
现在 --public 会正确地将 bind_host 设置为 "0.0.0.0"。

  修改后的逻辑：

  • --host <ip> → 绑定到指定 IP
  • --network → 绑定到 0.0.0.0
  • --public → 绑定到 0.0.0.0（同时 lan_only=False）
  • 默认（无参数）→ 绑定到 127.0.0.1
```


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The logic of `--public` is a bit confusing, directly `kimi-web --public` or bind local

from kimi-cli:

```bash
--public now correctly sets bind_host to "0.0.0.0".

  Modified logic:

  • --host <ip> → Bind to specified IP
  • --network → bind to 0.0.0.0
  • --public → bind to 0.0.0.0 (with lan_only=False)
  • Default (no parameters) → bind to 127.0.0.1
```
