### PR TITLE
fix: remove redundant mode validation in WriteFile tool

### DIFF
--- a/src/kimi_cli/tools/file/write.py
+++ b/src/kimi_cli/tools/file/write.py
@@ -80,16 +80,6 @@ class WriteFile(CallableTool2[Params]):
                     brief="Parent directory not found",
                 )
 
-            # Validate mode parameter
-            if params.mode not in ["overwrite", "append"]:
-                return ToolError(
-                    message=(
-                        f"Invalid write mode: `{params.mode}`. "
-                        "Mode must be either `overwrite` or `append`."
-                    ),
-                    brief="Invalid write mode",
-                )
-
             file_existed = await p.exists()
             old_text = None
             if file_existed:


### PR DESCRIPTION
## Summary

Remove redundant runtime validation of the `mode` parameter in the WriteFile tool.

## Problem

The `WriteFile` tool in `src/kimi_cli/tools/file/write.py` contained redundant validation code (lines 84-91) that checked whether the `mode` parameter was either "overwrite" or "append". This check is unnecessary because:

1. The Pydantic `Literal["overwrite", "append"]` type annotation on the `Params.mode` field already enforces this constraint at the data validation layer
2. Any invalid value would raise a `ValidationError` before reaching the tool's `__call__` method
3. The existing test suite includes `test_write_with_invalid_mode` which confirms this behavior

## Solution

Removed the redundant validation block, reducing code complexity while maintaining the same validation guarantees through Pydantic.

## Test plan

- [x] All existing tests pass (`test_write_file.py` - 13/13 passed)
- [x] Code formatting passes (ruff format check)
- [x] Linting passes (ruff check)
- [x] The `test_write_with_invalid_mode` test confirms Pydantic ValidationError is still raised for invalid modes

## Changes

- `src/kimi_cli/tools/file/write.py`: Removed 10 lines of redundant validation code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
