### PR TITLE
docs: add kimi web and kimi acp usage modes to getting started

### DIFF
--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -10,7 +10,11 @@ Kimi Code CLI is suited for:
 - **Understanding projects**: Exploring unfamiliar codebases, answering architecture and implementation questions
 - **Automating tasks**: Batch processing files, running builds and tests, executing scripts
 
-Kimi Code CLI provides a shell-like interactive experience in the terminal. You can describe your needs in natural language or switch to shell mode at any time to execute commands directly. Beyond terminal usage, Kimi Code CLI also supports integration with [IDEs](./ides.md) and other local agent clients via the [Agent Client Protocol].
+Kimi Code CLI supports the following usage modes:
+
+- **[Interactive CLI (`kimi`)](../reference/kimi-command.md)**: Chat with AI in the terminal using natural language or execute shell commands directly
+- **[Browser UI (`kimi web`)](../reference/kimi-web.md)**: Open a graphical interface in your local browser, with session management, file references, code highlighting, and more
+- **[Agent integration (`kimi acp`)](../reference/kimi-acp.md)**: Run as a service and integrate with [IDEs](./ides.md) and other local agent clients via the [Agent Client Protocol]
 
 ::: info Tip
 If you encounter issues or have suggestions, please provide feedback on [GitHub Issues](https://github.com/MoonshotAI/kimi-cli/issues).

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -10,7 +10,11 @@ Kimi Code CLI 适合以下场景：
 - **理解项目**：探索陌生的代码库，解答架构和实现问题
 - **自动化任务**：批量处理文件、执行构建和测试、运行脚本
 
-Kimi Code CLI 在终端中提供类似 Shell 的交互体验，你可以用自然语言描述需求，也可以随时切换到 Shell 模式直接执行命令。除了终端使用，Kimi Code CLI 还支持通过 [Agent Client Protocol] 集成到 [IDE](./ides.md) 和其他本地 Agent 客户端中。
+Kimi Code CLI 支持以下几种使用方式：
+
+- **[交互式命令行（`kimi`）](../reference/kimi-command.md)**：在终端中以 Shell 方式与 AI 对话，支持自然语言描述任务或直接执行 Shell 命令
+- **[浏览器界面（`kimi web`）](../reference/kimi-web.md)**：在本地浏览器中打开图形界面，支持会话管理、文件引用、代码高亮等
+- **[Agent 集成（`kimi acp`）](../reference/kimi-acp.md)**：以服务方式运行，通过 [Agent Client Protocol] 集成到 [IDE](./ides.md) 和其他本地 Agent 客户端中
 
 ::: info 提示
 如果你遇到问题或有建议，欢迎在 [GitHub Issues](https://github.com/MoonshotAI/kimi-cli/issues) 反馈。


### PR DESCRIPTION
## Related Issue

N/A — standalone documentation improvement.

## Description

The "Getting Started" guide previously described Kimi Code CLI's interaction model in a single sentence. This PR replaces it with a structured bullet list that introduces the three distinct usage modes:

- **Interactive CLI (`kimi`)** — terminal chat interface
- **Browser UI (`kimi web`)** — graphical local browser interface
- **Agent integration (`kimi acp`)** — ACP service for IDE and agent client integration

Links use inline relative paths (`../reference/kimi-command.md` etc.) so the kimi-coding-docs sync script automatically converts them to absolute URLs on the documentation site.

Both `docs/zh/guides/getting-started.md` (source of truth) and `docs/en/guides/getting-started.md` are updated and verified in sync via `make gen-docs`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any. (N/A)
- [x] I have added tests that prove my fix is effective or that my feature works. (N/A — docs only)
- [x] I have run `make gen-changelog` to update the changelog. (N/A — no user-facing feature change)
- [x] I have run `make gen-docs` to update the user documentation. (verified — no further changes needed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
