### PR TITLE
docs: fix Kimi IDE ACP config - add missing type: custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For example, to use Kimi Code CLI with [Zed](https://zed.dev/) or [JetBrains](ht
 {
   "agent_servers": {
     "Kimi Code CLI": {
+      "type": "custom",
       "command": "kimi",
       "args": ["acp"],
       "env": {}


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

Fix the official Kimi IDE ACP configuration by adding the missing `type: custom` field.

## Description

The Kimi IDE `settings.json` requires an explicit `"type": "custom"` field when configuring custom ACP agents. Without this field, the configuration is invalid and the ACP server will not be recognized by the IDE.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
