### PR TITLE
fix: enable proxy support via environment variables in aiohttp

### DIFF
--- a/src/kimi_cli/utils/aiohttp.py
+++ b/src/kimi_cli/utils/aiohttp.py
@@ -9,4 +9,7 @@ _ssl_context = ssl.create_default_context(cafile=certifi.where())
 
 
 def new_client_session() -> aiohttp.ClientSession:
-    return aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=_ssl_context))
+    return aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(ssl=_ssl_context),
+        trust_env=True,
+    )


### PR DESCRIPTION
## Problem

`aiohttp.ClientSession` does not read `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` environment variables by default (`trust_env` defaults to `False`). Users behind corporate proxies cannot use kimi-cli.

## Fix

Set `trust_env=True` in `new_client_session()` (`utils/aiohttp.py`).

Fixes #1234
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
