### PR TITLE
Fix minor bugs in file tools and UI feedback

### DIFF
--- a/src/kimi_cli/tools/file/read.py
+++ b/src/kimi_cli/tools/file/read.py
@@ -177,7 +177,9 @@ class ReadFile(CallableTool2[Params]):
             elif len(lines) < params.n_lines:
                 message += " End of file reached."
             if truncated_line_numbers:
-                message += f" Lines {truncated_line_numbers} were truncated."
+                # Format line numbers as comma-separated list for better readability
+                lines_str = ", ".join(str(n) for n in truncated_line_numbers)
+                message += f" Lines {lines_str} were truncated."
             return ToolOk(
                 output="".join(lines_with_no),  # lines already contain \n, just join them
                 message=message,

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -135,13 +135,17 @@ class StrReplaceFile(CallableTool2[Params]):
             # Write the modified content back to the file
             await p.write_text(content, errors="replace")
 
-            # Count changes for success message
+            # Count changes for success message by re-applying edits to count
             total_replacements = 0
+            temp_content = original_content
             for edit in edits:
                 if edit.replace_all:
-                    total_replacements += original_content.count(edit.old)
+                    total_replacements += temp_content.count(edit.old)
+                    temp_content = temp_content.replace(edit.old, edit.new)
                 else:
-                    total_replacements += 1 if edit.old in original_content else 0
+                    if edit.old in temp_content:
+                        total_replacements += 1
+                        temp_content = temp_content.replace(edit.old, edit.new, 1)
 
             return ToolReturnValue(
                 is_error=False,

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -395,8 +395,9 @@ def feedback(app: Shell, args: str):
 
     ISSUE_URL = "https://github.com/MoonshotAI/kimi-cli/issues"
     if webbrowser.open(ISSUE_URL):
-        return
-    console.print(f"Please submit feedback at [underline]{ISSUE_URL}[/underline].")
+        console.print("Opening GitHub issues in your browser...")
+    else:
+        console.print(f"Could not open browser. Please visit: [underline]{ISSUE_URL}[/underline]")
 
 
 @registry.command(aliases=["reset"])

--- a/tests/tools/test_read_file.py
+++ b/tests/tools/test_read_file.py
@@ -288,8 +288,7 @@ async def test_line_truncation_and_messaging(read_file_tool: ReadFile, temp_work
     assert not result.is_error
     assert isinstance(result.output, str)
     assert result.message == snapshot(
-        "3 lines read from file starting from line 1. End of file reached. "
-        "Lines [1, 3] were truncated."
+        "3 lines read from file starting from line 1. End of file reached. Lines 1, 3 were truncated."
     )
 
     # Verify truncation actually happened for specific lines


### PR DESCRIPTION
## Summary

This PR fixes three minor bugs that improve user experience and correctness:

### 1. Fix replacement count calculation in StrReplaceFile

When multiple edits are provided to `StrReplaceFile`, the replacement count was calculated based on `original_content`, which didn't account for cumulative changes from previous edits. This could result in incorrect replacement counts being reported to the user.

**Fix**: Re-apply edits sequentially on a temporary copy to correctly count actual replacements.

### 2. Fix truncated line numbers formatting in ReadFile

The truncated line numbers were displayed as Python list representation (e.g., `Lines [1, 3] were truncated`), which is not user-friendly.

**Fix**: Format as comma-separated list (e.g., `Lines 1, 3 were truncated`).

### 3. Improve webbrowser.open() handling in /feedback command

The `/feedback` command had no feedback when the browser opened successfully, leaving users uncertain.

**Fix**: Show appropriate message whether browser opens successfully or not.

## Test plan

- All existing tests pass (34 tests in test_str_replace_file.py and test_read_file.py)
- Code formatting and type checking pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
