### PR TITLE
fix(ui): add dedicated error message for API rate limit (429)

### DIFF
--- a/src/kimi_cli/ui/print/__init__.py
+++ b/src/kimi_cli/ui/print/__init__.py
@@ -6,7 +6,7 @@ import sys
 from functools import partial
 from pathlib import Path
 
-from kosong.chat_provider import ChatProviderError
+from kosong.chat_provider import APIStatusError, ChatProviderError
 from kosong.message import Message
 from rich import print
 
@@ -100,7 +100,13 @@ class Print:
             print(str(e))
         except ChatProviderError as e:
             logger.exception("LLM provider error:")
-            print(str(e))
+            if isinstance(e, APIStatusError) and e.status_code == 429:
+                print(
+                    "API rate limit reached. Please wait a moment before retrying,"
+                    " or reduce the number of concurrent agents."
+                )
+            else:
+                print(str(e))
         except MaxStepsReached as e:
             logger.warning("Max steps reached: {n_steps}", n_steps=e.n_steps)
             print(str(e))

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -272,6 +272,11 @@ class Shell:
                 console.print("[red]Membership expired, please renew your plan[/red]")
             elif isinstance(e, APIStatusError) and e.status_code == 403:
                 console.print("[red]Quota exceeded, please upgrade your plan or retry later[/red]")
+            elif isinstance(e, APIStatusError) and e.status_code == 429:
+                console.print(
+                    "[yellow]API rate limit reached. Please wait a moment before retrying,"
+                    " or reduce the number of concurrent agents.[/yellow]"
+                )
             else:
                 console.print(f"[red]LLM provider error: {e}[/red]")
         except MaxStepsReached as e:


### PR DESCRIPTION
## Summary

- Add a specific, user-friendly error message when API rate limit (HTTP 429) is hit and retries are exhausted
- Applied to both shell UI and print UI, consistent with existing 401/402/403 handling
- Uses `[yellow]` styling (warning, not error) since the issue is transient and recoverable

## Context

Reported in #1383 — users hitting rate limits see a generic `LLM provider error: ...` message, which doesn't clearly explain the cause or suggest what to do. The 429 case was missing from the status-code-specific error handling that already covers 401 (auth), 402 (membership expired), and 403 (quota exceeded).

## Changes

- `src/kimi_cli/ui/shell/__init__.py`: Add `elif` branch for `e.status_code == 429` with actionable message
- `src/kimi_cli/ui/print/__init__.py`: Add same 429 handling + import `APIStatusError`

## Test plan

- [x] Verify 429 branch is consistent with existing error handling pattern
- [x] Both shell and print UIs updated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
