### PR TITLE
fix: handle empty tools list in OpenAILegacy provider

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -127,15 +127,22 @@ class OpenAILegacy:
         generation_kwargs.update(self._generation_kwargs)
 
         try:
-            response = await self.client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                tools=(tool_to_openai(tool) for tool in tools),
-                stream=self.stream,
-                stream_options={"include_usage": True} if self.stream else omit,
-                reasoning_effort=self._reasoning_effort,
+            # Build request kwargs, only include tools if non-empty
+            # Some APIs (like DashScope) reject empty tools list
+            request_kwargs: dict[str, Any] = {
+                "model": self.model,
+                "messages": messages,
+                "stream": self.stream,
                 **generation_kwargs,
-            )
+            }
+            if tools:
+                request_kwargs["tools"] = (tool_to_openai(tool) for tool in tools)
+            if self.stream:
+                request_kwargs["stream_options"] = {"include_usage": True}
+            if self._reasoning_effort is not omit:
+                request_kwargs["reasoning_effort"] = self._reasoning_effort
+            
+            response = await self.client.chat.completions.create(**request_kwargs)
             return OpenAILegacyStreamedMessage(response, self._reasoning_key)
         except (OpenAIError, httpx.HTTPError) as e:
             raise convert_error(e) from e


### PR DESCRIPTION
Some OpenAI-compatible APIs (like DashScope/Aliyun) reject requests with empty tools list.

This fix only includes the 'tools' parameter when tools are actually present.

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

N/A - This is a minor bug fix (15 lines of code) that addresses an API compatibility issue.

## Description

### Problem

When `kosong.step()` is called with `EmptyToolset()` (e.g., during context compaction), the `OpenAILegacy` provider sends an empty tools list to the API. Some OpenAI-compatible APIs (like DashScope/Aliyun) strictly validate the request and reject empty tools lists with error:

```
Error code: 400 - {'error': {'message': "[] is too short - 'tools'", 'type': 'invalid_request_error'}}
```

This prevents context compaction from working when using these APIs.

### Solution

Modified `OpenAILegacy.generate()` to only include the `tools` parameter in the API request when tools are actually present (non-empty). The fix builds request kwargs dynamically:

- Always include: `model`, `messages`, `stream`, generation kwargs
- Conditionally include: `tools` (only if non-empty), `stream_options` (only if streaming), `reasoning_effort` (only if set)

### Changes

- `packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py`: Modified `generate()` method to conditionally include `tools` parameter

## Testing

- [x] Tested with DashScope API (deepseek-v3 model)
- [x] Context compaction now works without errors
- [x] Normal tool calls continue to work as expected
- [x] Empty tools list no longer triggers API error

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any. (N/A - no existing issue for this specific bug)
- [ ] I have added tests that prove my fix is effective or that my feature works. (Minor fix, existing tests cover the functionality)
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

## Notes for Reviewers

This is a minimal, backward-compatible fix that only affects request building logic in the OpenAILegacy provider. The change ensures compatibility with stricter OpenAI-compatible APIs while maintaining existing behavior for all other use cases.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
