### PR TITLE
feat(acp): add support for file reference in ACP protocol

### DIFF
--- a/src/kimi_cli/acp/convert.py
+++ b/src/kimi_cli/acp/convert.py
@@ -28,6 +28,15 @@ def acp_blocks_to_content_parts(prompt: list[ACPContentBlock]) -> list[ContentPa
                         )
                     )
                 )
+            case acp.schema.EmbeddedResourceContentBlock():
+                # Embedded resources contain content from the Client
+                resource = block.resource
+                if isinstance(resource, acp.schema.TextResourceContents):
+                    content.append(TextPart(text=f"File: {resource.uri}\n\n{resource.text}"))
+                elif resource.__class__.__name__ == "BlobResourceContents":
+                    logger.info("Skipping binary embedded resource: {uri}", uri=resource.uri)
+                else:
+                    logger.warning("Unknown resource type: {resource}", resource=resource)
             case _:
                 logger.warning("Unsupported prompt content block: {block}", block=block)
     return content

--- a/tests/ui_and_conv/test_acp_convert.py
+++ b/tests/ui_and_conv/test_acp_convert.py
@@ -1,7 +1,12 @@
+import tempfile
+from pathlib import Path
+from typing import cast
+
 import acp
 
-from kimi_cli.acp.convert import tool_result_to_acp_content
-from kimi_cli.wire.types import DiffDisplayBlock, ToolReturnValue
+from kimi_cli.acp.convert import acp_blocks_to_content_parts, tool_result_to_acp_content
+from kimi_cli.acp.types import ACPContentBlock
+from kimi_cli.wire.types import DiffDisplayBlock, TextPart, ToolReturnValue
 
 
 def test_tool_result_to_acp_content_handles_diff_display():
@@ -21,3 +26,93 @@ def test_tool_result_to_acp_content_handles_diff_display():
     assert content.path == "foo.txt"
     assert content.old_text == "before"
     assert content.new_text == "after"
+
+
+def test_acp_blocks_to_content_parts_handles_text_block():
+    blocks = [acp.schema.TextContentBlock(type="text", text="Hello, world!")]
+
+    result = acp_blocks_to_content_parts(cast(list[ACPContentBlock], blocks))
+
+    assert len(result) == 1
+    assert isinstance(result[0], TextPart)
+    assert result[0].text == "Hello, world!"
+
+
+def test_acp_blocks_to_content_parts_handles_resource_block():
+    """ResourceContentBlock should be logged but not converted to content."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("File content here")
+        temp_path = f.name
+
+    try:
+        uri = f"file://{temp_path}"
+        blocks = [acp.schema.ResourceContentBlock(type="resource_link", uri=uri, name="test.txt")]
+
+        result = acp_blocks_to_content_parts(cast(list[ACPContentBlock], blocks))
+
+        assert len(result) == 0
+    finally:
+        Path(temp_path).unlink()
+
+
+def test_acp_blocks_to_content_parts_handles_embedded_resource_block():
+    resource = acp.schema.TextResourceContents(
+        uri="file:///path/to/file.txt", text="Embedded content", mime_type="text/plain"
+    )
+    blocks = [acp.schema.EmbeddedResourceContentBlock(type="resource", resource=resource)]
+
+    result = acp_blocks_to_content_parts(cast(list[ACPContentBlock], blocks))
+
+    assert len(result) == 1
+    assert isinstance(result[0], TextPart)
+    assert "file:///path/to/file.txt" in result[0].text
+    assert "Embedded content" in result[0].text
+
+
+def test_acp_blocks_to_content_parts_handles_nonexistent_file():
+    """ResourceContentBlock with nonexistent file should be logged but not converted."""
+    blocks = [
+        acp.schema.ResourceContentBlock(
+            type="resource_link", uri="file:///nonexistent/file.txt", name="missing.txt"
+        )
+    ]
+
+    result = acp_blocks_to_content_parts(cast(list[ACPContentBlock], blocks))
+
+    assert len(result) == 0
+
+
+def test_acp_blocks_to_content_parts_handles_invalid_uri_scheme():
+    """ResourceContentBlock with non-file URI should be logged but not converted."""
+    blocks = [
+        acp.schema.ResourceContentBlock(
+            type="resource_link", uri="http://example.com/file.txt", name="remote.txt"
+        )
+    ]
+
+    result = acp_blocks_to_content_parts(cast(list[ACPContentBlock], blocks))
+
+    assert len(result) == 0
+
+
+def test_acp_blocks_to_content_parts_handles_mixed_blocks():
+    """Mixed blocks should handle text and embedded resources, but skip resource links."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Test file")
+        temp_path = f.name
+
+    try:
+        blocks = [
+            acp.schema.TextContentBlock(type="text", text="Text block"),
+            acp.schema.ResourceContentBlock(
+                type="resource_link", uri=f"file://{temp_path}", name="test.txt"
+            ),
+        ]
+
+        result = acp_blocks_to_content_parts(cast(list[ACPContentBlock], blocks))
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextPart)
+        assert result[0].text == "Text block"
+    finally:
+        Path(temp_path).unlink()


### PR DESCRIPTION
## Related Issue

Resolves #1054

## Description

This PR adds support for embedded resources in the ACP (Agent Communication Protocol) by implementing proper handling of `EmbeddedResourceContentBlock` according to the official ACP protocol specification. This enables IDE integrations (like Zed) to use @-mentions to reference files.

### Changes Made

**`src/kimi_cli/acp/convert.py`**:
- Added handler for `EmbeddedResourceContentBlock` - extracts and converts embedded text content to `TextPart`
- Handles both text resources (`TextResourceContents`) and logs info for binary resources (`BlobResourceContents`)

**`tests/ui_and_conv/test_acp_convert.py`**:
- Test for handling `EmbeddedResourceContentBlock` with embedded content
- Tests verify that unsupported block types (including `ResourceContentBlock`) are not converted

### Technical Details

According to the [official ACP specification](https://agentclientprotocol.com/protocol/content):

**`EmbeddedResourceContentBlock`** (type: "resource"):
- This is the **preferred way** for Clients to include context (e.g., @-mentions) that the Agent may not have direct access to
- The Client reads the file and embeds the actual content in the message
- Our implementation extracts this embedded content and passes it to the LLM


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
