### PR TITLE
refactor: clean up exception.py - add __all__ and remove redundant pass statements

### DIFF
--- a/src/kimi_cli/exception.py
+++ b/src/kimi_cli/exception.py
@@ -1,43 +1,39 @@
 from __future__ import annotations
 
+__all__ = (
+    "KimiCLIException",
+    "ConfigError",
+    "AgentSpecError",
+    "InvalidToolError",
+    "SystemPromptTemplateError",
+    "MCPConfigError",
+    "MCPRuntimeError",
+)
+
 
 class KimiCLIException(Exception):
     """Base exception class for Kimi Code CLI."""
-
-    pass
 
 
 class ConfigError(KimiCLIException, ValueError):
     """Configuration error."""
 
-    pass
-
 
 class AgentSpecError(KimiCLIException, ValueError):
     """Agent specification error."""
-
-    pass
 
 
 class InvalidToolError(KimiCLIException, ValueError):
     """Invalid tool error."""
 
-    pass
-
 
 class SystemPromptTemplateError(KimiCLIException, ValueError):
     """System prompt template error."""
-
-    pass
 
 
 class MCPConfigError(KimiCLIException, ValueError):
     """MCP config error."""
 
-    pass
-
 
 class MCPRuntimeError(KimiCLIException, RuntimeError):
     """MCP runtime error."""
-
-    pass


### PR DESCRIPTION
## What
- Added `__all__` declaration to explicitly export the 7 public exception classes
- Removed redundant `pass` statements from all exception class bodies (unnecessary after docstrings)

## Why
- `__all__` improves API clarity and enables `from kimi_cli.exception import *` to work correctly
- Removing unnecessary `pass` statements reduces visual noise and follows Python best practices
- No functional changes — purely code quality improvements

## How to verify
```bash
# Syntax check
python3 -m py_compile src/kimi_cli/exception.py

# Verify __all__ is correct
python3 -c "from kimi_cli.exception import __all__; print(__all__)"
```

## Notes
- Breaking change: **No**
- Risk: **Low**
- Files changed: 1

---
*PR prepared with AI assistance (Claude Code PR Factory)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
