### PR TITLE
fix: handle Kitty keyboard protocol Enter key in VS Code terminal

### DIFF
--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -38,7 +38,7 @@ from kimi_cli.utils.logging import open_original_stderr
 from kimi_cli.utils.signals import install_sigint_handler
 from kimi_cli.utils.slashcmd import SlashCommand, SlashCommandCall, parse_slash_command_call
 from kimi_cli.utils.subprocess_env import get_clean_env
-from kimi_cli.utils.term import ensure_new_line, ensure_tty_sane
+from kimi_cli.utils.term import disable_kitty_keyboard_protocol, ensure_new_line, ensure_tty_sane
 from kimi_cli.wire.types import ContentPart, StatusUpdate
 
 
@@ -159,6 +159,8 @@ class Shell:
             await idle_events.put(_PromptEvent(kind="input", user_input=user_input))
 
     async def run(self, command: str | None = None) -> bool:
+        disable_kitty_keyboard_protocol()
+
         if command is not None:
             # run single command and exit
             logger.info("Running agent with command: {command}", command=command)

--- a/src/kimi_cli/ui/shell/keyboard.py
+++ b/src/kimi_cli/ui/shell/keyboard.py
@@ -162,23 +162,39 @@ def _listen_for_keyboard_unix(
 
             if c == b"\x1b":
                 sequence = c
-                for _ in range(2):
-                    if cancel.is_set():
-                        break
-                    try:
-                        fragment = sys.stdin.buffer.read(1)
-                    except (OSError, ValueError):
-                        fragment = b""
-                    if not fragment:
-                        break
-                    sequence += fragment
-                    if sequence in _ARROW_KEY_MAP:
-                        break
+                try:
+                    next_byte = sys.stdin.buffer.read(1)
+                except (OSError, ValueError):
+                    next_byte = b""
 
-                event = _ARROW_KEY_MAP.get(sequence)
-                if event is not None:
-                    emit(event)
-                elif sequence == b"\x1b":
+                if next_byte == b"[":
+                    # CSI sequence – read until a final byte (0x40–0x7E)
+                    sequence += next_byte
+                    for _ in range(16):
+                        if cancel.is_set():
+                            break
+                        try:
+                            fragment = sys.stdin.buffer.read(1)
+                        except (OSError, ValueError):
+                            fragment = b""
+                        if not fragment:
+                            break
+                        sequence += fragment
+                        if 0x40 <= fragment[0] <= 0x7E:
+                            break
+
+                    event = _ARROW_KEY_MAP.get(sequence)
+                    if event is None:
+                        event = _parse_csi_u(sequence)
+                    if event is not None:
+                        emit(event)
+                elif next_byte:
+                    # Non-CSI escape sequence – try the 2-byte map
+                    sequence += next_byte
+                    event = _ARROW_KEY_MAP.get(sequence)
+                    if event is not None:
+                        emit(event)
+                else:
                     emit(KeyEvent.ESCAPE)
             elif c in (b"\r", b"\n"):
                 emit(KeyEvent.ENTER)
@@ -282,6 +298,30 @@ _ARROW_KEY_MAP: dict[bytes, KeyEvent] = {
     b"\x1b[C": KeyEvent.RIGHT,
     b"\x1b[D": KeyEvent.LEFT,
 }
+
+_CSI_U_KEY_MAP: dict[int, KeyEvent] = {
+    13: KeyEvent.ENTER,
+    9: KeyEvent.TAB,
+    27: KeyEvent.ESCAPE,
+    32: KeyEvent.SPACE,
+}
+
+
+def _parse_csi_u(sequence: bytes) -> KeyEvent | None:
+    """Parse a Kitty keyboard protocol CSI-u sequence.
+
+    Format: ``ESC [ <keycode> [; <modifiers> [; <text>]] u``
+    For example ``\\x1b[13u`` is Enter and ``\\x1b[13;2u`` is Shift+Enter.
+    """
+    if not sequence.startswith(b"\x1b[") or not sequence.endswith(b"u"):
+        return None
+    params = sequence[2:-1]  # between '[' and 'u'
+    parts = params.split(b";")
+    try:
+        keycode = int(parts[0])
+    except (ValueError, IndexError):
+        return None
+    return _CSI_U_KEY_MAP.get(keycode)
 
 _WINDOWS_KEY_MAP: dict[bytes, KeyEvent] = {
     b"H": KeyEvent.UP,  # Up arrow

--- a/src/kimi_cli/utils/term.py
+++ b/src/kimi_cli/utils/term.py
@@ -7,6 +7,21 @@ import sys
 import time
 
 
+def disable_kitty_keyboard_protocol() -> None:
+    """Disable the Kitty keyboard protocol by sending the "pop" escape sequence.
+
+    VS Code >= 1.109.0 enables the Kitty keyboard protocol which encodes key
+    presses as CSI-u sequences (e.g. ``\\x1b[13u`` for Enter).
+    ``prompt_toolkit`` 3.x does not recognise these, so raw characters like
+    ``[13u`` leak into user input.  Sending ``\\x1b[<u`` asks the terminal to
+    revert to the standard key encoding.
+    """
+    if not sys.stdout.isatty():
+        return
+    sys.stdout.write("\x1b[<u")
+    sys.stdout.flush()
+
+
 def ensure_new_line() -> None:
     """Ensure the next prompt starts at column 0 regardless of prior command output."""
 

--- a/tests/ui_and_conv/test_keyboard.py
+++ b/tests/ui_and_conv/test_keyboard.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from kimi_cli.ui.shell.keyboard import KeyEvent, _parse_csi_u
+
+
+class TestParseCsiU:
+    """Tests for Kitty keyboard protocol CSI-u sequence parsing."""
+
+    def test_enter(self) -> None:
+        assert _parse_csi_u(b"\x1b[13u") == KeyEvent.ENTER
+
+    def test_tab(self) -> None:
+        assert _parse_csi_u(b"\x1b[9u") == KeyEvent.TAB
+
+    def test_escape(self) -> None:
+        assert _parse_csi_u(b"\x1b[27u") == KeyEvent.ESCAPE
+
+    def test_space(self) -> None:
+        assert _parse_csi_u(b"\x1b[32u") == KeyEvent.SPACE
+
+    def test_enter_with_modifier(self) -> None:
+        # Shift+Enter: \x1b[13;2u — keycode should still be recognised
+        assert _parse_csi_u(b"\x1b[13;2u") == KeyEvent.ENTER
+
+    def test_enter_with_multiple_params(self) -> None:
+        # \x1b[13;1;13u — keycode + modifier + text event
+        assert _parse_csi_u(b"\x1b[13;1;13u") == KeyEvent.ENTER
+
+    def test_unknown_keycode(self) -> None:
+        assert _parse_csi_u(b"\x1b[97u") is None  # 'a' — not mapped
+
+    def test_not_csi_u_suffix(self) -> None:
+        assert _parse_csi_u(b"\x1b[A") is None  # arrow key, not CSI-u
+
+    def test_not_csi_prefix(self) -> None:
+        assert _parse_csi_u(b"\x1bOu") is None
+
+    def test_invalid_keycode(self) -> None:
+        assert _parse_csi_u(b"\x1b[u") is None
+
+    def test_empty_sequence(self) -> None:
+        assert _parse_csi_u(b"") is None

--- a/tests/utils/test_term.py
+++ b/tests/utils/test_term.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from kimi_cli.utils.term import disable_kitty_keyboard_protocol
+
+
+class TestDisableKittyKeyboardProtocol:
+    def test_sends_pop_sequence_to_tty(self) -> None:
+        with (
+            patch("kimi_cli.utils.term.sys.stdout") as mock_stdout,
+        ):
+            mock_stdout.isatty.return_value = True
+            disable_kitty_keyboard_protocol()
+            mock_stdout.write.assert_called_once_with("\x1b[<u")
+            mock_stdout.flush.assert_called_once()
+
+    def test_skips_non_tty(self) -> None:
+        with patch("kimi_cli.utils.term.sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = False
+            disable_kitty_keyboard_protocol()
+            mock_stdout.write.assert_not_called()


### PR DESCRIPTION
## Related Issue

Resolve #1437

## Description

VS Code >= 1.109.0 enables the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), which encodes key presses as CSI-u sequences (e.g. `\x1b[13u` for Enter). `prompt_toolkit` 3.x does not recognise these sequences, so raw characters like `[13u` leak into user input instead of being interpreted as the Enter key.

This PR applies two complementary strategies:

1. **Disable the Kitty protocol at shell startup** — `disable_kitty_keyboard_protocol()` in `term.py` sends the "pop" escape sequence (`\x1b[<u`) to revert the terminal to standard key encoding. This is called once from `Shell.run()`.

2. **Parse CSI-u sequences in the keyboard listener** — The escape sequence reader in `keyboard.py` is extended to read full CSI sequences (not just 2 bytes after ESC) and map Kitty CSI-u keycodes (Enter=13, Tab=9, Escape=27, Space=32) to the correct `KeyEvent` values. This serves as a defense-in-depth measure for the `KeyboardListener` used during task visualization.

### Changes

- `src/kimi_cli/utils/term.py` — Added `disable_kitty_keyboard_protocol()` 
- `src/kimi_cli/ui/shell/__init__.py` — Call `disable_kitty_keyboard_protocol()` at shell startup
- `src/kimi_cli/ui/shell/keyboard.py` — Rewrote CSI sequence reader to handle variable-length sequences; added `_parse_csi_u()` and `_CSI_U_KEY_MAP`
- `tests/utils/test_term.py` — Unit tests for the disable function
- `tests/ui_and_conv/test_keyboard.py` — Unit tests for CSI-u parsing

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
