### PR TITLE
fix: use ANSI red for yolo indicator to improve readability

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1567,7 +1567,7 @@ class CustomPromptSession:
                 mode += f" ({', '.join(mode_details)})"
         status = self._status_provider()
         if status.yolo_enabled:
-            fragments.extend([("bold fg:#ffff00", "yolo"), ("", " " * 2)])
+            fragments.extend([("bold fg:ansired", "yolo"), ("", " " * 2)])
             columns -= len("yolo") + 2
         if status.plan_mode:
             fragments.extend([("bold fg:#00aaff", "plan"), ("", " " * 2)])


### PR DESCRIPTION
## Problem

The yolo indicator uses hardcoded `fg:#ffff00` (bright yellow), which is nearly invisible on light terminal backgrounds (e.g., Ghostty light theme).

## Fix

Switch to `ansired` which uses the terminal's own palette color, adapting to both light and dark themes. Red also better conveys the 'caution' semantics of yolo mode.

Fixes #1301
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
