### PR TITLE
feat(http): enable trust_env in creating aiohttp.ClientSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Web: Enable `trust_env` in aiohttp client session to respect proxy environment variables (`https_proxy`, `http_proxy`, etc.)
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -117,6 +117,35 @@ export OPENAI_API_KEY="sk-xxx"
 | `KIMI_CLI_PASTE_CHAR_THRESHOLD` | Character threshold for folding pasted text (default: `1000`) |
 | `KIMI_CLI_PASTE_LINE_THRESHOLD` | Line threshold for folding pasted text (default: `15`) |
 
+### Proxy environment variables
+
+Kimi Code CLI supports configuring HTTP/HTTPS proxies through standard proxy environment variables. These variables affect all HTTP requests to external APIs (including Kimi API, OAuth services, web scraping, etc.).
+
+| Environment Variable | Description |
+| --- | --- |
+| `http_proxy` / `HTTP_PROXY` | HTTP proxy server address |
+| `https_proxy` / `HTTPS_PROXY` | HTTPS proxy server address |
+| `all_proxy` / `ALL_PROXY` | Proxy server address for all protocols |
+| `no_proxy` / `NO_PROXY` | Comma-separated list of addresses that do not use proxy |
+
+**Proxy configuration examples**
+
+```sh
+# Set HTTPS proxy
+export https_proxy="http://proxy.example.com:8080"
+
+# Set proxy with authentication
+export https_proxy="http://username:password@proxy.example.com:8080"
+
+# Bypass proxy for certain addresses
+export no_proxy="localhost,127.0.0.1,api.moonshot.cn"
+```
+
+::: tip
+- Setting both `http_proxy` and `https_proxy` ensures all types of requests go through the proxy
+- `no_proxy` supports wildcards, e.g., `.example.com` matches all subdomains of `example.com`
+:::
+
 ### `KIMI_SHARE_DIR`
 
 Customize the share directory path for Kimi Code CLI. The default path is `~/.kimi`, where configuration, sessions, logs, and other runtime data are stored.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Web: Enable `trust_env` in aiohttp client session to respect proxy environment variables (`https_proxy`, `http_proxy`, etc.)
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -117,6 +117,35 @@ export OPENAI_API_KEY="sk-xxx"
 | `KIMI_CLI_PASTE_CHAR_THRESHOLD` | 粘贴文本折叠的字符数阈值（默认 `1000`） |
 | `KIMI_CLI_PASTE_LINE_THRESHOLD` | 粘贴文本折叠的行数阈值（默认 `15`） |
 
+### 代理环境变量
+
+Kimi Code CLI 支持通过标准的代理环境变量配置 HTTP/HTTPS 代理。这些变量会影响所有对外部 API 的 HTTP 请求（包括 Kimi API、OAuth 服务、网页抓取等）。
+
+| 环境变量 | 说明 |
+| --- | --- |
+| `http_proxy` / `HTTP_PROXY` | HTTP 代理服务器地址 |
+| `https_proxy` / `HTTPS_PROXY` | HTTPS 代理服务器地址 |
+| `all_proxy` / `ALL_PROXY` | 所有协议的代理服务器地址 |
+| `no_proxy` / `NO_PROXY` | 不使用代理的地址列表（逗号分隔） |
+
+**设置代理示例**
+
+```sh
+# 设置 HTTPS 代理
+export https_proxy="http://proxy.example.com:8080"
+
+# 设置带有认证的代理
+export https_proxy="http://username:password@proxy.example.com:8080"
+
+# 对某些地址不使用代理
+export no_proxy="localhost,127.0.0.1,api.moonshot.cn"
+```
+
+::: tip 提示
+- 同时设置 `http_proxy` 和 `https_proxy` 可以确保所有类型的请求都经过代理
+- `no_proxy` 中的地址支持通配符，如 `.example.com` 会匹配所有 `example.com` 的子域名
+:::
+
 ### `KIMI_SHARE_DIR`
 
 自定义 Kimi Code CLI 的共享目录路径。默认路径为 `~/.kimi`，配置、会话、日志等运行时数据存储在此目录下。

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Web：在 aiohttp 客户端会话中启用 `trust_env`，以支持代理环境变量（`https_proxy`、`http_proxy` 等）
+
 ## 1.37.0 (2026-04-20)
 
 - Print：退出前等待后台任务完成——在单次 `--print` 模式下，进程现在会等待仍在运行的后台 Agent 完成并让模型处理它们的结果，而不是直接退出并杀死它们。等待时长上限为 `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)`（默认上限 1 小时）；超时后杀死任务并通过 `<system-reminder>` 给模型最后一轮机会向用户总结后再退出

--- a/src/kimi_cli/utils/aiohttp.py
+++ b/src/kimi_cli/utils/aiohttp.py
@@ -19,6 +19,7 @@ def new_client_session(
     timeout: aiohttp.ClientTimeout | None = None,
 ) -> aiohttp.ClientSession:
     return aiohttp.ClientSession(
+        trust_env=True,
         connector=aiohttp.TCPConnector(ssl=_ssl_context),
         timeout=timeout or _DEFAULT_TIMEOUT,
     )


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #1234

## Description

<!-- Please describe your changes in detail. -->
Add parameter `trust_env=True` when creating `aiohttp.ClientSession` in `src/kimi_cli/utils/aiohttp.py`.
This would make aiohttp.ClientSession respect environment variable such as `https_proxy`, `HTTPS_PROXY` and so on.
By default, `trust_env` is set `False` in `__init__` funcion of `aiohttp.ClientSession`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
