### PR TITLE
docs(ides): Replace instructions on how to use Kimi CLI in Zed

### DIFF
--- a/docs/en/guides/ides.md
+++ b/docs/en/guides/ides.md
@@ -8,31 +8,7 @@ Before configuring your IDE, make sure you have installed Kimi Code CLI and comp
 
 ## Using in Zed
 
-[Zed](https://zed.dev/) is a modern IDE that supports ACP.
-
-Add the following to Zed's configuration file `~/.config/zed/settings.json`:
-
-```json
-{
-  "agent_servers": {
-    "Kimi Code CLI": {
-      "type": "custom",
-      "command": "kimi",
-      "args": ["acp"],
-      "env": {}
-    }
-  }
-}
-```
-
-Configuration notes:
-
-- `type`: Fixed value `"custom"`
-- `command`: Path to the Kimi Code CLI command. If `kimi` is not in PATH, use the full path
-- `args`: Startup arguments. `acp` enables ACP mode
-- `env`: Environment variables, usually left empty
-
-After saving the configuration, you can create Kimi Code CLI sessions in Zed's Agent panel.
+[Zed](https://zed.dev/) is a modern IDE that supports ACP. To use Kimi CLI within Zed, you can install it via the [ACP registry](https://agentclientprotocol.com/get-started/registry) in Zed by launching the command palette and typing `zed: acp registry`.
 
 ## Using in JetBrains IDEs
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

N/A

## Description

Agent Server Extensions are being deprecated in favor of the ACP registry. You can learn more [here](https://zed.dev/blog/acp-registry), but soon the current docs will not be valid.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
