### PR TITLE
fix: add Alt+V as alternative paste shortcut on Windows

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import sys
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Sequence
@@ -940,7 +941,12 @@ def _build_toolbar_tips(clipboard_available: bool) -> list[str]:
         "ctrl-j: newline",
     ]
     if clipboard_available:
-        tips.append("ctrl-v: paste clipboard")
+        if sys.platform == "win32":
+            tips.append("ctrl-v / alt-v: paste clipboard")
+        elif sys.platform == "darwin":
+            tips.append("cmd-v / ctrl-v: paste clipboard")
+        else:
+            tips.append("ctrl-v: paste clipboard")
     tips.append("@: mention files")
     return tips
 
@@ -1196,6 +1202,19 @@ class CustomPromptSession:
                     return
                 self._insert_pasted_text(event.current_buffer, clipboard_data.text)
                 event.app.invalidate()
+
+            if sys.platform == "win32":
+                # On Windows Terminal, Ctrl+V is intercepted by the terminal
+                # for its own paste. Add Alt+V as an alternative shortcut.
+                @_kb.add("escape", "v", eager=True)
+                def _(event: KeyPressEvent) -> None:
+                    if self._try_paste_media(event):
+                        return
+                    clipboard_data = event.app.clipboard.get_data()
+                    if clipboard_data is None:  # type: ignore[reportUnnecessaryComparison]
+                        return
+                    self._insert_pasted_text(event.current_buffer, clipboard_data.text)
+                    event.app.invalidate()
 
             clipboard = PyperclipClipboard()
         else:


### PR DESCRIPTION
## Related Issue

Resolve #781

## Description

Windows Terminal intercepts `Ctrl+V` for its own paste operation, preventing it from reaching Kimi CLI. This adds `Alt+V` (`escape v` in prompt_toolkit) as an alternative paste shortcut on Windows, matching the approach used by Claude Code.

The handler reuses the same logic as the existing `Ctrl+V` binding — it first attempts media paste via `_try_paste_media()`, then falls back to text paste from the clipboard.

Also updates the toolbar tips to show platform-appropriate paste shortcuts:
- **Windows**: `ctrl-v / alt-v: paste clipboard`
- **macOS**: `cmd-v / ctrl-v: paste clipboard`
- **Linux**: `ctrl-v: paste clipboard`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
