### PR TITLE
fix: enforce UTF-8 encoding on Windows to prevent ASCII crashes

### DIFF
--- a/src/kimi_cli/__main__.py
+++ b/src/kimi_cli/__main__.py
@@ -1,8 +1,40 @@
 from __future__ import annotations
 
+import io
+import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+
+
+def _ensure_utf8_stdio() -> None:
+    """Reconfigure stdout/stderr to UTF-8 on Windows to prevent ASCII encoding crashes.
+
+    On Windows with certain locales, Python defaults to a legacy ANSI code page
+    (e.g. cp1252 or even ascii), which causes UnicodeEncodeError when printing
+    emoji or CJK characters used in prompt symbols and model output.
+    """
+    if sys.platform != "win32":
+        return
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        if stream is None or getattr(stream, "encoding", "").lower().replace("-", "") == "utf8":
+            continue
+        if isinstance(stream, io.TextIOWrapper):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:
+                pass
+        else:
+            try:
+                binary = getattr(stream, "buffer", None)
+                if binary is not None:
+                    wrapper = io.TextIOWrapper(binary, encoding="utf-8", errors="replace", line_buffering=stream.line_buffering)
+                    setattr(sys, stream_name, wrapper)
+            except Exception:
+                pass
+    # Also hint to child processes
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
 
 
 def _prog_name() -> str:
@@ -10,6 +42,7 @@ def _prog_name() -> str:
 
 
 def main(argv: Sequence[str] | None = None) -> int | str | None:
+    _ensure_utf8_stdio()
     args = list(sys.argv[1:] if argv is None else argv)
 
     if len(args) == 1 and args[0] in {"--version", "-V"}:

--- a/src/kimi_cli/ui/shell/console.py
+++ b/src/kimi_cli/ui/shell/console.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from rich.console import Console
 from rich.theme import Theme
 
@@ -29,4 +31,10 @@ NEUTRAL_MARKDOWN_THEME = Theme(
 )
 
 _NEUTRAL_MARKDOWN_THEME = NEUTRAL_MARKDOWN_THEME
-console = Console(highlight=False, theme=NEUTRAL_MARKDOWN_THEME)
+
+_force_utf8 = sys.platform == "win32"
+console = Console(
+    highlight=False,
+    theme=NEUTRAL_MARKDOWN_THEME,
+    **({"force_terminal": True} if _force_utf8 else {}),
+)

--- a/tests/utils/test_utf8_encoding.py
+++ b/tests/utils/test_utf8_encoding.py
@@ -1,0 +1,65 @@
+"""Tests for UTF-8 encoding enforcement on Windows.
+
+Regression tests for issue #773: on Windows with a legacy ANSI code page,
+printing emoji prompt symbols (✨, 💫, 📋) crashes with
+'ascii' codec can't encode characters.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+class TestEnsureUtf8Stdio:
+    """Test _ensure_utf8_stdio from __main__."""
+
+    def test_noop_on_non_windows(self) -> None:
+        """Should do nothing on non-Windows platforms."""
+        from kimi_cli.__main__ import _ensure_utf8_stdio
+
+        with patch.object(sys, "platform", "linux"):
+            # Should return without touching streams
+            _ensure_utf8_stdio()
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_reconfigures_ascii_stdout_on_windows(self) -> None:
+        """stdout should be reconfigured to UTF-8 when defaulting to ASCII."""
+        from kimi_cli.__main__ import _ensure_utf8_stdio
+
+        buf = io.BytesIO()
+        fake_stdout = io.TextIOWrapper(buf, encoding="ascii")
+        with patch.object(sys, "stdout", fake_stdout), patch.object(sys, "platform", "win32"):
+            _ensure_utf8_stdio()
+            assert sys.stdout.encoding.lower().replace("-", "") == "utf8"
+
+    def test_skips_when_already_utf8(self) -> None:
+        """Should not touch streams already using UTF-8."""
+        from kimi_cli.__main__ import _ensure_utf8_stdio
+
+        buf = io.BytesIO()
+        fake_stdout = io.TextIOWrapper(buf, encoding="utf-8")
+        original_stdout = sys.stdout
+        with patch.object(sys, "stdout", fake_stdout), patch.object(sys, "platform", "win32"):
+            _ensure_utf8_stdio()
+            # The wrapper should remain the same object (not replaced)
+            assert sys.stdout is fake_stdout
+
+
+class TestConsoleEncoding:
+    """Test that the Rich console can handle emoji and CJK without errors."""
+
+    def test_console_prints_emoji(self) -> None:
+        """Console must render prompt emoji without UnicodeEncodeError."""
+        from kimi_cli.ui.shell.console import console
+
+        buf = io.StringIO()
+        # Render to a string buffer to verify no encoding crash
+        with console.capture() as capture:
+            console.print("✨ 💫 📋 Hello 你好")
+        output = capture.get()
+        assert "✨" in output
+        assert "你好" in output


### PR DESCRIPTION
## Related Issue

Resolve #773

## Description

On Windows with legacy ANSI code pages (e.g. `cp1252` or `ascii`), Python defaults `sys.stdout`/`sys.stderr` to the system code page. This causes `UnicodeEncodeError: 'ascii' codec can't encode characters` when printing emoji prompt symbols (`✨`, `💫`, `📋`) or CJK characters in model output — making the CLI completely unusable for affected users.

### Root cause

1. **`sys.stdout`/`sys.stderr` default to ASCII** on Windows with certain locale settings
2. **Rich `Console`** inherits the stream encoding, so `console.print()` with non-ASCII content raises `UnicodeEncodeError`
3. Prompt symbols like `PROMPT_SYMBOL_THINKING = "💫"` are hardcoded emoji that require UTF-8

### Changes

- **`__main__.py`**: Added `_ensure_utf8_stdio()` that runs at startup on Windows:
  - Reconfigures `sys.stdout`/`sys.stderr` to UTF-8 via `stream.reconfigure(encoding="utf-8")`
  - Falls back to wrapping with `io.TextIOWrapper(buffer, encoding="utf-8")` for non-standard streams
  - Sets `PYTHONIOENCODING=utf-8` env var for child processes
- **`ui/shell/console.py`**: Enabled `force_terminal=True` on Windows to prevent Rich from falling back to a dumb terminal with limited encoding support
- **Tests**: Added regression tests for UTF-8 enforcement and console emoji rendering

### Testing

- Verified emoji and CJK characters render without `UnicodeEncodeError`
- Existing tests remain green (no behavioral change on non-Windows platforms)
- `_ensure_utf8_stdio()` is a no-op when encoding is already UTF-8

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
