### PR TITLE
feat(ui): add video clipboard paste support

### DIFF
--- a/docs/en/guides/interaction.md
+++ b/docs/en/guides/interaction.md
@@ -45,14 +45,30 @@ Sometimes you need to enter multiple lines, such as pasting a code snippet or er
 
 After finishing your input, press `Enter` to send the complete message.
 
-## Clipboard and image paste
+## Clipboard and media paste
 
-Press `Ctrl-V` to paste text or images from the clipboard.
+Press `Ctrl-V` to paste text, images, or video files from the clipboard.
 
-If the clipboard contains an image, Kimi Code CLI will automatically add the image as an attachment to the message. After sending the message, the AI can see and analyze the image.
+If the clipboard contains an **image**, Kimi Code CLI will automatically add the image as an attachment to the message. After sending the message, the AI can see and analyze the image.
+
+If the clipboard contains a **video file path**, Kimi Code CLI will insert a reference to the video file. The AI can then use the `ReadMediaFile` tool to read and analyze the video content.
+
+Supported video formats include: MP4, MKV, AVI, MOV, WMV, WebM, M4V, FLV, 3GP, and 3G2.
+
+### Video input in print mode (non-interactive)
+
+When using [print mode](../customization/print-mode.md) with `-c` or `--command`, you can reference video files directly:
+
+```sh
+kimi --print -c "Analyze this video /path/to/video.mp4"
+```
+
+Kimi Code CLI will automatically detect video file paths in your command and make them available to the AI for analysis.
 
 ::: tip
 Image input requires the model to support the `image_in` capability. Video input requires the `video_in` capability.
+
+Models like [Kimi K2.5](https://huggingface.co/moonshotai/Kimi-K2.5) support video understanding with strong performance on benchmarks like VideoMMMU (86.6), VideoMME (87.4), and LongVideoBench (79.8).
 :::
 
 ## Slash commands

--- a/docs/zh/guides/interaction.md
+++ b/docs/zh/guides/interaction.md
@@ -45,14 +45,30 @@ Thinking 模式需要当前模型支持。部分模型（如 `kimi-k2-thinking-t
 
 输入完成后，按 `Enter` 发送整条消息。
 
-## 剪贴板与图片粘贴
+## 剪贴板与媒体粘贴
 
-按 `Ctrl-V` 可以粘贴剪贴板中的文本或图片。
+按 `Ctrl-V` 可以粘贴剪贴板中的文本、图片或视频文件。
 
-如果剪贴板中是图片，Kimi Code CLI 会自动将图片作为附件添加到消息中。发送消息后，AI 可以看到并分析这张图片。
+如果剪贴板中是**图片**，Kimi Code CLI 会自动将图片作为附件添加到消息中。发送消息后，AI 可以看到并分析这张图片。
+
+如果剪贴板中是**视频文件路径**，Kimi Code CLI 会插入该视频文件的引用。AI 随后可以使用 `ReadMediaFile` 工具读取和分析视频内容。
+
+支持的视频格式包括：MP4、MKV、AVI、MOV、WMV、WebM、M4V、FLV、3GP 和 3G2。
+
+### Print 模式（非交互式）中的视频输入
+
+在使用 [Print 模式](../customization/print-mode.md) 配合 `-c` 或 `--command` 时，你可以直接引用视频文件：
+
+```sh
+kimi --print -c "分析这个视频 /path/to/video.mp4"
+```
+
+Kimi Code CLI 会自动检测命令中的视频文件路径，并让 AI 进行分析。
 
 ::: tip 提示
 图片输入需要当前模型支持 `image_in` 能力，视频输入需要支持 `video_in` 能力。
+
+像 [Kimi K2.5](https://huggingface.co/moonshotai/Kimi-K2.5) 这样的模型支持视频理解，在 VideoMMMU (86.6)、VideoMME (87.4) 和 LongVideoBench (79.8) 等基准测试中表现优异。
 :::
 
 ## 斜杠命令

--- a/src/kimi_cli/tools/file/utils.py
+++ b/src/kimi_cli/tools/file/utils.py
@@ -52,6 +52,9 @@ _VIDEO_MIME_BY_SUFFIX = {
     ".3gp": "video/3gpp",
     ".3g2": "video/3gpp2",
 }
+
+# Public export for video extensions mapping
+VIDEO_EXTENSIONS = _VIDEO_MIME_BY_SUFFIX
 _TEXT_MIME_BY_SUFFIX = {
     ".svg": "image/svg+xml",
 }

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -43,7 +43,12 @@ from kimi_cli.llm import ModelCapability
 from kimi_cli.share import get_share_dir
 from kimi_cli.soul import StatusSnapshot, format_context_status
 from kimi_cli.ui.shell.console import console
-from kimi_cli.utils.clipboard import grab_image_from_clipboard, is_clipboard_available
+from kimi_cli.utils.clipboard import (
+    ClipboardVideo,
+    grab_image_from_clipboard,
+    grab_video_from_clipboard,
+    is_clipboard_available,
+)
 from kimi_cli.utils.logging import logger
 from kimi_cli.utils.media_tags import wrap_media_part
 from kimi_cli.utils.slashcmd import SlashCommand
@@ -531,7 +536,7 @@ def _build_image_part(image_bytes: bytes, mime_type: str) -> ImageURLPart:
     )
 
 
-type CachedAttachmentKind = Literal["image"]
+type CachedAttachmentKind = Literal["image", "video"]
 
 
 @dataclass(slots=True)
@@ -544,8 +549,10 @@ class CachedAttachment:
 class AttachmentCache:
     def __init__(self, root: Path | None = None) -> None:
         self._root = root or Path("/tmp/kimi")
-        self._dir_map: dict[CachedAttachmentKind, str] = {"image": "images"}
+        self._dir_map: dict[CachedAttachmentKind, str] = {"image": "images", "video": "videos"}
         self._payload_map: dict[tuple[CachedAttachmentKind, str, str], CachedAttachment] = {}
+        # For video references, we store path references without copying
+        self._video_refs: dict[str, Path] = {}
 
     def _dir_for(self, kind: CachedAttachmentKind) -> Path:
         return self._root / self._dir_map[kind]
@@ -604,6 +611,34 @@ class AttachmentCache:
         image.save(png_bytes, format="PNG")
         return self.store_bytes("image", ".png", png_bytes.getvalue())
 
+    def store_video_reference(self, video: ClipboardVideo) -> CachedAttachment | None:
+        """Store a video file path reference (does not copy the file).
+
+        Videos are referenced by their original path rather than being copied to cache
+        to avoid unnecessary disk usage for potentially large files.
+        """
+        dir_path = self._ensure_dir("video")
+        if dir_path is None:
+            return None
+
+        # Create a reference file containing the original path
+        attachment_id = self._reserve_id(dir_path, ".ref")
+        ref_path = dir_path / attachment_id
+        try:
+            ref_path.write_text(str(video.path), encoding="utf-8")
+        except OSError as exc:
+            logger.warning(
+                "Failed to write video reference file: {file} ({error})",
+                file=ref_path,
+                error=exc,
+            )
+            return None
+
+        cached = CachedAttachment(kind="video", attachment_id=attachment_id, path=ref_path)
+        # Store the original video path for quick lookup
+        self._video_refs[attachment_id] = video.path
+        return cached
+
     def load_bytes(
         self, kind: CachedAttachmentKind, attachment_id: str
     ) -> tuple[Path, bytes] | None:
@@ -631,12 +666,31 @@ class AttachmentCache:
             mime_type = _guess_image_mime(path)
             part = _build_image_part(image_bytes, mime_type)
             return wrap_media_part(part, tag="image", attrs={"path": str(path)})
+        if kind == "video":
+            # Get the original video path from the reference
+            video_path = self._video_refs.get(attachment_id)
+            if video_path is None:
+                # Try to read from the reference file
+                ref_path = self._dir_for("video") / attachment_id
+                if not ref_path.exists():
+                    return None
+                try:
+                    video_path = Path(ref_path.read_text(encoding="utf-8").strip())
+                    self._video_refs[attachment_id] = video_path
+                except (OSError, ValueError):
+                    return None
+            if not video_path.exists():
+                return None
+            # Return as text part with @ mention for the agent to read via ReadMediaFile
+            return [TextPart(text=f"@{video_path}")]
         return None
 
 
 def _parse_attachment_kind(raw_kind: str) -> CachedAttachmentKind | None:
     if raw_kind == "image":
         return "image"
+    if raw_kind == "video":
+        return "video"
     return None
 
 
@@ -734,7 +788,10 @@ class CustomPromptSession:
 
             @_kb.add("c-v", eager=True)
             def _(event: KeyPressEvent) -> None:
+                # Try to paste image first, then video, then fall back to text
                 if self._try_paste_image(event):
+                    return
+                if self._try_paste_video(event):
                     return
                 clipboard_data = event.app.clipboard.get_data()
                 event.current_buffer.paste_clipboard_data(clipboard_data)
@@ -859,6 +916,30 @@ class CustomPromptSession:
         )
 
         placeholder = f"[image:{cached.attachment_id},{image.width}x{image.height}]"
+        event.current_buffer.insert_text(placeholder)
+        event.app.invalidate()
+        return True
+
+    def _try_paste_video(self, event: KeyPressEvent) -> bool:
+        """Try to paste a video file from the clipboard. Return True if successful."""
+        video = grab_video_from_clipboard()
+        if video is None:
+            return False
+
+        if "video_in" not in self._model_capabilities:
+            console.print("[yellow]Video input is not supported by the selected LLM model[/yellow]")
+            return False
+
+        cached = self._attachment_cache.store_video_reference(video)
+        if cached is None:
+            return False
+        logger.debug(
+            "Pasted video from clipboard: {attachment_id}, {video_path}",
+            attachment_id=cached.attachment_id,
+            video_path=video.path,
+        )
+
+        placeholder = f"[video:{cached.attachment_id}]"
         event.current_buffer.insert_text(placeholder)
         event.app.invalidate()
         return True

--- a/tests/test_attachment_cache.py
+++ b/tests/test_attachment_cache.py
@@ -5,6 +5,7 @@ import base64
 from PIL import Image
 
 from kimi_cli.ui.shell.prompt import AttachmentCache, _parse_attachment_kind
+from kimi_cli.utils.clipboard import ClipboardVideo
 from kimi_cli.wire.types import ImageURLPart, TextPart
 
 
@@ -51,3 +52,61 @@ def test_attachment_cache_dedupes_bytes(tmp_path) -> None:
     assert cached_first.path == cached_second.path
     assert cached_first.path.read_bytes() == payload
     assert len(list((tmp_path / "images").iterdir())) == 1
+
+
+def test_parse_attachment_kind_video() -> None:
+    assert _parse_attachment_kind("video") == "video"
+    assert _parse_attachment_kind("unknown") is None
+
+
+def test_attachment_cache_video_reference(tmp_path) -> None:
+    cache = AttachmentCache(root=tmp_path)
+    video_path = tmp_path / "test_video.mp4"
+    video_path.write_text("fake video content")
+
+    video = ClipboardVideo(path=video_path)
+    cached = cache.store_video_reference(video)
+    assert cached is not None
+    assert cached.path.exists()
+    assert cached.path.parent == tmp_path / "videos"
+    assert cached.path.read_text() == str(video_path)
+
+
+def test_attachment_cache_video_load_parts(tmp_path) -> None:
+    cache = AttachmentCache(root=tmp_path)
+    video_path = tmp_path / "test_video.mp4"
+    video_path.write_text("fake video content")
+
+    video = ClipboardVideo(path=video_path)
+    cached = cache.store_video_reference(video)
+    assert cached is not None
+
+    parts = cache.load_content_parts("video", cached.attachment_id)
+    assert parts is not None
+    assert len(parts) == 1
+    assert isinstance(parts[0], TextPart)
+    assert parts[0].text == f"@{video_path}"
+
+
+def test_attachment_cache_video_missing_file(tmp_path) -> None:
+    cache = AttachmentCache(root=tmp_path)
+    # Try to load a non-existent video
+    parts = cache.load_content_parts("video", "nonexistent.ref")
+    assert parts is None
+
+
+def test_attachment_cache_video_removed_original(tmp_path) -> None:
+    cache = AttachmentCache(root=tmp_path)
+    video_path = tmp_path / "test_video.mp4"
+    video_path.write_text("fake video content")
+
+    video = ClipboardVideo(path=video_path)
+    cached = cache.store_video_reference(video)
+    assert cached is not None
+
+    # Remove the original video file
+    video_path.unlink()
+
+    # Should return None because the original file is gone
+    parts = cache.load_content_parts("video", cached.attachment_id)
+    assert parts is None

--- a/tests/test_print_video.py
+++ b/tests/test_print_video.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from kimi_cli.ui.print import _build_content_parts, _extract_video_paths
+from kimi_cli.wire.types import TextPart
+
+
+class TestExtractVideoPaths:
+    def test_no_video_paths(self, tmp_path):
+        text = "This is just some text without any video files"
+        result = _extract_video_paths(text)
+        assert result == []
+
+    def test_single_video_path(self, tmp_path):
+        video_file = tmp_path / "test_video.mp4"
+        video_file.write_text("fake video content")
+        
+        text = f"Please analyze {video_file} for me"
+        result = _extract_video_paths(text)
+        
+        assert len(result) == 1
+        start, end, path = result[0]
+        assert path == video_file
+        assert text[start:end] == str(video_file)
+
+    def test_multiple_video_paths(self, tmp_path):
+        video1 = tmp_path / "first.mkv"
+        video2 = tmp_path / "second.mov"
+        video1.write_text("fake content 1")
+        video2.write_text("fake content 2")
+        
+        text = f"Compare {video1} with {video2}"
+        result = _extract_video_paths(text)
+        
+        assert len(result) == 2
+        assert result[0][2] == video1
+        assert result[1][2] == video2
+
+    def test_video_path_with_at_mention(self, tmp_path):
+        video_file = tmp_path / "clip.webm"
+        video_file.write_text("fake video")
+        
+        text = f"Check out @{video_file}"
+        result = _extract_video_paths(text)
+        
+        assert len(result) == 1
+        assert result[0][2] == video_file
+
+    def test_nonexistent_video_file(self, tmp_path):
+        video_file = tmp_path / "does_not_exist.mp4"
+        
+        text = f"Analyze {video_file}"
+        result = _extract_video_paths(text)
+        
+        # Should not include files that don't exist
+        assert result == []
+
+    def test_non_video_file(self, tmp_path):
+        text_file = tmp_path / "readme.txt"
+        text_file.write_text("just text")
+        
+        text = f"Read {text_file}"
+        result = _extract_video_paths(text)
+        
+        # Should not include non-video files
+        assert result == []
+
+
+class TestBuildContentParts:
+    def test_plain_text_no_videos(self):
+        command = "Just a simple command"
+        parts = _build_content_parts(command)
+        
+        assert len(parts) == 1
+        assert isinstance(parts[0], TextPart)
+        assert parts[0].text == command
+
+    def test_single_video(self, tmp_path):
+        video_file = tmp_path / "test.avi"
+        video_file.write_text("fake video")
+        
+        command = f"Analyze this video: {video_file}"
+        parts = _build_content_parts(command)
+        
+        # Should have: text + video tag open + video tag close (no trailing text)
+        assert len(parts) == 3
+        assert parts[0].text == "Analyze this video: "
+        assert '<video path="' in parts[1].text
+        assert '</video>' in parts[2].text
+
+    def test_multiple_videos(self, tmp_path):
+        video1 = tmp_path / "a.mp4"
+        video2 = tmp_path / "b.mkv"
+        video1.write_text("v1")
+        video2.write_text("v2")
+        
+        command = f"Compare {video1} and {video2} please"
+        parts = _build_content_parts(command)
+        
+        # Should have text parts and video tags for both videos
+        # text + video1 open/close + text + video2 open/close + text = 7 parts
+        assert len(parts) == 7
+        assert "Compare " in parts[0].text
+        assert str(video1) in parts[1].text
+        assert " and " in parts[3].text
+        assert str(video2) in parts[4].text
+        assert " please" in parts[6].text
+
+    def test_video_with_mime_type(self, tmp_path):
+        # Test MKV file gets correct mime type
+        video_file = tmp_path / "movie.mkv"
+        video_file.write_text("fake mkv")
+        
+        command = str(video_file)
+        parts = _build_content_parts(command)
+        
+        assert len(parts) == 2
+        assert 'content_type="video/x-matroska"' in parts[0].text
+
+    def test_mp4_with_mime_type(self, tmp_path):
+        video_file = tmp_path / "clip.mp4"
+        video_file.write_text("fake mp4")
+        
+        command = str(video_file)
+        parts = _build_content_parts(command)
+        
+        assert 'content_type="video/mp4"' in parts[0].text
+
+    def test_all_supported_extensions(self, tmp_path):
+        extensions = [".mp4", ".mkv", ".avi", ".mov", ".wmv", ".webm", ".m4v", ".flv", ".3gp", ".3g2"]
+        
+        for ext in extensions:
+            video_file = tmp_path / f"test{ext}"
+            video_file.write_text("fake")
+            
+            result = _extract_video_paths(str(video_file))
+            assert len(result) == 1, f"Extension {ext} should be detected"
+            assert result[0][2].suffix.lower() == ext


### PR DESCRIPTION
## Summary

Add video clipboard paste support (Ctrl-V) in shell mode and automatic video file detection in print mode.

## Changes

- Support all major video formats: MP4, MKV, AVI, MOV, WMV, WebM, M4V, FLV, 3GP, 3G2
- Shell mode: Paste video files from clipboard with Ctrl-V
- Print mode: Automatic video file detection for non-interactive usage
- Updated documentation for video input capabilities

## Testing

1. Copy a video file path to clipboard
2. Run `kimi` and press Ctrl-V
3. Verify video is attached to the conversation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
