### PR TITLE
feat: emit OSC terminal notifications on agent turn completion

### DIFF
--- a/src/kimi_cli/ui/shell/visualize.py
+++ b/src/kimi_cli/ui/shell/visualize.py
@@ -834,6 +834,21 @@ async def _keyboard_listener(
         await listener.stop()
 
 
+def _emit_osc_notification(title: str, body: str) -> None:
+    """Emit terminal notification via OSC 9 and OSC 777."""
+    # Use stderr fd directly because Rich's Live() may redirect sys.stdout,
+    # making sys.stdout.isatty() unreliable during rendering.
+    import os
+    if not os.isatty(2):
+        return
+    try:
+        # Write to stderr fd to bypass Rich's stdout proxy
+        os.write(2, f"\x1b]9;{body}\x07".encode())
+        os.write(2, f"\x1b]777;notify;{title};{body}\x07".encode())
+    except OSError:
+        pass
+
+
 class _LiveView:
     def __init__(self, initial_status: StatusUpdate, cancel_event: asyncio.Event | None = None):
         self._cancel_event = cancel_event
@@ -1396,6 +1411,7 @@ class _PromptLiveView(_LiveView):
                     self._turn_ended = True
                     self.cleanup(is_interrupt=False)
                     self._flush_prompt_refresh()
+                    _emit_osc_notification("Kimi", "Task completed")
                     break
 
                 self.dispatch_wire_message(msg)


### PR DESCRIPTION
## Feature

Emit OSC 9 and OSC 777 escape sequences when the agent completes a turn, enabling desktop notifications in supported terminals.

**Supported terminals:**
- OSC 9: iTerm2, Windows Terminal, ConEmu
- OSC 777: rxvt-unicode, VTE-based (GNOME Terminal, Tilix, etc.)

Only emits when stdout is a TTY to avoid noise in piped/redirected output.

Fixes #1342
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
