### PR TITLE
fix(shell): scope file-mention walk to typed directory prefix

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -225,6 +225,7 @@ class LocalFileMentionCompleter(Completer):
         self._limit = limit
         self._cache_time: float = 0.0
         self._cached_paths: list[str] = []
+        self._cache_scope: str = ""
         self._top_cache_time: float = 0.0
         self._top_cached_paths: list[str] = []
         self._fragment_hint: str | None = None
@@ -253,7 +254,7 @@ class LocalFileMentionCompleter(Completer):
         fragment = self._fragment_hint or ""
         if "/" not in fragment and len(fragment) < 3:
             return self._get_top_level_paths()
-        return self._get_deep_paths()
+        return self._get_deep_paths(fragment)
 
     def _get_top_level_paths(self) -> list[str]:
         now = time.monotonic()
@@ -276,15 +277,35 @@ class LocalFileMentionCompleter(Completer):
         self._top_cache_time = now
         return self._top_cached_paths
 
-    def _get_deep_paths(self) -> list[str]:
+    def _get_deep_paths(self, fragment: str = "") -> list[str]:
         now = time.monotonic()
-        if now - self._cache_time <= self._refresh_interval:
+
+        # Scope the walk to the directory prefix from the fragment.
+        # For "src/utils/he" → walk from <root>/src/utils/ instead of <root>/
+        # This avoids exhausting the limit on unrelated directories in large repos.
+        scope_prefix = ""
+        walk_root = self._root
+        if "/" in fragment:
+            dir_part = fragment.rsplit("/", 1)[0]
+            candidate = self._root / dir_part
+            if candidate.is_dir():
+                walk_root = candidate
+                scope_prefix = dir_part + "/"
+
+        cache_key = scope_prefix
+        if (
+            now - self._cache_time <= self._refresh_interval
+            and getattr(self, "_cache_scope", "") == cache_key
+        ):
             return self._cached_paths
 
         paths: list[str] = []
+        # When scoped, include the scope directory itself so callers see it.
+        if scope_prefix:
+            paths.append(scope_prefix)
         try:
-            for current_root, dirs, files in os.walk(self._root):
-                relative_root = Path(current_root).relative_to(self._root)
+            for current_root, dirs, files in os.walk(walk_root):
+                relative_root = Path(current_root).relative_to(walk_root)
 
                 # Prevent descending into ignored directories.
                 dirs[:] = sorted(d for d in dirs if not self._is_ignored(d))
@@ -296,7 +317,7 @@ class LocalFileMentionCompleter(Completer):
                     continue
 
                 if relative_root.parts:
-                    paths.append(relative_root.as_posix() + "/")
+                    paths.append(scope_prefix + relative_root.as_posix() + "/")
                     if len(paths) >= self._limit:
                         break
 
@@ -306,7 +327,7 @@ class LocalFileMentionCompleter(Completer):
                     relative = (relative_root / file_name).as_posix()
                     if not relative:
                         continue
-                    paths.append(relative)
+                    paths.append(scope_prefix + relative)
                     if len(paths) >= self._limit:
                         break
 
@@ -317,6 +338,7 @@ class LocalFileMentionCompleter(Completer):
 
         self._cached_paths = paths
         self._cache_time = now
+        self._cache_scope = cache_key
         return self._cached_paths
 
     @staticmethod

--- a/tests/ui_and_conv/test_file_completer.py
+++ b/tests/ui_and_conv/test_file_completer.py
@@ -91,6 +91,53 @@ def test_at_guard_prevents_email_like_fragments(tmp_path: Path):
     assert not texts
 
 
+def test_scoped_walk_finds_deep_files_in_large_repos(tmp_path: Path):
+    """In large repos, scoped walk should find files under the typed directory.
+
+    Regression test for #1375: when the total file count exceeds the limit,
+    files in later directories (alphabetically) become unreachable. Scoping
+    the walk to the typed directory prefix avoids this.
+    """
+    limit = 20
+
+    # Create many files in early directories to exhaust a small limit
+    for i in range(15):
+        d = tmp_path / f"aaa_dir_{i:02d}"
+        d.mkdir()
+        (d / "file.txt").write_text("x")
+
+    # Target files are in a directory that would be unreachable with flat walk
+    target = tmp_path / "zzz_target" / "nested"
+    target.mkdir(parents=True)
+    (target / "important.py").write_text("# important")
+    (target / "helper.py").write_text("# helper")
+
+    completer = LocalFileMentionCompleter(tmp_path, limit=limit)
+
+    # Without scoping, "zzz_target/" would never appear because the limit
+    # is exhausted by aaa_dir_* entries. With scoping, typing the directory
+    # prefix narrows the walk to just that subtree.
+    texts = _completion_texts(completer, "@zzz_target/")
+
+    assert "zzz_target/nested/" in texts
+    assert "zzz_target/nested/important.py" in texts
+    assert "zzz_target/nested/helper.py" in texts
+
+
+def test_scoped_walk_with_partial_filename(tmp_path: Path):
+    """Scoped walk works when fragment includes a partial filename after slash."""
+    src = tmp_path / "src" / "utils"
+    src.mkdir(parents=True)
+    (src / "helpers.py").write_text("")
+    (src / "config.py").write_text("")
+
+    completer = LocalFileMentionCompleter(tmp_path)
+
+    texts = _completion_texts(completer, "@src/utils/hel")
+
+    assert "src/utils/helpers.py" in texts
+
+
 def test_basename_prefix_is_ranked_first(tmp_path: Path):
     """Prefer basename prefix matches over cross-segment fuzzy matches.
 


### PR DESCRIPTION
## Summary

Fixes #1375 — In large repositories, the `@` file-mention completer becomes unable to find files in directories that sort alphabetically late (e.g., `src/`, `tests/`). The root cause is that `_get_deep_paths()` walks the entire project tree from the root and stops at `limit` (default 1000), so early directories exhaust the budget before later ones are ever visited.

### Changes

- **Scope the walk**: When the typed fragment contains a `/` (e.g., `@src/utils/hel`), extract the directory prefix and start `os.walk()` from that subdirectory instead of the project root. This ensures completions always search the intended subtree regardless of repo size.
- **Scope-aware caching**: The path cache now tracks which scope it was built for (`_cache_scope`), so switching between directories correctly invalidates stale results.
- **Include scope directory**: The scoped directory itself (e.g., `src/`) is included in results so existing behavior (showing the directory entry) is preserved.

### Test plan

- [x] Added `test_scoped_walk_finds_deep_files_in_large_repos` — regression test with 15 early directories exhausting a small limit, verifying late directories are still reachable
- [x] Added `test_scoped_walk_with_partial_filename` — verifies scoped walk works with partial filename after slash
- [x] All 8 existing + new tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
