### PR TITLE
feat(config): support configuring preserved messages in compaction

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -125,6 +125,7 @@ capabilities = ["thinking", "image_in"]
 | `max_ralph_iterations` | `integer` | `0` | Extra iterations after each user message; `0` disables; `-1` is unlimited |
 | `reserved_context_size` | `integer` | `50000` | Reserved token count for LLM response generation; auto-compaction triggers when `context_tokens + reserved_context_size >= max_context_size` |
 | `compaction_trigger_ratio` | `float` | `0.85` | Context usage ratio threshold for auto-compaction (0.5–0.99); auto-compaction triggers when `context_tokens >= max_context_size * compaction_trigger_ratio`, whichever condition is met first with `reserved_context_size` |
+| `max_preserved_messages` | `integer` | `2` | Number of recent messages to preserve during compaction |
 
 ### `services`
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -125,6 +125,7 @@ capabilities = ["thinking", "image_in"]
 | `max_ralph_iterations` | `integer` | `0` | 每个 User 消息后额外自动迭代次数；`0` 表示关闭；`-1` 表示无限 |
 | `reserved_context_size` | `integer` | `50000` | 预留给 LLM 响应生成的 token 数量；当 `context_tokens + reserved_context_size >= max_context_size` 时自动触发压缩 |
 | `compaction_trigger_ratio` | `float` | `0.85` | 触发自动压缩的上下文使用率阈值（0.5–0.99）；当 `context_tokens >= max_context_size * compaction_trigger_ratio` 时自动触发压缩，与 `reserved_context_size` 条件取先触发者 |
+| `max_preserved_messages` | `integer` | `2` | 压缩时保留的最近消息数量 |
 
 ### `services`
 

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -86,6 +86,8 @@ class LoopControl(BaseModel):
     """Context usage ratio threshold for auto-compaction. Default is 0.85 (85%).
     Auto-compaction triggers when context_tokens >= max_context_size * compaction_trigger_ratio
     or when context_tokens + reserved_context_size >= max_context_size."""
+    max_preserved_messages: int = Field(default=2, ge=1)
+    """Number of recent messages to preserve during compaction. Default is 2."""
 
 
 class MoonshotSearchConfig(BaseModel):

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -109,7 +109,9 @@ class KimiSoul:
         self._approval = agent.runtime.approval
         self._context = context
         self._loop_control = agent.runtime.config.loop_control
-        self._compaction = SimpleCompaction()  # TODO: maybe configurable and composable
+        self._compaction = SimpleCompaction(
+            max_preserved_messages=self._loop_control.max_preserved_messages
+        )
 
         for tool in agent.toolset.tools:
             if tool.name == SendDMail_NAME:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -33,6 +33,7 @@ def test_default_config_dump():
                 "max_ralph_iterations": 0,
                 "reserved_context_size": 50000,
                 "compaction_trigger_ratio": 0.85,
+                "max_preserved_messages": 2,
             },
             "services": {"moonshot_search": None, "moonshot_fetch": None},
             "mcp": {"client": {"tool_call_timeout_ms": 60000}},
@@ -103,6 +104,16 @@ def test_load_config_compaction_trigger_ratio():
 def test_load_config_compaction_trigger_ratio_default():
     config = load_config_from_string("{}")
     assert config.loop_control.compaction_trigger_ratio == 0.85
+
+
+def test_load_config_max_preserved_messages():
+    config = load_config_from_string('{"loop_control": {"max_preserved_messages": 5}}')
+    assert config.loop_control.max_preserved_messages == 5
+
+
+def test_load_config_max_preserved_messages_default():
+    config = load_config_from_string("{}")
+    assert config.loop_control.max_preserved_messages == 2
 
 
 def test_load_config_compaction_trigger_ratio_too_low():


### PR DESCRIPTION
<!-- 
 Thank you for your contribution to Kimi Code CLI! 
 Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers. 
 Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth. 
 
 See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more. 
 --> 
 
 ## Related Issue 
 
 <!-- Please link to the issue here. --> 
 
 N/A (Resolves internal TODO in `src/kimi_cli/soul/kimisoul.py`)
 
 ## Description 
 
 <!-- Please describe your changes in detail. --> 
 
 This PR adds a new configuration option `max_preserved_messages` to the `loop_control` section in `config.toml`. 
 
 - **Feature**: Users can now control the number of recent messages preserved when auto-compaction is triggered.
 - **Default**: The default value is set to `2`, maintaining the existing behavior while offering flexibility for users who wish to retain more context.
 - **Implementation**: Updated `LoopControl` config model and `KimiSoul` initialization to pass the configured value to `SimpleCompaction`.
 
 ## Checklist 
 
 - [x] I have read the `https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md`  document. 
 - [ ] I have linked the related issue, if any. 
 - [x] I have added tests that prove my fix is effective or that my feature works. 
 - [x] I have run `make gen-changelog` to update the changelog. 
 - [x] I have run `make gen-docs` to update the user documentation. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
