### PR TITLE
fix(tools): treat dismissed questions as errors instead of proceeding

### DIFF
--- a/src/kimi_cli/tools/ask_user/__init__.py
+++ b/src/kimi_cli/tools/ask_user/__init__.py
@@ -150,8 +150,10 @@ class AskUserQuestion(CallableTool2[Params]):
 
         if not answers:
             return ToolReturnValue(
-                is_error=False,
-                output='{"answers": {}, "note": "User dismissed the question without answering."}',
+                is_error=True,
+                output="User dismissed the question without answering. "
+                "Do NOT assume any answer or proceed on the user's behalf. "
+                "Stop and wait for the user's next message.",
                 message="User dismissed the question without answering.",
                 display=[BriefDisplayBlock(text="User dismissed")],
             )

--- a/src/kimi_cli/tools/plan/__init__.py
+++ b/src/kimi_cli/tools/plan/__init__.py
@@ -134,9 +134,9 @@ class ExitPlanMode(CallableTool2[Params]):
 
         if not answers:
             return ToolReturnValue(
-                is_error=False,
-                output="User dismissed without choosing. Plan mode remains active. "
-                "Continue working on your plan or call ExitPlanMode again when ready.",
+                is_error=True,
+                output="User dismissed the plan review without choosing. Plan mode remains active. "
+                "Do NOT proceed with implementation. Stop and wait for the user's next message.",
                 message="Dismissed",
                 display=[BriefDisplayBlock(text="Dismissed")],
             )

--- a/src/kimi_cli/tools/plan/enter.py
+++ b/src/kimi_cli/tools/plan/enter.py
@@ -136,8 +136,9 @@ class EnterPlanMode(CallableTool2[Params]):
 
         if not answers:
             return ToolReturnValue(
-                is_error=False,
-                output="User dismissed without choosing. Proceed with implementation directly.",
+                is_error=True,
+                output="User dismissed the plan mode prompt without choosing. "
+                "Do NOT proceed with implementation. Stop and wait for the user's next message.",
                 message="Dismissed",
                 display=[BriefDisplayBlock(text="Dismissed")],
             )

--- a/tests/core/test_plan_mode.py
+++ b/tests/core/test_plan_mode.py
@@ -378,7 +378,7 @@ class TestExitPlanModeHappyPaths:
         assert not result.is_error
         assert "User feedback:" not in _tool_output_text(result)
 
-    async def test_dismissed_returns_continue(
+    async def test_dismissed_returns_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         tool, toggle_cb, _ = _setup_exit_tool(tmp_path)
@@ -387,8 +387,9 @@ class TestExitPlanModeHappyPaths:
 
         result = await tool(tool.params())
         assert isinstance(result, ToolReturnValue)
-        assert not result.is_error
+        assert result.is_error
         assert "dismissed" in _tool_output_text(result).lower()
+        assert "do not proceed" in _tool_output_text(result).lower()
         toggle_cb.assert_not_awaited()
 
     async def test_question_not_supported(
@@ -475,8 +476,9 @@ class TestEnterPlanModeHappyPaths:
 
         result = await tool(tool.params())
         assert isinstance(result, ToolReturnValue)
-        assert not result.is_error
+        assert result.is_error
         assert "dismissed" in _tool_output_text(result).lower()
+        assert "do not proceed" in _tool_output_text(result).lower()
         toggle_cb.assert_not_awaited()
 
     async def test_question_not_supported(

--- a/tests/tools/test_ask_user.py
+++ b/tests/tools/test_ask_user.py
@@ -79,7 +79,7 @@ async def test_ask_user_basic(ask_user_tool: AskUserQuestion):
 
 
 async def test_ask_user_dismissed(ask_user_tool: AskUserQuestion):
-    """Test that user dismiss returns a non-error result with dismiss note."""
+    """Test that user dismiss returns an error result instructing the LLM to stop."""
     wire = Wire()
     wire_token = _current_wire.set(wire)
     tool_call = ToolCall(
@@ -100,11 +100,10 @@ async def test_ask_user_dismissed(ask_user_tool: AskUserQuestion):
         msg.resolve({})
 
         result = await asyncio.wait_for(tool_task, timeout=2.0)
-        assert not result.is_error
+        assert result.is_error
         assert isinstance(result.output, str)
-        parsed = json.loads(result.output)
-        assert parsed["answers"] == {}
-        assert "dismissed" in parsed.get("note", "").lower()
+        assert "dismissed" in result.output.lower()
+        assert "do not" in result.output.lower()
     finally:
         wire.shutdown()
         current_tool_call.reset(tc_token)

--- a/tests_e2e/test_wire_question.py
+++ b/tests_e2e/test_wire_question.py
@@ -180,10 +180,8 @@ def test_question_request_error_response(tmp_path) -> None:
         for tr in tool_results:
             if tr["payload"]["tool_call_id"] == "tc-q2":
                 rv = tr["payload"]["return_value"]
-                assert not rv["is_error"]
-                output = json.loads(rv["output"])
-                assert output["answers"] == {}
-                assert "dismissed" in output.get("note", "").lower()
+                assert rv["is_error"]
+                assert "dismissed" in rv["output"].lower()
                 break
         else:
             raise AssertionError("ToolResult for tc-q2 not found")


### PR DESCRIPTION
## Summary

Fixes #1404 — when a user dismisses a plan mode prompt or any question dialog without answering, the LLM now stops and waits instead of assuming permission to proceed.

**Root cause**: `EnterPlanMode`, `ExitPlanMode`, and `AskUserQuestion` all returned `is_error=False` with directive output text when the user dismissed a question (empty answers `{}`). Most critically, `EnterPlanMode` returned *"Proceed with implementation directly"* — explicitly instructing the LLM to bypass planning and start coding without user consent.

**Fix**: All three tools now return `is_error=True` on dismissal with output text that explicitly tells the LLM: *"Do NOT proceed. Stop and wait for the user's next message."* Treating dismissal as an error condition ensures the LLM halts rather than interpreting silence as consent.

### Changes

| File | Before | After |
|------|--------|-------|
| `tools/plan/enter.py` | `is_error=False`, "Proceed with implementation directly" | `is_error=True`, "Do NOT proceed" |
| `tools/plan/__init__.py` | `is_error=False`, "Continue working on your plan" | `is_error=True`, "Do NOT proceed" |
| `tools/ask_user/__init__.py` | `is_error=False`, JSON with empty answers | `is_error=True`, "Do NOT assume any answer" |
| `tests/core/test_plan_mode.py` | `assert not result.is_error` | `assert result.is_error` + content checks |
| `tests/tools/test_ask_user.py` | `assert not result.is_error` + JSON parse | `assert result.is_error` + content checks |
| `tests_e2e/test_wire_question.py` | `assert not rv["is_error"]` | `assert rv["is_error"]` |

## Test plan

- [x] All 48 unit tests pass (`tests/core/test_plan_mode.py`, `tests/tools/test_ask_user.py`)
- [ ] Manual: run `kimi`, trigger plan mode, dismiss the dialog → LLM should stop and wait
- [ ] Manual: trigger AskUserQuestion, dismiss → LLM should not assume an answer
- [ ] Manual: in plan mode, call ExitPlanMode, dismiss review → LLM should stay in plan mode and wait
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
