### PR TITLE
fix: strip whitespace from custom headers to prevent illegal header value errors

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -195,7 +195,7 @@ def get_device_id() -> str:
 def _ascii_header_value(value: str, *, fallback: str = "unknown") -> str:
     try:
         value.encode("ascii")
-        return value
+        return value.strip()
     except UnicodeEncodeError:
         sanitized = value.encode("ascii", errors="ignore").decode("ascii").strip()
         return sanitized or fallback

--- a/tests/utils/test_oauth_headers.py
+++ b/tests/utils/test_oauth_headers.py
@@ -1,0 +1,22 @@
+from kimi_cli.auth.oauth import _ascii_header_value
+
+
+def test_ascii_header_value_strips_trailing_space():
+    assert _ascii_header_value("test ") == "test"
+    assert _ascii_header_value(" test") == "test"
+    assert _ascii_header_value("  test  ") == "test"
+
+
+def test_ascii_header_value_non_ascii_strips_trailing_space():
+    # Non-ASCII character (Chinese 'test') followed by space
+    # The non-ASCII characters are ignored by encode('ascii', errors='ignore')
+    # So "测试 " becomes " " and then .strip() makes it empty, returning fallback
+    assert _ascii_header_value("测试 ") == "unknown"
+    # "A测试 " -> "A " -> "A"
+    assert _ascii_header_value("A测试 ") == "A"
+
+
+def test_ascii_header_value_fallback():
+    # Only non-ASCII characters that get ignored, resulting in empty string
+    assert _ascii_header_value("🚀") == "unknown"
+    assert _ascii_header_value("🚀", fallback="default") == "default"


### PR DESCRIPTION
## Description

On some Linux distributions, `platform.version()` can return a string with a trailing space. Since `httpx` (used by the OpenAI client) is strictly RFC 7230 compliant, it rejects any header values with leading or trailing whitespace, leading to an `openai.APIConnectionError` with the message `Illegal header value`.

This PR ensures that all custom headers are stripped of whitespace in `_ascii_header_value` before being sent.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any
  - [x] https://github.com/MoonshotAI/kimi-cli/issues/886
  - [x] https://github.com/MoonshotAI/kimi-cli/issues/1226
  - [x] https://github.com/MoonshotAI/kimi-cli/issues/1227
  - [x] https://github.com/MoonshotAI/kimi-cli/issues/1263
  - [x] https://github.com/MoonshotAI/kimi-cli/issues/414
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
