### PR TITLE
fix: strip whitespace from oauth header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Core: Pass session ID as `user_id` metadata to Anthropic API
+- Core: Strip whitespace from OAuth header values to prevent encoding errors
 
 ## 1.17.0 (2026-03-03)
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -5,6 +5,7 @@ This page documents the changes in each Kimi Code CLI release.
 ## Unreleased
 
 - Core: Pass session ID as `user_id` metadata to Anthropic API
+- Core: Strip whitespace from OAuth header values to prevent encoding errors
 
 ## 1.17.0 (2026-03-03)
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -5,6 +5,7 @@
 ## 未发布
 
 - Core：将会话 ID 作为 `user_id` 元数据传递给 Anthropic API
+- Core：对 OAuth 头字段值去除首尾空白，避免编码错误
 
 ## 1.17.0 (2026-03-03)
 

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -193,9 +193,10 @@ def get_device_id() -> str:
 
 
 def _ascii_header_value(value: str, *, fallback: str = "unknown") -> str:
+    value = value.strip()
     try:
         value.encode("ascii")
-        return value
+        return value or fallback
     except UnicodeEncodeError:
         sanitized = value.encode("ascii", errors="ignore").decode("ascii").strip()
         return sanitized or fallback

--- a/tests/utils/test_utils_environment.py
+++ b/tests/utils/test_utils_environment.py
@@ -3,6 +3,8 @@ import platform
 import pytest
 from kaos.path import KaosPath
 
+from kimi_cli.auth.oauth import _ascii_header_value, _common_headers
+
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Skipping test on Windows")
 async def test_environment_detection(monkeypatch):
@@ -39,3 +41,28 @@ async def test_environment_detection_windows(monkeypatch):
     assert env.os_version == "10.0.19044"
     assert env.shell_name == "Windows PowerShell"
     assert str(env.shell_path) == "powershell.exe"
+
+
+def test_ascii_header_value_strips_ascii_whitespace():
+    assert _ascii_header_value("  value  ") == "value"
+    assert _ascii_header_value("   ") == "unknown"
+
+
+def test_common_headers_strip_os_version(monkeypatch):
+    monkeypatch.setattr(platform, "node", lambda: "host")
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(platform, "release", lambda: "6.8.0-101-generic")
+    monkeypatch.setattr(
+        platform,
+        "version",
+        lambda: "#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC ",
+    )
+    monkeypatch.setattr("kimi_cli.auth.oauth.get_device_id", lambda: "device-id")
+
+    headers = _common_headers()
+
+    assert (
+        headers["X-Msh-Os-Version"]
+        == "#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC"
+    )


### PR DESCRIPTION
## Related Issue

Resolve #886, ##414

## Description

Strip leading and trailing whitespace from OAuth/common header values before sending requests. This fixes X-Msh-Os-Version when platform.version() includes trailing whitespace and prevents httpx.LocalProtocolError.

Observed in logs:

httpcore.LocalProtocolError: Illegal header value `b'#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC '`
httpx.LocalProtocolError: Illegal header value `b'#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC '`
openai.APIConnectionError: Connection error.
kosong.chat_provider.APIConnectionError: Connection error.

## Checklist

- [x] I have read the CONTRIBUTING (https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run make gen-changelog to update the changelog.
- [x] I have run make gen-docs to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
