### PR TITLE
feat(cli): add build-web command and official wire file support

### DIFF
--- a/src/kimi_cli/cli/info.py
+++ b/src/kimi_cli/cli/info.py
@@ -46,6 +46,55 @@ def _emit_info(json_output: bool) -> None:
         typer.echo(line)
 
 
+def sdk_setup_text() -> str:
+    """Return Kimi Agent SDK / Wire setup instructions."""
+    text = """
+Welcome to Kimi Code CLI!
+
+# Wire SDK Setup
+## Prerequisites
+```
+pip install kimi-cli-agent-sdk
+```
+Or install from GitHub for the latest development version:
+```
+pip install git+https://github.com/moonshotai/kimi-sdk.git
+```
+
+## Usage example
+```python
+from kimi_cli.agent import KimiCLI
+
+async def main():
+    async with KimiCLI.connect() as wire:
+        # Send commands to Kimi CLI
+        await wire.send_message({
+            "method": "chat",
+            "params": {
+                "messages": [{"role": "user", "content": "Hello, Kimi!"}]
+            }
+        })
+        
+        # Wait for responses
+        async for response in wire.messages():
+            print(response)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
+
+For more information, check out the official documentation.
+""".strip()
+    return text
+
+
+@cli.command()
+def print_sdk_setup():
+    """Print Kimi Agent SDK / Wire setup instructions"""
+    typer.echo(sdk_setup_text())
+
+
 cli = typer.Typer(help="Show version and protocol information.")
 
 

--- a/src/kimi_cli/cli/web.py
+++ b/src/kimi_cli/cli/web.py
@@ -1,10 +1,123 @@
 """Web UI command for Kimi Code CLI."""
 
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
 from typing import Annotated
 
 import typer
 
 cli = typer.Typer(help="Run Kimi Code CLI web interface.")
+
+
+def resolve_npm() -> str | None:
+    candidates = ["npm"]
+    if os.name == "nt":
+        candidates.extend(["npm.cmd", "npm.exe", "npm.bat"])
+    for candidate in candidates:
+        npm = shutil.which(candidate)
+        if npm:
+            return npm
+    return None
+
+
+def run_npm(npm: str, args: list[str]) -> int:
+    try:
+        result = subprocess.run([npm, *args], check=False)
+    except FileNotFoundError:
+        print(
+            "npm not found or failed to execute. Install Node.js (npm) and ensure it is on PATH.",
+            file=sys.stderr,
+        )
+        return 1
+    return int(result.returncode)
+
+
+def build_web_ui(root: Path) -> int:
+    web_dir = root / "web"
+    dist_dir = web_dir / "dist"
+    node_modules = web_dir / "node_modules"
+    static_dir = root / "src" / "kimi_cli" / "web" / "static"
+    strict_version = os.environ.get("KIMI_WEB_STRICT_VERSION", "").lower() in {"1", "true", "yes"}
+    required_web_type_files = (
+        node_modules / "vite" / "client.d.ts",
+        node_modules / "@types" / "node" / "index.d.ts",
+    )
+
+    npm = resolve_npm()
+    if npm is None:
+        print("npm not found. Install Node.js (npm) to build the web UI.", file=sys.stderr)
+        return 1
+
+    pyproject = root / "pyproject.toml"
+    if not pyproject.exists():
+        print(f"pyproject.toml not found under {root}", file=sys.stderr)
+        return 1
+
+    with pyproject.open("rb") as handle:
+        project_data = tomllib.load(handle)
+    expected_version = str(project_data["project"]["version"])
+    explicit_expected = os.environ.get("KIMI_WEB_EXPECT_VERSION")
+    if explicit_expected and explicit_expected != expected_version:
+        print(
+            f"web version mismatch: pyproject={expected_version}, expected={explicit_expected}",
+            file=sys.stderr,
+        )
+        return 1
+
+    def has_required_web_type_files() -> bool:
+        return all(path.is_file() for path in required_web_type_files)
+
+    needs_install = (not node_modules.exists()) or (not has_required_web_type_files())
+    if needs_install:
+        if node_modules.exists():
+            print("web dependencies are incomplete; reinstalling with devDependencies...")
+        returncode = run_npm(npm, ["--prefix", str(web_dir), "ci", "--include=dev"])
+        if returncode != 0:
+            return returncode
+
+    returncode = run_npm(npm, ["--prefix", str(web_dir), "run", "build"])
+    if returncode != 0:
+        return returncode
+
+    if not dist_dir.exists():
+        print("web/dist not found after build. Check the web build output.", file=sys.stderr)
+        return 1
+
+    def find_version_in_dist(version: str) -> bool:
+        search_suffixes = {".js", ".css", ".html", ".map"}
+        version_with_prefix = f"v{version}"
+        found_plain = False
+        for path in dist_dir.rglob("*"):
+            if not path.is_file() or path.suffix not in search_suffixes:
+                continue
+            try:
+                content = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if version_with_prefix in content:
+                return True
+            if version in content:
+                found_plain = True
+        return found_plain
+
+    if strict_version and not find_version_in_dist(expected_version):
+        print(
+            f"web version not found in build output; expected version {expected_version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if static_dir.exists():
+        shutil.rmtree(static_dir)
+    static_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(dist_dir, static_dir)
+
+    print(f"Synced web UI to {static_dir}")
+    return 0
 
 
 @cli.callback(invoke_without_command=True)
@@ -78,3 +191,17 @@ def web(
         restrict_sensitive_apis=restrict_sensitive_apis,
         lan_only=lan_only,
     )
+
+
+@cli.command()
+def build(
+    root: Annotated[
+        Path,
+        typer.Option("--root", help="Repository root containing web/ and pyproject.toml"),
+    ] = Path("."),
+):
+    """Build and sync the web UI into src/kimi_cli/web/static"""
+    import sys
+    
+    result = build_web_ui(root.resolve())
+    sys.exit(result)


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
