### PR TITLE
fix: enable inline math formula rendering in web UI

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "gitdiff-parser": "^0.3.1",
     "js-md5": "^0.8.3",
     "js-yaml": "^4.1.1",
+    "katex": "^0.16.28",
     "lucide-react": "^0.561.0",
     "motion": "^12.23.24",
     "nanoid": "^5.1.6",

--- a/web/src/bootstrap.tsx
+++ b/web/src/bootstrap.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "katex/dist/katex.min.css";
 import App from "./App.tsx";
 import { ErrorBoundary } from "./components/error-boundary";
 

--- a/web/src/components/ai-elements/streamdown.tsx
+++ b/web/src/components/ai-elements/streamdown.tsx
@@ -28,11 +28,14 @@ export const safeRehypePlugins: StreamdownProps["rehypePlugins"] = [
  * 2. Escapes both < and > in HTML-like tags elsewhere
  */
 export const escapeHtmlOutsideCodeBlocks = (text: string): string => {
-  // Match ONLY valid fenced code blocks (``` at line start) and inline code.
-  // Mid-line ``` is a syntax error and should be treated as plain text.
-  // Fenced code blocks: ``` at line start, optional language, content, then \n```
-  // Also match inline code: `..` (single backticks, no newlines inside)
-  const codeBlockRegex = /(^|\n)```[a-z]*\n[\s\S]*?\n```|`[^`\n]+`/g;
+  // Match regions that should NOT be escaped:
+  // 1. Fenced code blocks: ``` at line start, optional language, content, then \n```
+  // 2. Inline code: `..` (single backticks, no newlines inside)
+  // 3. Display math: $$...$$ (can span multiple lines)
+  // 4. Inline math: $...$ (no newlines, non-empty, no leading/trailing space)
+  // Math delimiters must be preserved because KaTeX needs raw < and > for expressions like $x < y$.
+  const codeBlockRegex =
+    /(^|\n)```[a-z]*\n[\s\S]*?\n```|`[^`\n]+`|\$\$[\s\S]*?\$\$|\$(?!\s)[^$\n]+(?<!\s)\$/g;
   const codeBlocks: { start: number; end: number }[] = [];
 
   // Find all valid code blocks


### PR DESCRIPTION
## Problem

Block math (`$$...$$`) renders correctly, but inline math (`$...$`) does not because all rehype plugins are disabled in the streamdown configuration.

## Fix

Re-enable the `'katex'` rehype plugin specifically. KaTeX only processes math delimiters and does not pose an XSS risk (unlike the `'raw'` and `'harden'` plugins which remain disabled).

Also import `katex/dist/katex.min.css` for proper formula styling. The katex package is already a transitive dependency of streamdown (confirmed in package-lock.json).

Fixes #1420
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
