### PR TITLE
fix: strip HTTP-unsafe characters from header values

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import platform
+import re
 import socket
 import sys
 import time
@@ -192,13 +193,15 @@ def get_device_id() -> str:
     return device_id
 
 
+# Characters unsafe for HTTP header values: control chars (0x00-0x1F),
+# DEL (0x7F), non-ASCII (0x80+), and '#' which some servers/proxies
+# reject (e.g. Linux kernel version strings like "#101~22.04.1-Ubuntu ...").
+_UNSAFE_HEADER_RE = re.compile(r"[^\x20-\x7e]|#")
+
+
 def _ascii_header_value(value: str, *, fallback: str = "unknown") -> str:
-    try:
-        value.encode("ascii")
-        return value.strip()
-    except UnicodeEncodeError:
-        sanitized = value.encode("ascii", errors="ignore").decode("ascii").strip()
-        return sanitized or fallback
+    sanitized = _UNSAFE_HEADER_RE.sub("", value).strip()
+    return sanitized or fallback
 
 
 def _common_headers() -> dict[str, str]:

--- a/tests/auth/test_ascii_header.py
+++ b/tests/auth/test_ascii_header.py
@@ -1,9 +1,11 @@
 """Tests for _ascii_header_value and _common_headers in oauth module.
 
 Regression tests for the issue where Linux kernel version strings containing
-trailing whitespace/newlines (e.g. platform.version() returning
-"#101-Ubuntu SMP ...\n") would be included in HTTP headers, causing
-connection errors.
+'#' characters and trailing whitespace (e.g. platform.version() returning
+"#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC ...") would produce invalid HTTP
+header values, causing connection errors.
+
+See: https://github.com/MoonshotAI/kimi-cli/issues/1389
 """
 
 from unittest.mock import patch
@@ -21,11 +23,28 @@ class TestAsciiHeaderValue:
         """Regression: Linux platform.version() may contain trailing newline."""
         assert _ascii_header_value("6.8.0-101\n") == "6.8.0-101"
 
+    def test_strips_hash_character(self) -> None:
+        """Regression (#1389): '#' in kernel version causes connection errors."""
+        result = _ascii_header_value(
+            "#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC 2025"
+        )
+        assert "#" not in result
+        assert "101~22.04.1-Ubuntu" in result
+
+    def test_strips_control_characters(self) -> None:
+        assert _ascii_header_value("hello\x00world") == "helloworld"
+
     def test_non_ascii_sanitized(self) -> None:
         assert _ascii_header_value("héllo") == "hllo"
 
     def test_all_non_ascii_returns_fallback(self) -> None:
         assert _ascii_header_value("你好") == "unknown"
+
+    def test_empty_string_returns_fallback(self) -> None:
+        assert _ascii_header_value("") == "unknown"
+
+    def test_custom_fallback(self) -> None:
+        assert _ascii_header_value("你好", fallback="n/a") == "n/a"
 
 
 class TestCommonHeaders:
@@ -33,10 +52,13 @@ class TestCommonHeaders:
 
     @patch("kimi_cli.auth.oauth.platform")
     @patch("kimi_cli.auth.oauth.get_device_id", return_value="abc123")
-    def test_no_whitespace_in_header_values(self, _mock_device_id, mock_platform) -> None:
-        """All header values must be free of leading/trailing whitespace."""
+    def test_no_unsafe_chars_in_header_values(self, _mock_device_id, mock_platform) -> None:
+        """All header values must be free of '#', control chars, and whitespace padding."""
         mock_platform.node.return_value = "myhost"
-        mock_platform.version.return_value = "#101-Ubuntu SMP\n"
+        mock_platform.version.return_value = (
+            "#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC 2025\n"
+        )
         headers = _common_headers()
         for key, value in headers.items():
             assert value == value.strip(), f"Header {key!r} has untrimmed whitespace: {value!r}"
+            assert "#" not in value, f"Header {key!r} contains '#': {value!r}"


### PR DESCRIPTION
## Summary

- `_ascii_header_value()` only filtered non-ASCII characters but allowed HTTP-unsafe ASCII characters like `#` through unchanged
- On Linux systems where `platform.version()` returns kernel strings starting with `#` (e.g. `#101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC ...`), this produced invalid HTTP header values causing **connection errors that made kimi-cli completely unusable**
- Replace the ASCII-encode check with a single regex that strips all characters outside printable ASCII range (`0x20-0x7E`) plus `#`, which some servers/proxies reject

## Changes

**`src/kimi_cli/auth/oauth.py`**
- Simplified `_ascii_header_value()` to use a compiled regex (`_UNSAFE_HEADER_RE`) that removes control characters, non-ASCII, and `#` in one pass
- The new implementation is both shorter and more robust than the previous try/except approach

**`tests/auth/test_ascii_header.py`**
- Added regression test for `#` in kernel version strings (the root cause of #1389)
- Added tests for control characters, empty strings, and custom fallback
- Updated `TestCommonHeaders` to verify no `#` appears in header values

## Test plan

- [x] All 9 tests pass in `tests/auth/test_ascii_header.py`
- [x] Verified the fix handles the exact `platform.version()` output from affected systems

Fixes #1389
Related: #1368, #1364, #1321
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
