### PR TITLE
fix: resolve git diff status bar overlap with prompt input in web UI

### DIFF
--- a/web/src/features/chat/components/chat-prompt-composer.tsx
+++ b/web/src/features/chat/components/chat-prompt-composer.tsx
@@ -127,7 +127,7 @@ export const ChatPromptComposer = memo(function ChatPromptComposerComponent({
 
   return (
     <div className="w-full">
-      <div className="w-full px-2">
+      <div className="w-full px-2 relative z-10">
         <GitDiffStatusBar
           stats={gitDiffStats ?? null}
           isLoading={isGitDiffLoading}

--- a/web/src/features/chat/components/git-diff-status-bar.tsx
+++ b/web/src/features/chat/components/git-diff-status-bar.tsx
@@ -222,8 +222,8 @@ export const GitDiffStatusBar = memo(function GitDiffStatusBarComponent({
           )}
         </div>
       </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="max-h-32 overflow-y-auto">
+      <CollapsibleContent className="overflow-hidden">
+        <div className="max-h-48 overflow-y-auto border-t border-border/50">
           {files.map((file) => (
             <div
               key={file.path}


### PR DESCRIPTION
## Problem

The git diff status bar's collapsible file list overlaps with the prompt input area below it, obscuring the input.

## Fix

- Add `relative z-10` to the status bar wrapper for proper stacking
- Add `overflow-hidden` to `CollapsibleContent` to contain expansion
- Add separator border when file list is expanded
- Increase max height from 128px to 192px for better usability

Fixes #1302
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
