### PR TITLE
fix: add -NoProfile flag to PowerShell subprocess invocation

### DIFF
--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -127,5 +127,5 @@ class Shell(CallableTool2[Params]):
 
     def _shell_args(self, command: str) -> tuple[str, ...]:
         if self._is_powershell:
-            return (str(self._shell_path), "-command", command)
+            return (str(self._shell_path), "-NoProfile", "-command", command)
         return (str(self._shell_path), "-c", command)


### PR DESCRIPTION
## Problem

On Windows, Kimi CLI runs PowerShell without `-NoProfile`, causing the user's profile to load. If the profile contains UI commands (e.g., setting `CursorPosition`), they fail in the non-interactive subprocess, making the Shell tool completely unusable.

## Fix

Add `-NoProfile` flag before `-command` in `_shell_args()` (`tools/shell/__init__.py`).

Fixes #1341
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
