### PR TITLE
fix: suppress verbose MCP debug messages from console output

### DIFF
--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -339,7 +339,8 @@ def kimi(
 
     # Don't redirect stderr yet. Our stderr redirector replaces fd=2 with a pipe, which
     # would swallow Click/Typer startup errors (e.g. config parsing / BadParameter).
-    # We re-enable stderr redirection after KimiCLI.create() succeeds.
+    # We re-enable stderr redirection just before KimiCLI.create(), after CLI parsing
+    # is complete but before MCP servers are loaded.
     enable_logging(debug, redirect_stderr=False)
 
     def _emit_fatal_error(message: str) -> None:
@@ -526,6 +527,11 @@ def kimi(
                 if changed:
                     session.save_state()
 
+            # Enable stderr redirection before MCP loading to capture verbose
+            # debug messages from mcp-remote and similar libraries. CLI parsing
+            # is already complete at this point, so startup errors have been shown.
+            redirect_stderr_to_logger()
+
             instance = await KimiCLI.create(
                 session,
                 config=config,
@@ -542,10 +548,6 @@ def kimi(
                 defer_mcp_loading=ui == "shell" and prompt is None,
             )
             startup_progress.stop()
-
-            # Install stderr redirection only after initialization succeeded, so runtime
-            # stderr noise is captured into logs without hiding startup failures.
-            redirect_stderr_to_logger()
             preserve_background_tasks = False
             try:
                 match ui:


### PR DESCRIPTION
## Related Issue

Resolve #1214

## Description

When using the `-C` flag (or any mode that loads MCP servers), verbose debug/trace messages from the `mcp-remote` library were printed directly to the console during startup. This happened because `redirect_stderr_to_logger()` was called *after* `KimiCLI.create()`, but MCP server loading occurs *inside* `KimiCLI.create()`.

This PR moves the `redirect_stderr_to_logger()` call to just before `KimiCLI.create()`, so that stderr output from MCP server initialization is captured into the log file instead of cluttering the console. At this point, CLI argument parsing is already complete, so any startup errors (e.g., config parsing / BadParameter) will have already been displayed to the user.

### Changes

- **`src/kimi_cli/cli/__init__.py`**: Moved `redirect_stderr_to_logger()` from after `KimiCLI.create()` to before it, and updated the surrounding comments to reflect the new placement rationale.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
