### PR TITLE
chore: bump version to 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.14.0 (2026-02-26)
+
 - Shell: Make FetchURL tool's URL parameter a clickable hyperlink in the terminal
 - Tool: Add `AskUserQuestion` tool for presenting structured questions with predefined options during execution, supporting single-select, multi-select, and custom text input
 - Wire: Add `QuestionRequest` / `QuestionResponse` message types and capability negotiation for structured question interactions

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+## 1.14.0 (2026-02-26)
+
 - Shell: Make FetchURL tool's URL parameter a clickable hyperlink in the terminal
 - Tool: Add `AskUserQuestion` tool for presenting structured questions with predefined options during execution, supporting single-select, multi-select, and custom text input
 - Wire: Add `QuestionRequest` / `QuestionResponse` message types and capability negotiation for structured question interactions

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 1.14.0 (2026-02-26)
+
 - Shell：在终端中将 `FetchURL` 工具的 URL 参数显示为可点击的超链接
 - Tool：新增 `AskUserQuestion` 工具，支持在执行过程中向用户展示结构化问题和预定义选项，支持单选、多选和自定义文本输入
 - Wire：新增 `QuestionRequest` / `QuestionResponse` 消息类型和能力协商机制，用于结构化问答交互

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.13.0"
+version = "1.14.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.13.0"]
+dependencies = ["kimi-cli==1.14.0"]
 
 [project.scripts]
 kimi = "kimi_cli.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.13.0"
+version = "1.14.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1298,7 +1298,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },


### PR DESCRIPTION
## Summary

Bump kimi-cli and kimi-code to version 1.14.0.

## Changes

- **pyproject.toml**: kimi-cli version 1.13.0 → 1.14.0
- **packages/kimi-code/pyproject.toml**: kimi-code version and dependency synced to 1.14.0
- **CHANGELOG.md**: Entries moved from Unreleased to 1.14.0 (2026-02-26)
- **docs/en/release-notes/changelog.md**: English changelog synced
- **docs/zh/release-notes/changelog.md**: Chinese changelog updated
- **uv.lock**: Lockfile updated

## New in 1.14.0

- Shell: Clickable hyperlinks for FetchURL tool's URL parameter
- Tool: `AskUserQuestion` tool for structured questions with predefined options
- Wire: `QuestionRequest` / `QuestionResponse` message types for structured Q&A
- Shell: Interactive question panel for `AskUserQuestion`
- Web: `QuestionDialog` component for answering structured questions inline
- Core: Session state persistence (approval decisions, dynamic subagents)
- Core: Atomic JSON writes for metadata and session state files
- Wire: `steer` request to inject user messages into active agent turns (protocol v1.4)
- Web: Cmd/Ctrl+Click on FetchURL URL to open in new tab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
