### PR TITLE
fix: support Cmd+V paste alongside Ctrl+V on macOS

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import sys
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Sequence
@@ -940,7 +941,8 @@ def _build_toolbar_tips(clipboard_available: bool) -> list[str]:
         "ctrl-j: newline",
     ]
     if clipboard_available:
-        tips.append("ctrl-v: paste clipboard")
+        paste_key = "cmd-v / ctrl-v" if sys.platform == "darwin" else "ctrl-v"
+        tips.append(f"{paste_key}: paste clipboard")
     tips.append("@: mention files")
     return tips
 
@@ -985,6 +987,7 @@ class CustomPromptSession:
         self._running_prompt_previous_mode: PromptMode | None = None
         self._running_prompt_delegate: RunningPromptDelegate | None = None
         clipboard_available = is_clipboard_available()
+        self._clipboard_available = clipboard_available
         self._tips = _build_toolbar_tips(clipboard_available)
 
         history_entries = _load_history_entries(self._history_file)
@@ -1476,6 +1479,8 @@ class CustomPromptSession:
         buffer.insert_text(token_or_text)
 
     def _handle_bracketed_paste(self, event: KeyPressEvent) -> None:
+        if self._clipboard_available and self._try_paste_media(event):
+            return
         self._insert_pasted_text(event.current_buffer, event.data)
         event.app.invalidate()
 

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -58,7 +58,7 @@ _KEYBOARD_SHORTCUTS = [
     ("Shift-Tab", "Toggle plan mode (read-only research)"),
     ("Ctrl-O", "Edit in external editor ($VISUAL/$EDITOR)"),
     ("Ctrl-J / Alt-Enter", "Insert newline"),
-    ("Ctrl-V", "Paste (supports images)"),
+    ("Ctrl-V / Cmd-V", "Paste (supports images)"),
     ("Ctrl-D", "Exit"),
     ("Ctrl-C", "Interrupt"),
 ]


### PR DESCRIPTION
## Related Issue

Resolve #1433

## Description

On macOS, Cmd+V is the standard paste shortcut, but the CLI only handled Ctrl+V for clipboard media paste (images, files). When users pressed Cmd+V, the terminal sent the clipboard content via bracketed paste, which was inserted as raw text (file paths) instead of being processed as media.

### Changes:
1. **`_handle_bracketed_paste`** now attempts media paste (`_try_paste_media`) first when clipboard is available, falling back to text insertion if no media is found. This ensures Cmd+V (which terminals send as bracketed paste) also triggers image/file detection.
2. **Toolbar tips** show `cmd-v / ctrl-v` on macOS instead of just `ctrl-v`.
3. **Help text** (`/help`) updated to show `Ctrl-V / Cmd-V` for the paste shortcut.

## Checklist

- [x] I've read the [contributing guide](CONTRIBUTING.md)
- [x] I've confirmed this change works on macOS (Darwin arm64)
- [x] Syntax verified on changed files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
