### PR TITLE
feat: persist approve_for_session decisions across session resume

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -117,7 +117,7 @@ class Runtime:
                 KIMI_SKILLS=skills_formatted or "No skills found.",
             ),
             denwa_renji=DenwaRenji(),
-            approval=Approval(yolo=yolo),
+            approval=Approval(yolo=yolo, session_dir=session.dir),
             labor_market=LaborMarket(),
             environment=environment,
             skills=skills_by_name,

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 from kimi_cli.soul.toolset import get_current_tool_call_or_none
@@ -25,17 +27,41 @@ type Response = Literal["approve", "approve_for_session", "reject"]
 
 
 class ApprovalState:
-    def __init__(self, yolo: bool = False):
+    def __init__(self, yolo: bool = False, session_dir: Path | None = None):
         self.yolo = yolo
-        self.auto_approve_actions: set[str] = set()  # TODO: persist across sessions
+        self.auto_approve_actions: set[str] = set()
         """Set of action names that should automatically be approved."""
+        self._state_file = session_dir / "approval_state.json" if session_dir else None
+        self._load()
+
+    def _load(self) -> None:
+        if self._state_file is None or not self._state_file.exists():
+            return
+        try:
+            data = json.loads(self._state_file.read_text(encoding="utf-8"))
+            actions = data.get("auto_approve_actions", [])
+            if isinstance(actions, list):
+                self.auto_approve_actions = set(actions)
+        except Exception:
+            logger.debug("Failed to load approval state, starting fresh")
+
+    def _save(self) -> None:
+        if self._state_file is None:
+            return
+        try:
+            self._state_file.write_text(
+                json.dumps({"auto_approve_actions": sorted(self.auto_approve_actions)}),
+                encoding="utf-8",
+            )
+        except Exception:
+            logger.debug("Failed to save approval state")
 
 
 class Approval:
-    def __init__(self, yolo: bool = False, *, state: ApprovalState | None = None):
+    def __init__(self, yolo: bool = False, *, state: ApprovalState | None = None, session_dir: Path | None = None):
         self._request_queue = Queue[Request]()
         self._requests: dict[str, tuple[Request, asyncio.Future[bool]]] = {}
-        self._state = state or ApprovalState(yolo=yolo)
+        self._state = state or ApprovalState(yolo=yolo, session_dir=session_dir)
 
     def share(self) -> Approval:
         """Create a new approval queue that shares state (yolo + auto-approve)."""
@@ -141,6 +167,7 @@ class Approval:
                 future.set_result(True)
             case "approve_for_session":
                 self._state.auto_approve_actions.add(request.action)
+                self._state._save()
                 future.set_result(True)
             case "reject":
                 future.set_result(False)


### PR DESCRIPTION
## Problem

When resuming a session, actions previously approved via 'approve for session' are lost because `ApprovalState.auto_approve_actions` is only kept in memory (there's a TODO comment about this).

## Fix

- Add `session_dir` parameter to `ApprovalState` and `Approval`
- Persist `auto_approve_actions` to `approval_state.json` in the session directory
- Load saved state on initialization
- Save state whenever an action is approved for session
- Pass `session.dir` from `Runtime.create()`

Deleting the state file resets approvals, as expected.

Fixes #765
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
