### PR TITLE
fix: add asyncio.Lock to Context to prevent concurrent file write errors on Windows

### DIFF
--- a/src/kimi_cli/soul/context.py
+++ b/src/kimi_cli/soul/context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Sequence
 from pathlib import Path
@@ -21,6 +22,7 @@ class Context:
         self._next_checkpoint_id: int = 0
         """The ID of the next checkpoint, starting from 0, incremented after each checkpoint."""
         self._system_prompt: str | None = None
+        self._file_lock = asyncio.Lock()
 
     async def restore(self) -> bool:
         logger.debug("Restoring context from file: {file_backend}", file_backend=self._file_backend)
@@ -83,20 +85,21 @@ class Context:
         """
         prompt_line = json.dumps({"role": "_system_prompt", "content": prompt}) + "\n"
 
-        if not self._file_backend.exists() or self._file_backend.stat().st_size == 0:
-            async with aiofiles.open(self._file_backend, "w", encoding="utf-8") as f:
-                await f.write(prompt_line)
-        else:
-            tmp_path = self._file_backend.with_suffix(".tmp")
-            async with aiofiles.open(tmp_path, "w", encoding="utf-8") as tmp_f:
-                await tmp_f.write(prompt_line)
-                async with aiofiles.open(self._file_backend, encoding="utf-8") as src_f:
-                    while True:
-                        chunk = await src_f.read(64 * 1024)
-                        if not chunk:
-                            break
-                        await tmp_f.write(chunk)
-            await aiofiles.os.replace(tmp_path, self._file_backend)
+        async with self._file_lock:
+            if not self._file_backend.exists() or self._file_backend.stat().st_size == 0:
+                async with aiofiles.open(self._file_backend, "w", encoding="utf-8") as f:
+                    await f.write(prompt_line)
+            else:
+                tmp_path = self._file_backend.with_suffix(".tmp")
+                async with aiofiles.open(tmp_path, "w", encoding="utf-8") as tmp_f:
+                    await tmp_f.write(prompt_line)
+                    async with aiofiles.open(self._file_backend, encoding="utf-8") as src_f:
+                        while True:
+                            chunk = await src_f.read(64 * 1024)
+                            if not chunk:
+                                break
+                            await tmp_f.write(chunk)
+                await aiofiles.os.replace(tmp_path, self._file_backend)
 
         self._system_prompt = prompt
 
@@ -105,8 +108,9 @@ class Context:
         self._next_checkpoint_id += 1
         logger.debug("Checkpointing, ID: {id}", id=checkpoint_id)
 
-        async with aiofiles.open(self._file_backend, "a", encoding="utf-8") as f:
-            await f.write(json.dumps({"role": "_checkpoint", "id": checkpoint_id}) + "\n")
+        async with self._file_lock:
+            async with aiofiles.open(self._file_backend, "a", encoding="utf-8") as f:
+                await f.write(json.dumps({"role": "_checkpoint", "id": checkpoint_id}) + "\n")
         if add_user_message:
             await self.append_message(
                 Message(role="user", content=[system(f"CHECKPOINT {checkpoint_id}")])
@@ -131,43 +135,44 @@ class Context:
             logger.error("Checkpoint {checkpoint_id} does not exist", checkpoint_id=checkpoint_id)
             raise ValueError(f"Checkpoint {checkpoint_id} does not exist")
 
-        # rotate the context file
-        rotated_file_path = await next_available_rotation(self._file_backend)
-        if rotated_file_path is None:
-            logger.error("No available rotation path found")
-            raise RuntimeError("No available rotation path found")
-        await aiofiles.os.replace(self._file_backend, rotated_file_path)
-        logger.debug(
-            "Rotated context file: {rotated_file_path}", rotated_file_path=rotated_file_path
-        )
+        async with self._file_lock:
+            # rotate the context file
+            rotated_file_path = await next_available_rotation(self._file_backend)
+            if rotated_file_path is None:
+                logger.error("No available rotation path found")
+                raise RuntimeError("No available rotation path found")
+            await aiofiles.os.replace(self._file_backend, rotated_file_path)
+            logger.debug(
+                "Rotated context file: {rotated_file_path}", rotated_file_path=rotated_file_path
+            )
 
-        # restore the context until the specified checkpoint
-        self._history.clear()
-        self._token_count = 0
-        self._next_checkpoint_id = 0
-        self._system_prompt = None
-        async with (
-            aiofiles.open(rotated_file_path, encoding="utf-8") as old_file,
-            aiofiles.open(self._file_backend, "w", encoding="utf-8") as new_file,
-        ):
-            async for line in old_file:
-                if not line.strip():
-                    continue
+            # restore the context until the specified checkpoint
+            self._history.clear()
+            self._token_count = 0
+            self._next_checkpoint_id = 0
+            self._system_prompt = None
+            async with (
+                aiofiles.open(rotated_file_path, encoding="utf-8") as old_file,
+                aiofiles.open(self._file_backend, "w", encoding="utf-8") as new_file,
+            ):
+                async for line in old_file:
+                    if not line.strip():
+                        continue
 
-                line_json = json.loads(line)
-                if line_json["role"] == "_checkpoint" and line_json["id"] == checkpoint_id:
-                    break
+                    line_json = json.loads(line)
+                    if line_json["role"] == "_checkpoint" and line_json["id"] == checkpoint_id:
+                        break
 
-                await new_file.write(line)
-                if line_json["role"] == "_system_prompt":
-                    self._system_prompt = line_json["content"]
-                elif line_json["role"] == "_usage":
-                    self._token_count = line_json["token_count"]
-                elif line_json["role"] == "_checkpoint":
-                    self._next_checkpoint_id = line_json["id"] + 1
-                else:
-                    message = Message.model_validate(line_json)
-                    self._history.append(message)
+                    await new_file.write(line)
+                    if line_json["role"] == "_system_prompt":
+                        self._system_prompt = line_json["content"]
+                    elif line_json["role"] == "_usage":
+                        self._token_count = line_json["token_count"]
+                    elif line_json["role"] == "_checkpoint":
+                        self._next_checkpoint_id = line_json["id"] + 1
+                    else:
+                        message = Message.model_validate(line_json)
+                        self._history.append(message)
 
     async def clear(self):
         """
@@ -182,34 +187,37 @@ class Context:
 
         logger.debug("Clearing context")
 
-        # rotate the context file
-        rotated_file_path = await next_available_rotation(self._file_backend)
-        if rotated_file_path is None:
-            logger.error("No available rotation path found")
-            raise RuntimeError("No available rotation path found")
-        await aiofiles.os.replace(self._file_backend, rotated_file_path)
-        self._file_backend.touch()
-        logger.debug(
-            "Rotated context file: {rotated_file_path}", rotated_file_path=rotated_file_path
-        )
+        async with self._file_lock:
+            # rotate the context file
+            rotated_file_path = await next_available_rotation(self._file_backend)
+            if rotated_file_path is None:
+                logger.error("No available rotation path found")
+                raise RuntimeError("No available rotation path found")
+            await aiofiles.os.replace(self._file_backend, rotated_file_path)
+            self._file_backend.touch()
+            logger.debug(
+                "Rotated context file: {rotated_file_path}", rotated_file_path=rotated_file_path
+            )
 
-        self._history.clear()
-        self._token_count = 0
-        self._next_checkpoint_id = 0
-        self._system_prompt = None
+            self._history.clear()
+            self._token_count = 0
+            self._next_checkpoint_id = 0
+            self._system_prompt = None
 
     async def append_message(self, message: Message | Sequence[Message]):
         logger.debug("Appending message(s) to context: {message}", message=message)
         messages = [message] if isinstance(message, Message) else message
         self._history.extend(messages)
 
-        async with aiofiles.open(self._file_backend, "a", encoding="utf-8") as f:
-            for message in messages:
-                await f.write(message.model_dump_json(exclude_none=True) + "\n")
+        async with self._file_lock:
+            async with aiofiles.open(self._file_backend, "a", encoding="utf-8") as f:
+                for message in messages:
+                    await f.write(message.model_dump_json(exclude_none=True) + "\n")
 
     async def update_token_count(self, token_count: int):
         logger.debug("Updating token count in context: {token_count}", token_count=token_count)
         self._token_count = token_count
 
-        async with aiofiles.open(self._file_backend, "a", encoding="utf-8") as f:
-            await f.write(json.dumps({"role": "_usage", "token_count": token_count}) + "\n")
+        async with self._file_lock:
+            async with aiofiles.open(self._file_backend, "a", encoding="utf-8") as f:
+                await f.write(json.dumps({"role": "_usage", "token_count": token_count}) + "\n")


### PR DESCRIPTION
## Summary

Fixes #1429

On Windows, multiple async coroutines within the same Kimi CLI process can open the session context file (`context.jsonl`) concurrently, triggering `PermissionError: [Errno 13]` due to OS-level file locking semantics.

This PR adds an `asyncio.Lock` to the `Context` class to serialize all file I/O operations on the backing file, preventing concurrent access conflicts.

### Changes

- Add `self._file_lock = asyncio.Lock()` to `Context.__init__`
- Wrap file write operations in all methods with `async with self._file_lock`:
  - `write_system_prompt` — write/prepend system prompt
  - `checkpoint` — append checkpoint record
  - `revert_to` — rotate + rewrite file
  - `clear` — rotate + truncate file
  - `append_message` — append message records
  - `update_token_count` — append usage record
- `restore()` is read-only and called once at init, so it does not need the lock

### Why `asyncio.Lock` is sufficient

The root cause is multiple coroutines within the **same process** racing to open the same file. Since all coroutines share one event loop, `asyncio.Lock` (not `threading.Lock`) is the correct synchronization primitive. This serializes file access without blocking the event loop.

## Test plan

- [x] Verified the fix compiles and the lock is correctly applied to all write paths
- [ ] Reproduce on Windows: start Kimi CLI, paste 5000+ characters, confirm no `PermissionError`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
