### PR TITLE
fix(ui): correct usage bar color logic

### DIFF
--- a/src/kimi_cli/ui/shell/usage.py
+++ b/src/kimi_cli/ui/shell/usage.py
@@ -250,15 +250,21 @@ def _build_usage_panel(summary: UsageRow | None, limits: list[UsageRow]) -> Pane
 
 
 def _format_row(row: UsageRow, label_width: int) -> RenderableType:
-    ratio = (row.limit - row.used) / row.limit if row.limit > 0 else 0
-    color = _ratio_color(ratio)
+    if row.limit > 0:
+        usage_ratio = row.used / row.limit
+        color = _ratio_color(usage_ratio)
+        percent = (1 - usage_ratio) * 100
+        percent_text = f"{percent:.0f}% left"
+    else:
+        usage_ratio = 0
+        color = "grey50"
+        percent_text = "N/A"
 
     label = Text(f"{row.label:<{label_width}}  ", style="cyan")
     bar = ProgressBar(total=row.limit or 1, completed=row.used, width=20, complete_style=color)
 
     detail = Text()
-    percent = ratio * 100
-    detail.append(f"  {percent:.0f}% left", style="bold")
+    detail.append(f"  {percent_text}", style="bold")
     if row.reset_hint:
         detail.append(f"  ({row.reset_hint})", style="grey50")
 

--- a/tests/ui_and_conv/test_usage.py
+++ b/tests/ui_and_conv/test_usage.py
@@ -1,0 +1,48 @@
+"""Tests for usage display color logic."""
+
+import pytest
+
+from kimi_cli.ui.shell.usage import _ratio_color
+
+
+class TestRatioColor:
+    """Tests for _ratio_color function."""
+
+    def test_low_usage_returns_green(self):
+        """When less than 70% is used, should return green."""
+        assert _ratio_color(0.0) == "green"
+        assert _ratio_color(0.5) == "green"
+        assert _ratio_color(0.69) == "green"
+
+    def test_medium_usage_returns_yellow(self):
+        """When between 70% and 90% is used, should return yellow."""
+        assert _ratio_color(0.7) == "yellow"
+        assert _ratio_color(0.8) == "yellow"
+        assert _ratio_color(0.89) == "yellow"
+
+    def test_high_usage_returns_red(self):
+        """When 90% or more is used, should return red."""
+        assert _ratio_color(0.9) == "red"
+        assert _ratio_color(0.95) == "red"
+        assert _ratio_color(1.0) == "red"
+
+    @pytest.mark.parametrize(
+        "ratio,expected",
+        [
+            # Low usage -> green
+            (0.07, "green"),  # 7% used, plenty left
+            (0.5, "green"),  # 50% used, still ok
+            (0.69, "green"),  # 69% used, boundary case
+            # Medium usage -> yellow
+            (0.7, "yellow"),  # 70% used, warning zone
+            (0.75, "yellow"),  # 75% used
+            (0.89, "yellow"),  # 89% used, boundary case
+            # High usage -> red
+            (0.9, "red"),  # 90% used, danger zone
+            (0.95, "red"),  # 95% used
+            (1.0, "red"),  # 100% used, exhausted
+        ],
+    )
+    def test_ratio_color_boundaries(self, ratio: float, expected: str):
+        """Test color boundaries for various usage ratios."""
+        assert _ratio_color(ratio) == expected

--- a/tests/ui_and_conv/test_usage.py
+++ b/tests/ui_and_conv/test_usage.py
@@ -39,10 +39,16 @@ class TestFormatRow:
     @pytest.mark.parametrize(
         "used,limit,expected_ratio",
         [
-            (7, 100, 0.07),    # 7% used -> low usage
-            (50, 100, 0.5),    # 50% used -> low usage
-            (75, 100, 0.75),   # 75% used -> medium usage
-            (95, 100, 0.95),   # 95% used -> high usage
+            (0, 100, 0.0),     # 0% used -> boundary (green)
+            (7, 100, 0.07),    # 7% used -> low usage (green)
+            (50, 100, 0.5),    # 50% used -> low usage (green)
+            (69, 100, 0.69),   # 69% used -> boundary (green)
+            (70, 100, 0.7),    # 70% used -> boundary (yellow)
+            (75, 100, 0.75),   # 75% used -> medium usage (yellow)
+            (89, 100, 0.89),   # 89% used -> boundary (yellow)
+            (90, 100, 0.9),    # 90% used -> boundary (red)
+            (95, 100, 0.95),   # 95% used -> high usage (red)
+            (100, 100, 1.0),   # 100% used -> boundary (red)
         ],
     )
     def test_format_row_passes_usage_ratio(self, used: int, limit: int, expected_ratio: float):

--- a/tests/ui_and_conv/test_usage.py
+++ b/tests/ui_and_conv/test_usage.py
@@ -1,8 +1,10 @@
 """Tests for usage display color logic."""
 
+from unittest.mock import patch
+
 import pytest
 
-from kimi_cli.ui.shell.usage import _ratio_color
+from kimi_cli.ui.shell.usage import _format_row, _ratio_color, UsageRow
 
 
 class TestRatioColor:
@@ -29,3 +31,38 @@ class TestRatioColor:
     def test_ratio_color(self, ratio: float, expected: str, description: str):
         """Test color for various usage ratios."""
         assert _ratio_color(ratio) == expected, f"Failed for {description}"
+
+
+class TestFormatRow:
+    """Tests for _format_row function."""
+
+    @pytest.mark.parametrize(
+        "used,limit,expected_ratio",
+        [
+            (7, 100, 0.07),    # 7% used -> low usage
+            (50, 100, 0.5),    # 50% used -> low usage
+            (75, 100, 0.75),   # 75% used -> medium usage
+            (95, 100, 0.95),   # 95% used -> high usage
+        ],
+    )
+    def test_format_row_passes_usage_ratio(self, used: int, limit: int, expected_ratio: float):
+        """Test that _format_row passes usage ratio (used/limit) to _ratio_color."""
+        row = UsageRow(label="Test", used=used, limit=limit)
+
+        with patch("kimi_cli.ui.shell.usage._ratio_color") as mock_ratio_color:
+            mock_ratio_color.return_value = "green"
+            _format_row(row, label_width=10)
+
+            mock_ratio_color.assert_called_once()
+            actual_ratio = mock_ratio_color.call_args[0][0]
+            assert abs(actual_ratio - expected_ratio) < 0.001, (
+                f"Expected usage ratio {expected_ratio}, got {actual_ratio}"
+            )
+
+    def test_format_row_zero_limit(self):
+        """Test _format_row handles zero limit gracefully."""
+        row = UsageRow(label="Test", used=0, limit=0)
+
+        # Should not raise and should display "N/A"
+        result = _format_row(row, label_width=10)
+        assert result is not None

--- a/tests/ui_and_conv/test_usage.py
+++ b/tests/ui_and_conv/test_usage.py
@@ -8,41 +8,24 @@ from kimi_cli.ui.shell.usage import _ratio_color
 class TestRatioColor:
     """Tests for _ratio_color function."""
 
-    def test_low_usage_returns_green(self):
-        """When less than 70% is used, should return green."""
-        assert _ratio_color(0.0) == "green"
-        assert _ratio_color(0.5) == "green"
-        assert _ratio_color(0.69) == "green"
-
-    def test_medium_usage_returns_yellow(self):
-        """When between 70% and 90% is used, should return yellow."""
-        assert _ratio_color(0.7) == "yellow"
-        assert _ratio_color(0.8) == "yellow"
-        assert _ratio_color(0.89) == "yellow"
-
-    def test_high_usage_returns_red(self):
-        """When 90% or more is used, should return red."""
-        assert _ratio_color(0.9) == "red"
-        assert _ratio_color(0.95) == "red"
-        assert _ratio_color(1.0) == "red"
-
     @pytest.mark.parametrize(
-        "ratio,expected",
+        "ratio,expected,description",
         [
             # Low usage -> green
-            (0.07, "green"),  # 7% used, plenty left
-            (0.5, "green"),  # 50% used, still ok
-            (0.69, "green"),  # 69% used, boundary case
+            (0.0, "green", "0% used"),
+            (0.07, "green", "7% used, plenty left"),
+            (0.5, "green", "50% used, still ok"),
+            (0.69, "green", "69% used, boundary"),
             # Medium usage -> yellow
-            (0.7, "yellow"),  # 70% used, warning zone
-            (0.75, "yellow"),  # 75% used
-            (0.89, "yellow"),  # 89% used, boundary case
+            (0.7, "yellow", "70% used, warning zone"),
+            (0.75, "yellow", "75% used"),
+            (0.89, "yellow", "89% used, boundary"),
             # High usage -> red
-            (0.9, "red"),  # 90% used, danger zone
-            (0.95, "red"),  # 95% used
-            (1.0, "red"),  # 100% used, exhausted
+            (0.9, "red", "90% used, danger zone"),
+            (0.95, "red", "95% used"),
+            (1.0, "red", "100% used, exhausted"),
         ],
     )
-    def test_ratio_color_boundaries(self, ratio: float, expected: str):
-        """Test color boundaries for various usage ratios."""
-        assert _ratio_color(ratio) == expected
+    def test_ratio_color(self, ratio: float, expected: str, description: str):
+        """Test color for various usage ratios."""
+        assert _ratio_color(ratio) == expected, f"Failed for {description}"


### PR DESCRIPTION
Pass usage ratio (instead of remaining ratio) to _ratio_color. This fixes the inverted color display where high remaining showed red and low remaining showed green.

- _format_row: calculate usage_ratio = used / limit
- _ratio_color: usage >= 0.9 -> red, >= 0.7 -> yellow, else green

Fixes: 50% left showing green, 93% left showing red

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve  N/A

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
