### PR TITLE
fix: recognize /? as valid lash command.

### DIFF
--- a/src/kimi_cli/utils/slashcmd.py
+++ b/src/kimi_cli/utils/slashcmd.py
@@ -112,7 +112,7 @@ def parse_slash_command_call(user_input: str) -> SlashCommandCall | None:
     if not user_input or not user_input.startswith("/"):
         return None
 
-    name_match = re.match(r"^\/([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)*)", user_input)
+    name_match = re.match(r"^\/([a-zA-Z0-9_?-]+(?::[a-zA-Z0-9_?-]+)*)", user_input)
 
     if not name_match:
         return None

--- a/tests/utils/test_slash_command.py
+++ b/tests/utils/test_slash_command.py
@@ -54,6 +54,11 @@ def test_parse_slash_command_call():
         SlashCommandCall(name="skill:doc-writing", args="", raw_input="/skill:doc-writing")
     )
 
+    # Test ? alias for help 
+    result = parse_slash_command_call("/?")
+    assert result == snapshot(SlashCommandCall(name="?", args="", raw_input="/?"))
+
+    
     # Edge cases: double slash
     assert parse_slash_command_call("//comment") is None
     assert parse_slash_command_call("//") is None


### PR DESCRIPTION
## Description
Fixes #1069 - The `/?` command was not recognized as a valid slash command due to a regex limitation.

## Changes Made
- Added `?` to the regex character class in `slashcmd.py` line 115
- Added test case for `/?` parsing in `test_slash_command.py`

## Testing
- All slash command tests pass (3/3)
- The `/?` alias now correctly parses to the help command

## Checklist
- [x] Code follows project style
- [x] Added tests for the fix
- [x] All tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
