### PR TITLE
docs: clarify dev setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,10 @@ projects with changed files run their hooks. You can skip them for an intermedia
 
 The hooks execute the relevant `make format-*` and `make check-*` targets, so ensure dependencies
 are installed (`make prepare` or `uv sync`).
+
+## Web UI development
+
+If you want to run Web UI from source, install [Node.js](https://nodejs.org/) (npm is required) and run
+`make build-web` once to build (and sync) the frontend.
+
+For frontend development with hot reload, run `make web-back` and `make web-front` in separate terminals.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ git clone https://github.com/MoonshotAI/kimi-cli.git
 cd kimi-cli
 
 make prepare  # prepare the development environment
+uv run kimi  # run Kimi Code CLI
 ```
 
 Then you can start working on Kimi Code CLI.


### PR DESCRIPTION
## Description

The previous docs did not clearly explain how to run Web UI from source or start hot reload, which made it hard for contributors to get Kimi Code CLI running locally. This change adds a concise Web UI development section in CONTRIBUTING.md that explains the build prerequisite (make build-web) and the two-terminal hot-reload workflow (make web-back and make web-front).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
