### PR TITLE
fix: restore codeblock copy functionality in Web UI

### DIFF
--- a/web/src/components/ai-elements/code-block.tsx
+++ b/web/src/components/ai-elements/code-block.tsx
@@ -508,13 +508,25 @@ export const CodeBlockCopyButton = ({
   const { code } = useContext(CodeBlockContext);
 
   const copyToClipboard = async () => {
-    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+    if (typeof window === "undefined") {
       onError?.(new Error("Clipboard API not available"));
       return;
     }
 
     try {
-      await navigator.clipboard.writeText(code);
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      } else {
+        // Fallback for non-secure contexts (plain HTTP, Termux, etc.)
+        const textarea = document.createElement("textarea");
+        textarea.value = code;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
       setIsCopied(true);
       onCopy?.();
       setTimeout(() => setIsCopied(false), timeout);


### PR DESCRIPTION
## Related Issue

Resolve #1340

## Description

The `navigator.clipboard.writeText` API requires a **secure context** (HTTPS or `localhost`). When the Web UI is accessed over plain HTTP (e.g., remote server, Android Termux), the Clipboard API is unavailable and the copy button silently does nothing.

**Root cause:** The original code checked for `navigator.clipboard.writeText` availability upfront and returned early with an `onError` callback if missing — but the error was never surfaced to the user, making the button appear broken.

**Fix:** Instead of bailing out when the Clipboard API is unavailable, fall back to the legacy `document.execCommand("copy")` approach using a temporary off-screen `<textarea>`. This works in non-secure contexts and on older browsers.

- Clipboard API is still preferred when available (secure contexts)
- Fallback uses `document.execCommand("copy")` with a hidden `<textarea>`
- Error handling is preserved for both paths

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.