### PR TITLE
feat: add skip option for tool approval prompts

### DIFF
--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -22,7 +22,7 @@ class Request:
     display: list[DisplayBlock]
 
 
-type Response = Literal["approve", "approve_for_session", "reject"]
+type Response = Literal["approve", "approve_for_session", "reject", "skip"]
 
 
 class ApprovalState:
@@ -45,7 +45,7 @@ class ApprovalState:
 class Approval:
     def __init__(self, yolo: bool = False, *, state: ApprovalState | None = None):
         self._request_queue = Queue[Request]()
-        self._requests: dict[str, tuple[Request, asyncio.Future[bool]]] = {}
+        self._requests: dict[str, tuple[Request, asyncio.Future[bool | None]]] = {}
         self._state = state or ApprovalState(yolo=yolo)
 
     def share(self) -> Approval:
@@ -65,7 +65,7 @@ class Approval:
         action: str,
         description: str,
         display: list[DisplayBlock] | None = None,
-    ) -> bool:
+    ) -> bool | None:
         """
         Request approval for the given action. Intended to be called by tools.
 
@@ -76,7 +76,7 @@ class Approval:
             description (str): The description of the action. This is used to display to the user.
 
         Returns:
-            bool: True if the action is approved, False otherwise.
+            True if approved, False if rejected, None if skipped.
 
         Raises:
             RuntimeError: If the approval is requested from outside a tool call.
@@ -106,7 +106,7 @@ class Approval:
             description=description,
             display=display or [],
         )
-        approved_future = asyncio.Future[bool]()
+        approved_future = asyncio.Future[bool | None]()
         self._request_queue.put_nowait(request)
         self._requests[request.id] = (request, approved_future)
         return await approved_future
@@ -157,3 +157,5 @@ class Approval:
                 future.set_result(True)
             case "reject":
                 future.set_result(False)
+            case "skip":
+                future.set_result(None)

--- a/src/kimi_cli/tools/background/__init__.py
+++ b/src/kimi_cli/tools/background/__init__.py
@@ -9,7 +9,7 @@ from kimi_cli.background import TaskStatus, TaskView, format_task, format_task_l
 from kimi_cli.soul.agent import Runtime
 from kimi_cli.soul.approval import Approval
 from kimi_cli.tools.display import BackgroundTaskDisplayBlock
-from kimi_cli.tools.utils import ToolRejectedError, load_desc
+from kimi_cli.tools.utils import ToolRejectedError, ToolSkippedError, load_desc
 
 TASK_OUTPUT_PREVIEW_BYTES = 32 << 10
 TASK_OUTPUT_READ_HINT_LINES = 300
@@ -297,12 +297,15 @@ class TaskStop(CallableTool2[TaskStopParams]):
         if view is None:
             return ToolError(message=f"Task not found: {params.task_id}", brief="Task not found")
 
-        if not await self._approval.request(
+        stop_approval = await self._approval.request(
             self.name,
             "stop background task",
             f"Stop background task `{params.task_id}`",
             display=[_task_display(self._runtime, params.task_id)],
-        ):
+        )
+        if stop_approval is None:
+            return ToolSkippedError()
+        if not stop_approval:
             return ToolRejectedError()
 
         view = self._runtime.background_tasks.kill(

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -11,7 +11,7 @@ from kimi_cli.soul.approval import Approval
 from kimi_cli.tools.display import DisplayBlock
 from kimi_cli.tools.file import FileActions
 from kimi_cli.tools.file.plan_mode import inspect_plan_edit_target
-from kimi_cli.tools.utils import ToolRejectedError, load_desc
+from kimi_cli.tools.utils import ToolRejectedError, ToolSkippedError, load_desc
 from kimi_cli.utils.diff import build_diff_blocks
 from kimi_cli.utils.path import is_within_workspace
 
@@ -155,13 +155,17 @@ class StrReplaceFile(CallableTool2[Params]):
             )
 
             # Plan file edits are auto-approved; all other edits need approval.
-            if not is_plan_file_edit and not await self._approval.request(
-                self.name,
-                action,
-                f"Edit file `{p}`",
-                display=diff_blocks,
-            ):
-                return ToolRejectedError()
+            if not is_plan_file_edit:
+                edit_approval = await self._approval.request(
+                    self.name,
+                    action,
+                    f"Edit file `{p}`",
+                    display=diff_blocks,
+                )
+                if edit_approval is None:
+                    return ToolSkippedError()
+                if not edit_approval:
+                    return ToolRejectedError()
 
             # Write the modified content back to the file
             await p.write_text(content, errors="replace")

--- a/src/kimi_cli/tools/file/write.py
+++ b/src/kimi_cli/tools/file/write.py
@@ -11,7 +11,7 @@ from kimi_cli.soul.approval import Approval
 from kimi_cli.tools.display import DisplayBlock
 from kimi_cli.tools.file import FileActions
 from kimi_cli.tools.file.plan_mode import inspect_plan_edit_target
-from kimi_cli.tools.utils import ToolRejectedError, load_desc
+from kimi_cli.tools.utils import ToolRejectedError, ToolSkippedError, load_desc
 from kimi_cli.utils.diff import build_diff_blocks
 from kimi_cli.utils.path import is_within_workspace
 
@@ -144,12 +144,15 @@ class WriteFile(CallableTool2[Params]):
                 )
 
                 # Request approval
-                if not await self._approval.request(
+                write_approval = await self._approval.request(
                     self.name,
                     action,
                     f"Write file `{p}`",
                     display=diff_blocks,
-                ):
+                )
+                if write_approval is None:
+                    return ToolSkippedError()
+                if not write_approval:
                     return ToolRejectedError()
 
             # Write content to file

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -13,7 +13,7 @@ from kimi_cli.soul.agent import Runtime
 from kimi_cli.soul.approval import Approval
 from kimi_cli.soul.toolset import get_current_tool_call_or_none
 from kimi_cli.tools.display import BackgroundTaskDisplayBlock, ShellDisplayBlock
-from kimi_cli.tools.utils import ToolRejectedError, ToolResultBuilder, load_desc
+from kimi_cli.tools.utils import ToolRejectedError, ToolResultBuilder, ToolSkippedError, load_desc
 from kimi_cli.utils.environment import Environment
 from kimi_cli.utils.subprocess_env import get_clean_env
 
@@ -82,7 +82,7 @@ class Shell(CallableTool2[Params]):
         if params.run_in_background:
             return await self._run_in_background(params)
 
-        if not await self._approval.request(
+        approval_result = await self._approval.request(
             self.name,
             "run command",
             f"Run command `{params.command}`",
@@ -92,7 +92,10 @@ class Shell(CallableTool2[Params]):
                     command=params.command,
                 )
             ],
-        ):
+        )
+        if approval_result is None:
+            return ToolSkippedError()
+        if not approval_result:
             return ToolRejectedError()
 
         def stdout_cb(line: bytes):
@@ -129,7 +132,7 @@ class Shell(CallableTool2[Params]):
                 brief="No tool call context",
             )
 
-        if not await self._approval.request(
+        bg_approval = await self._approval.request(
             self.name,
             "run background command",
             f"Run background command `{params.command}`",
@@ -139,7 +142,10 @@ class Shell(CallableTool2[Params]):
                     command=params.command,
                 )
             ],
-        ):
+        )
+        if bg_approval is None:
+            return ToolSkippedError()
+        if not bg_approval:
             return ToolRejectedError()
 
         try:

--- a/src/kimi_cli/tools/utils.py
+++ b/src/kimi_cli/tools/utils.py
@@ -189,3 +189,22 @@ class ToolRejectedError(ToolError):
             ),
             brief=brief,
         )
+
+
+class ToolSkippedError(ToolError):
+    """Returned when the user chooses to skip a tool call.
+
+    Unlike ``ToolRejectedError`` this does **not** abort the current step —
+    the agent loop continues executing any remaining tool calls and proceeds
+    to the next turn.
+    """
+
+    def __init__(self, message: str | None = None, brief: str = "Skipped by user"):
+        super().__init__(
+            message=message
+            or (
+                "The user chose to skip this tool call. "
+                "Continue with the remaining tasks without retrying this action."
+            ),
+            brief=brief,
+        )

--- a/src/kimi_cli/ui/shell/visualize.py
+++ b/src/kimi_cli/ui/shell/visualize.py
@@ -375,6 +375,7 @@ class _ApprovalRequestPanel:
         self.options: list[tuple[str, ApprovalResponse.Kind]] = [
             ("Approve once", "approve"),
             ("Approve for this session", "approve_for_session"),
+            ("Skip, continue with remaining tasks", "skip"),
             ("Reject, tell Kimi what to do instead", "reject"),
         ]
         self.selected_index = 0
@@ -471,7 +472,7 @@ class _ApprovalRequestPanel:
 
         # Keyboard hints
         lines.append(Text(""))
-        hint = "  \u25b2/\u25bc select  1/2/3 choose  \u21b5 confirm"
+        hint = f"  \u25b2/\u25bc select  1-{len(self.options)} choose  \u21b5 confirm"
         if self.has_expandable_content:
             hint += "  ctrl-e expand"
         lines.append(Text(hint, style="dim"))
@@ -1200,12 +1201,13 @@ class _LiveView:
                     self.refresh_soon()
                 case KeyEvent.ENTER:
                     self._submit_approval()
-                case KeyEvent.NUM_1 | KeyEvent.NUM_2 | KeyEvent.NUM_3:
+                case KeyEvent.NUM_1 | KeyEvent.NUM_2 | KeyEvent.NUM_3 | KeyEvent.NUM_4:
                     # Number keys directly select and submit approval option
                     num_map = {
                         KeyEvent.NUM_1: 0,
                         KeyEvent.NUM_2: 1,
                         KeyEvent.NUM_3: 2,
+                        KeyEvent.NUM_4: 3,
                     }
                     idx = num_map[event]
                     if idx < len(self._current_approval_request_panel.options):

--- a/src/kimi_cli/wire/types.py
+++ b/src/kimi_cli/wire/types.py
@@ -208,7 +208,7 @@ class ApprovalResponse(BaseModel):
     Indicates that an approval request has been resolved.
     """
 
-    type Kind = Literal["approve", "approve_for_session", "reject"]
+    type Kind = Literal["approve", "approve_for_session", "reject", "skip"]
 
     request_id: str
     """The ID of the resolved approval request."""


### PR DESCRIPTION
## Related Issue

Resolve #729

## Description

This PR adds a **"Skip, continue with remaining tasks"** option to the tool approval prompt. Currently users can only approve or reject a tool call. Rejecting aborts the entire step (`stop_reason=tool_rejected`), which is too disruptive when users simply want to bypass one particular tool call while allowing the agent to continue with its plan.

### Changes

- **`ToolSkippedError`** — New error class in `tools/utils.py`, sibling of `ToolRejectedError` (not a subclass). When returned from a tool, the agent loop sees it as a soft error and proceeds normally instead of aborting the step.
- **Approval response type** — Extended `Response` literal and `ApprovalResponse.Kind` wire type with `"skip"` variant. `Approval.request()` now returns `bool | None` (True=approve, False=reject, None=skip).
- **Tool callsites** — Updated all four approval consumers (`shell`, `file/write`, `file/replace`, `background`) to handle the tri-state return value.
- **UI** — Added "Skip, continue with remaining tasks" option in `visualize.py`. Unlike "Reject", the skip path does **not** set `_reject_all_following = True`, so subsequent tool calls still get their own approval prompt.

### Behavior

| Action | Approval result | Tool return | Step continues? |
|--------|----------------|-------------|----------------|
| Approve | `True` | normal execution | ✅ |
| Skip | `None` | `ToolSkippedError` | ✅ (agent sees "user skipped this") |
| Reject | `False` | `ToolRejectedError` | ❌ (`stop_reason=tool_rejected`) |

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
