### PR TITLE
fix: escape Rich markup in error and user content to prevent crashes

### DIFF
--- a/src/kimi_cli/ui/print/__init__.py
+++ b/src/kimi_cli/ui/print/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from kosong.chat_provider import ChatProviderError
 from kosong.message import Message
 from rich import print
+from rich.markup import escape
 
 from kimi_cli.cli import InputFormat, OutputFormat
 from kimi_cli.soul import (
@@ -80,7 +81,7 @@ class Print:
                 if command:
                     logger.info("Running agent with command: {command}", command=command)
                     if self.output_format == "text" and not self.final_only:
-                        print(command)
+                        print(escape(command))
                     await run_soul(
                         self.soul,
                         command,
@@ -94,22 +95,22 @@ class Print:
                 command = None
         except LLMNotSet as e:
             logger.exception("LLM not set:")
-            print(str(e))
+            print(escape(str(e)))
         except LLMNotSupported as e:
             logger.exception("LLM not supported:")
-            print(str(e))
+            print(escape(str(e)))
         except ChatProviderError as e:
             logger.exception("LLM provider error:")
-            print(str(e))
+            print(escape(str(e)))
         except MaxStepsReached as e:
             logger.warning("Max steps reached: {n_steps}", n_steps=e.n_steps)
-            print(str(e))
+            print(escape(str(e)))
         except RunCancelled:
             logger.error("Interrupted by user")
             print("Interrupted by user")
         except BaseException as e:
             logger.exception("Unknown error:")
-            print(f"Unknown error: {e}")
+            print(f"Unknown error: {escape(str(e))}")
             raise
         finally:
             remove_sigint()


### PR DESCRIPTION
## Problem

In print mode, `from rich import print` replaces the builtin print. When error messages or user input contain text resembling Rich markup tags (e.g., `[/login]`), Rich throws `MarkupError`, crashing the CLI.

Stack trace starts at `ui/print/__init__.py` → `rich.console.print` → `rich.markup.render`.

## Fix

Escape all dynamic content with `rich.markup.escape()` before passing to `print()` in `ui/print/__init__.py`.

Fixes #1291
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
