### PR TITLE
fix(acp): route shell commands through terminal args

### DIFF
--- a/src/kimi_cli/acp/tools.py
+++ b/src/kimi_cli/acp/tools.py
@@ -56,6 +56,7 @@ class Terminal(CallableTool2[ShellParams]):
         # Use the `name`, `description`, and `params` from the existing Shell tool,
         # so that when this is added to the toolset, it replaces the original Shell tool.
         super().__init__(shell_tool.name, shell_tool.description, shell_tool.params)
+        self._shell_tool = shell_tool
         self._acp_conn = acp_conn
         self._acp_session_id = acp_session_id
         self._approval = approval
@@ -80,23 +81,21 @@ class Terminal(CallableTool2[ShellParams]):
 
         timeout_seconds = float(params.timeout)
         timeout_label = f"{timeout_seconds:g}s"
-        terminal: acp.TerminalHandle | None = None
+        terminal_id: str | None = None
         exit_status: (
             acp.schema.WaitForTerminalExitResponse | acp.schema.TerminalExitStatus | None
         ) = None
         timed_out = False
 
         try:
+            shell_argv = self._shell_tool._shell_args(params.command)
             term = await self._acp_conn.create_terminal(
-                command=params.command,
+                command=shell_argv[0],
                 session_id=self._acp_session_id,
+                args=list(shell_argv[1:]),
                 output_byte_limit=builder.max_chars,
             )
-            # FIXME: update ACP sdk for the fix
-            assert isinstance(term, acp.TerminalHandle), (
-                "Expected TerminalHandle from create_terminal"
-            )
-            terminal = term
+            terminal_id = term.terminal_id
 
             acp_tool_call_id = get_current_acp_tool_call_id_or_none()
             assert acp_tool_call_id, "Expected to have an ACP tool call ID in context"
@@ -109,7 +108,7 @@ class Terminal(CallableTool2[ShellParams]):
                     content=[
                         acp.schema.TerminalToolCallContent(
                             type="terminal",
-                            terminal_id=terminal.id,
+                            terminal_id=terminal_id,
                         )
                     ],
                 ),
@@ -117,12 +116,21 @@ class Terminal(CallableTool2[ShellParams]):
 
             try:
                 async with asyncio.timeout(timeout_seconds):
-                    exit_status = await terminal.wait_for_exit()
+                    exit_status = await self._acp_conn.wait_for_terminal_exit(
+                        session_id=self._acp_session_id,
+                        terminal_id=terminal_id,
+                    )
             except TimeoutError:
                 timed_out = True
-                await terminal.kill()
+                await self._acp_conn.kill_terminal(
+                    session_id=self._acp_session_id,
+                    terminal_id=terminal_id,
+                )
 
-            output_response = await terminal.current_output()
+            output_response = await self._acp_conn.terminal_output(
+                session_id=self._acp_session_id,
+                terminal_id=terminal_id,
+            )
             builder.write(output_response.output)
             if output_response.exit_status:
                 exit_status = output_response.exit_status
@@ -153,6 +161,9 @@ class Terminal(CallableTool2[ShellParams]):
                 )
             return builder.ok(f"Command executed successfully.{truncated_note}")
         finally:
-            if terminal is not None:
+            if terminal_id is not None:
                 with suppress(Exception):
-                    await terminal.release()
+                    await self._acp_conn.release_terminal(
+                        session_id=self._acp_session_id,
+                        terminal_id=terminal_id,
+                    )

--- a/src/kimi_cli/acp/tools.py
+++ b/src/kimi_cli/acp/tools.py
@@ -88,7 +88,7 @@ class Terminal(CallableTool2[ShellParams]):
         timed_out = False
 
         try:
-            shell_argv = self._shell_tool._shell_args(params.command)
+            shell_argv = self._shell_tool.shell_args(params.command)
             term = await self._acp_conn.create_terminal(
                 command=shell_argv[0],
                 session_id=self._acp_session_id,

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -107,7 +107,7 @@ class Shell(CallableTool2[Params]):
                 else:
                     break
 
-        process = await kaos.exec(*self._shell_args(command), env=get_clean_env())
+        process = await kaos.exec(*self.shell_args(command), env=get_clean_env())
 
         try:
             await asyncio.wait_for(
@@ -122,7 +122,10 @@ class Shell(CallableTool2[Params]):
             await process.kill()
             raise
 
-    def _shell_args(self, command: str) -> tuple[str, ...]:
+    def shell_args(self, command: str) -> tuple[str, ...]:
         if self._is_powershell:
             return (str(self._shell_path), "-command", command)
         return (str(self._shell_path), "-c", command)
+
+    def _shell_args(self, command: str) -> tuple[str, ...]:
+        return self.shell_args(command)

--- a/tests/acp/test_terminal_tool.py
+++ b/tests/acp/test_terminal_tool.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+import acp
+import pytest
+
+from kimi_cli.acp.tools import Terminal
+from kimi_cli.soul.approval import Approval
+from kimi_cli.tools.shell import Shell
+from kimi_cli.tools.shell import Params as ShellParams
+from tests.conftest import tool_call_context
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeACPConn:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def create_terminal(
+        self,
+        command: str,
+        session_id: str,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        env: list[acp.schema.EnvVariable] | None = None,
+        output_byte_limit: int | None = None,
+        **kwargs: Any,
+    ) -> acp.schema.CreateTerminalResponse:
+        self.calls.append(
+            (
+                "create_terminal",
+                {
+                    "command": command,
+                    "session_id": session_id,
+                    "args": args,
+                    "cwd": cwd,
+                    "env": env,
+                    "output_byte_limit": output_byte_limit,
+                },
+            )
+        )
+        return acp.schema.CreateTerminalResponse(terminal_id="term-1")
+
+    async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
+        self.calls.append(("session_update", {"session_id": session_id, "update": update}))
+
+    async def wait_for_terminal_exit(
+        self, session_id: str, terminal_id: str, **kwargs: Any
+    ) -> acp.schema.WaitForTerminalExitResponse:
+        self.calls.append(("wait_for_terminal_exit", {"session_id": session_id, "terminal_id": terminal_id}))
+        return acp.schema.WaitForTerminalExitResponse(exit_code=0)
+
+    async def terminal_output(
+        self, session_id: str, terminal_id: str, **kwargs: Any
+    ) -> acp.schema.TerminalOutputResponse:
+        self.calls.append(("terminal_output", {"session_id": session_id, "terminal_id": terminal_id}))
+        return acp.schema.TerminalOutputResponse(
+            output="ok\n",
+            truncated=False,
+            exit_status=acp.schema.TerminalExitStatus(exit_code=0),
+        )
+
+    async def kill_terminal(self, session_id: str, terminal_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("kill_terminal", {"session_id": session_id, "terminal_id": terminal_id}))
+        return {}
+
+    async def release_terminal(self, session_id: str, terminal_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("release_terminal", {"session_id": session_id, "terminal_id": terminal_id}))
+        return {}
+
+
+@pytest.mark.parametrize(
+    ("shell_name", "shell_path", "expected_command", "expected_args"),
+    [
+        ("bash", "/bin/bash", "/bin/bash", ["-c", "echo test"]),
+        ("Windows PowerShell", "powershell.exe", "powershell.exe", ["-command", "echo test"]),
+    ],
+)
+async def test_terminal_shell_passes_executable_and_args(
+    monkeypatch: pytest.MonkeyPatch,
+    approval: Approval,
+    environment,
+    shell_name: str,
+    shell_path: str,
+    expected_command: str,
+    expected_args: list[str],
+):
+    from kimi_cli.acp import session as acp_session
+    from kimi_cli.utils.environment import Environment
+    from kaos.path import KaosPath
+
+    fake_conn = _FakeACPConn()
+    env = Environment(
+        os_kind=environment.os_kind,
+        os_arch=environment.os_arch,
+        os_version=environment.os_version,
+        shell_name=shell_name,
+        shell_path=KaosPath(shell_path),
+    )
+    shell_tool = Shell(approval, env)
+    terminal = Terminal(shell_tool, fake_conn, "session-1", approval)
+
+    monkeypatch.setattr(acp_session, "get_current_acp_tool_call_id_or_none", lambda: "tool-1")
+
+    with tool_call_context("Shell"):
+        result = await terminal(ShellParams(command="echo test", timeout=10))
+
+    create_call = next(call for call in fake_conn.calls if call[0] == "create_terminal")
+    assert create_call[1]["command"] == expected_command
+    assert create_call[1]["args"] == expected_args
+    assert ("wait_for_terminal_exit", {"session_id": "session-1", "terminal_id": "term-1"}) in fake_conn.calls
+    assert ("terminal_output", {"session_id": "session-1", "terminal_id": "term-1"}) in fake_conn.calls
+    assert ("release_terminal", {"session_id": "session-1", "terminal_id": "term-1"}) in fake_conn.calls
+    assert result.is_error is False

--- a/tests/acp/test_terminal_tool.py
+++ b/tests/acp/test_terminal_tool.py
@@ -78,7 +78,7 @@ class _FakeACPConn:
         ("Windows PowerShell", "powershell.exe", "powershell.exe", ["-command", "echo test"]),
     ],
 )
-async def test_terminal_shell_passes_executable_and_args(
+async def test_terminal_shell_uses_public_shell_args(
     monkeypatch: pytest.MonkeyPatch,
     approval: Approval,
     environment,

--- a/tests/tools/test_shell_invocation.py
+++ b/tests/tools/test_shell_invocation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from kaos.path import KaosPath
+
+from kimi_cli.soul.approval import Approval
+from kimi_cli.tools.shell import Shell
+from kimi_cli.utils.environment import Environment
+
+
+def test_shell_args_for_bash() -> None:
+    shell = Shell(
+        Approval(yolo=True),
+        Environment(
+            os_kind="Unix",
+            os_arch="aarch64",
+            os_version="1.0",
+            shell_name="bash",
+            shell_path=KaosPath("/bin/bash"),
+        ),
+    )
+
+    assert shell.shell_args("echo test") == ("/bin/bash", "-c", "echo test")
+
+
+def test_shell_args_for_powershell() -> None:
+    shell = Shell(
+        Approval(yolo=True),
+        Environment(
+            os_kind="Windows",
+            os_arch="x86_64",
+            os_version="1.0",
+            shell_name="Windows PowerShell",
+            shell_path=KaosPath("powershell.exe"),
+        ),
+    )
+
+    assert shell.shell_args("echo test") == ("powershell.exe", "-command", "echo test")


### PR DESCRIPTION
## Summary
- fix ACP Shell terminal execution to pass the shell executable in `command` and the shell invocation in `args`
- adapt the ACP terminal integration to the current ACP SDK response shape using `terminal_id`
- add a regression test covering bash and PowerShell command/args routing

## Problem
When `kimi acp` was used behind ACP clients with terminal support, Shell commands like `echo test` could fail with errors like:

- `spawn echo test ENOENT`
- `spawn ls -la ENOENT`

The ACP terminal adapter passed the entire shell command string as `terminal/create.command`, which made clients try to spawn the full string as an executable path.

The adapter also assumed `create_terminal()` returned a `TerminalHandle`, but the current ACP SDK returns a response containing `terminal_id`, with follow-up terminal operations happening through separate RPC methods.

## Fix
- use the existing Shell tool's `_shell_args()` to split shell execution into executable + args
- call `terminal/create` with:
  - `command=<shell executable>`
  - `args=[shell flags..., user command]`
- use `terminal_id` with `terminal/wait_for_exit`, `terminal/output`, `terminal/kill`, and `terminal/release`

## Validation
- `uv run pytest tests/acp/test_protocol_v1.py tests/acp/test_terminal_tool.py -q`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
