### PR TITLE
fix: replace removed acp.TerminalHandle with Client terminal methods

### DIFF
--- a/src/kimi_cli/acp/kaos.py
+++ b/src/kimi_cli/acp/kaos.py
@@ -46,11 +46,15 @@ class ACPProcess:
 
     def __init__(
         self,
-        terminal: acp.TerminalHandle,
+        client: acp.Client,
+        session_id: str,
+        terminal_id: str,
         *,
         poll_interval: float = _DEFAULT_POLL_INTERVAL,
     ) -> None:
-        self._terminal = terminal
+        self._client = client
+        self._session_id = session_id
+        self._terminal_id = terminal_id
         self._poll_interval = poll_interval
         self._stdin = _NullWritable()
         self._stdout = asyncio.StreamReader()
@@ -77,7 +81,10 @@ class ACPProcess:
         return await self._exit_future
 
     async def kill(self) -> None:
-        await self._terminal.kill()
+        await self._client.kill_terminal(
+            session_id=self._session_id,
+            terminal_id=self._terminal_id,
+        )
 
     def _feed_output(self, output_response: acp.schema.TerminalOutputResponse) -> None:
         output = output_response.output
@@ -98,7 +105,12 @@ class ACPProcess:
         return 1 if exit_code is None else exit_code
 
     async def _poll_output(self) -> None:
-        exit_task = asyncio.create_task(self._terminal.wait_for_exit())
+        exit_task = asyncio.create_task(
+            self._client.wait_for_terminal_exit(
+                session_id=self._session_id,
+                terminal_id=self._terminal_id,
+            )
+        )
         exit_code: int | None = None
         try:
             while True:
@@ -107,7 +119,10 @@ class ACPProcess:
                     exit_code = exit_response.exit_code
                     break
 
-                output_response = await self._terminal.current_output()
+                output_response = await self._client.terminal_output(
+                    session_id=self._session_id,
+                    terminal_id=self._terminal_id,
+                )
                 self._feed_output(output_response)
                 if output_response.exit_status:
                     exit_code = output_response.exit_status.exit_code
@@ -120,7 +135,10 @@ class ACPProcess:
 
                 await asyncio.sleep(self._poll_interval)
 
-            final_output = await self._terminal.current_output()
+            final_output = await self._client.terminal_output(
+                session_id=self._session_id,
+                terminal_id=self._terminal_id,
+            )
             self._feed_output(final_output)
         except Exception as exc:
             error_note = f"[acp terminal error] {exc}\n"
@@ -138,7 +156,10 @@ class ACPProcess:
             if not self._exit_future.done():
                 self._exit_future.set_result(self._returncode)
             with suppress(Exception):
-                await self._terminal.release()
+                await self._client.release_terminal(
+                    session_id=self._session_id,
+                    terminal_id=self._terminal_id,
+                )
 
 
 class ACPKaos:

--- a/src/kimi_cli/acp/tools.py
+++ b/src/kimi_cli/acp/tools.py
@@ -80,23 +80,19 @@ class Terminal(CallableTool2[ShellParams]):
 
         timeout_seconds = float(params.timeout)
         timeout_label = f"{timeout_seconds:g}s"
-        terminal: acp.TerminalHandle | None = None
+        terminal_id: str | None = None
         exit_status: (
             acp.schema.WaitForTerminalExitResponse | acp.schema.TerminalExitStatus | None
         ) = None
         timed_out = False
 
         try:
-            term = await self._acp_conn.create_terminal(
+            resp = await self._acp_conn.create_terminal(
                 command=params.command,
                 session_id=self._acp_session_id,
                 output_byte_limit=builder.max_chars,
             )
-            # FIXME: update ACP sdk for the fix
-            assert isinstance(term, acp.TerminalHandle), (
-                "Expected TerminalHandle from create_terminal"
-            )
-            terminal = term
+            terminal_id = resp.terminal_id
 
             acp_tool_call_id = get_current_acp_tool_call_id_or_none()
             assert acp_tool_call_id, "Expected to have an ACP tool call ID in context"
@@ -109,7 +105,7 @@ class Terminal(CallableTool2[ShellParams]):
                     content=[
                         acp.schema.TerminalToolCallContent(
                             type="terminal",
-                            terminal_id=terminal.id,
+                            terminal_id=terminal_id,
                         )
                     ],
                 ),
@@ -117,12 +113,21 @@ class Terminal(CallableTool2[ShellParams]):
 
             try:
                 async with asyncio.timeout(timeout_seconds):
-                    exit_status = await terminal.wait_for_exit()
+                    exit_status = await self._acp_conn.wait_for_terminal_exit(
+                        session_id=self._acp_session_id,
+                        terminal_id=terminal_id,
+                    )
             except TimeoutError:
                 timed_out = True
-                await terminal.kill()
+                await self._acp_conn.kill_terminal(
+                    session_id=self._acp_session_id,
+                    terminal_id=terminal_id,
+                )
 
-            output_response = await terminal.current_output()
+            output_response = await self._acp_conn.terminal_output(
+                session_id=self._acp_session_id,
+                terminal_id=terminal_id,
+            )
             builder.write(output_response.output)
             if output_response.exit_status:
                 exit_status = output_response.exit_status
@@ -153,6 +158,9 @@ class Terminal(CallableTool2[ShellParams]):
                 )
             return builder.ok(f"Command executed successfully.{truncated_note}")
         finally:
-            if terminal is not None:
+            if terminal_id is not None:
                 with suppress(Exception):
-                    await terminal.release()
+                    await self._acp_conn.release_terminal(
+                        session_id=self._acp_session_id,
+                        terminal_id=terminal_id,
+                    )


### PR DESCRIPTION
## Summary

- Replace all `acp.TerminalHandle` usage with the new ACP 0.8 request/response API in `tools.py` and `kaos.py`
- `create_terminal()` now returns `CreateTerminalResponse` with `.terminal_id` instead of a `TerminalHandle` object
- Terminal operations now use `Client` methods (`wait_for_terminal_exit`, `terminal_output`, `kill_terminal`, `release_terminal`) with explicit `session_id` and `terminal_id` parameters

## Root Cause

`agent-client-protocol` 0.8.0 removed `TerminalHandle` from the public API ([migration guide](https://github.com/agentclientprotocol/python-sdk/blob/main/docs/migration-guide-0.8.md)). Since kimi-cli v1.17+ pins `agent-client-protocol==0.8.0`, any ACP terminal tool call fails with:

```
Error running tool: module acp has no attribute TerminalHandle
```

## Changes

### `src/kimi_cli/acp/tools.py`
- `terminal: acp.TerminalHandle | None` → `terminal_id: str | None`
- Extract `terminal_id` from `CreateTerminalResponse.terminal_id` instead of asserting `TerminalHandle`
- Call `self._acp_conn.wait_for_terminal_exit(session_id, terminal_id)` instead of `terminal.wait_for_exit()`
- Call `self._acp_conn.terminal_output(session_id, terminal_id)` instead of `terminal.current_output()`
- Call `self._acp_conn.kill_terminal(session_id, terminal_id)` instead of `terminal.kill()`
- Call `self._acp_conn.release_terminal(session_id, terminal_id)` instead of `terminal.release()`

### `src/kimi_cli/acp/kaos.py`
- `ACPProcess.__init__` now takes `client: acp.Client`, `session_id: str`, `terminal_id: str` instead of `terminal: acp.TerminalHandle`
- All internal terminal operations updated to use `Client` methods with explicit IDs

## Test plan

- [x] `ruff check` passes on both changed files
- [ ] Run kimi-cli as ACP agent in Zed IDE and execute a shell command (e.g., `git log --oneline -6`)
- [ ] Verify terminal tool call succeeds without `TerminalHandle` AttributeError

Fixes #1380