### PR TITLE
fix: strip unsupported JSON Schema fields for Google GenAI provider

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
@@ -354,12 +354,23 @@ def tool_to_google_genai(tool: KosongTool) -> Tool:
     """Convert a Kosong tool to GoogleGenAI tool format."""
     # Kosong already validates parameters as JSON Schema format via jsonschema
     # The google-genai SDK accepts dict format and internally converts to Schema
+    parameters = tool.parameters
+    if isinstance(parameters, dict):
+        # Resolve $ref entries and remove $defs/definitions properly so that
+        # nested parameter types are preserved instead of becoming dangling refs
+        from kosong.utils.jsonschema import deref_json_schema
+
+        parameters = deref_json_schema(parameters)
+        # Strip remaining JSON Schema metadata fields that the google-genai SDK's
+        # Pydantic model rejects with extra_forbidden validation errors
+        unsupported_keys = {"$schema", "$id", "$comment"}
+        parameters = {k: v for k, v in parameters.items() if k not in unsupported_keys}
     return Tool(
         function_declarations=[
             FunctionDeclaration(
                 name=tool.name,
                 description=tool.description,
-                parameters=tool.parameters,  # type: ignore[arg-type] # GoogleGenAI accepts dict
+                parameters=parameters,  # type: ignore[arg-type] # GoogleGenAI accepts dict
             )
         ]
     )


### PR DESCRIPTION
## Problem

When MCP tools provide standard JSON Schema parameters containing metadata fields like `$schema`, the google-genai SDK's Pydantic model rejects them with `extra_forbidden` validation errors, preventing tool calls.

## Fix

Strip unsupported JSON Schema metadata fields (`$schema`, `$id`, `$ref`, `$comment`, `definitions`, `$defs`) from tool parameters in `tool_to_google_genai()` before passing to the SDK.

Fixes #734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
