### PR TITLE
fix(scripts): source uv env after installation to update PATH

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,7 @@ if command -v uv >/dev/null 2>&1; then
   UV_BIN="uv"
 else
   install_uv
+  source "$HOME/.local/bin/env"
   UV_BIN="uv"
 fi
 


### PR DESCRIPTION
## Related Issue

Resolve #1107

## Description

After `install_uv()` installs uv, `~/.local/bin` is not in the current shell's PATH, causing the subsequent `command -v uv` check to fail with "uv not found after installation".

This PR adds `source "$HOME/.local/bin/env"` after installing uv, which is the standard way recommended by uv's own installer to update PATH in the current shell session.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
