### PR TITLE
fix: source uv environment after fresh installation in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,22 @@ if command -v uv >/dev/null 2>&1; then
   UV_BIN="uv"
 else
   install_uv
+
+  # The uv installer adds itself to ~/.local/bin (or $CARGO_HOME/bin)
+  # but doesn't update the current shell's PATH. Source all available
+  # env scripts and ensure the default location is on PATH.
+  if [ -f "$HOME/.local/bin/env" ]; then
+    . "$HOME/.local/bin/env"
+  fi
+  if [ -f "${CARGO_HOME:-$HOME/.cargo}/env" ]; then
+    . "${CARGO_HOME:-$HOME/.cargo}/env"
+  fi
+  # Always add ~/.local/bin as fallback in case env scripts don't cover it
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) export PATH="$HOME/.local/bin:$PATH" ;;
+  esac
+
   UV_BIN="uv"
 fi
 


### PR DESCRIPTION
## Problem

After installing uv via the astral.sh installer, the current shell's PATH is not updated, causing `uv not found after installation` errors.

## Fix

Source the uv env script (`~/.local/bin/env` or `$CARGO_HOME/env`) after installation, with a fallback to manually adding `~/.local/bin` to PATH.

Fixes #1107
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
