### PR TITLE
fix: filter .git directory from file mention autocomplete

### DIFF
--- a/src/kimi_cli/web/api/sessions.py
+++ b/src/kimi_cli/web/api/sessions.py
@@ -524,12 +524,15 @@ async def get_session_file(
         )
 
     if file_path.is_dir():
+        hidden_dirs = {".git"}
         result: list[dict[str, str | int]] = []
         for subpath in file_path.iterdir():
             if restrict_sensitive_apis:
                 rel_subpath = rel_path / subpath.name
                 if _is_sensitive_relative_path(rel_subpath):
                     continue
+            if subpath.name.startswith(".") and subpath.name in hidden_dirs and subpath.is_dir():
+                continue
             if subpath.is_dir():
                 result.append({"name": subpath.name, "type": "directory"})
             else:


### PR DESCRIPTION
## Problem

When using `@` to mention files in the web UI, the `.git/` directory's internal objects (objects, refs, pack files, etc.) are included in the autocomplete results, polluting the file list with thousands of irrelevant entries.

## Fix

Skip the `.git` directory when iterating directory entries in the `get_session_file` endpoint (`web/api/sessions.py`).

Fixes #1339
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
