### PR TITLE
feat: add /timeout command to configure shell command timeout

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -81,6 +81,8 @@ class Runtime:
     background_tasks: BackgroundTaskManager
     skills: dict[str, Skill]
     additional_dirs: list[KaosPath]
+    shell_timeout_s: int = 5 * 60
+    """User-configurable default timeout for foreground shell commands (seconds)."""
     role: Literal["root", "fixed_subagent", "dynamic_subagent"] = "root"
 
     @staticmethod

--- a/src/kimi_cli/soul/slash.py
+++ b/src/kimi_cli/soul/slash.py
@@ -101,6 +101,26 @@ async def yolo(soul: KimiSoul, args: str):
 
 
 @registry.command
+async def timeout(soul: KimiSoul, args: str):
+    """Set the default timeout for shell commands. Usage: /timeout <seconds>"""
+    arg = args.strip()
+    if not arg:
+        current = soul.runtime.shell_timeout_s
+        wire_send(TextPart(text=f"Current shell timeout: {current}s. Usage: /timeout <seconds>"))
+        return
+    try:
+        value = int(arg)
+    except ValueError:
+        wire_send(TextPart(text=f"Invalid timeout value: {arg!r}. Please provide a number in seconds."))
+        return
+    if value < 1:
+        wire_send(TextPart(text="Timeout must be at least 1 second."))
+        return
+    soul.runtime.shell_timeout_s = value
+    wire_send(TextPart(text=f"Shell timeout set to {value}s."))
+
+
+@registry.command
 async def plan(soul: KimiSoul, args: str):
     """Toggle plan mode. Usage: /plan [on|off|view|clear]"""
     subcmd = args.strip().lower()

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -104,8 +104,9 @@ class Shell(CallableTool2[Params]):
             builder.write(line_str)
 
         try:
+            effective_timeout = max(params.timeout, self._runtime.shell_timeout_s)
             exitcode = await self._run_shell_command(
-                params.command, stdout_cb, stderr_cb, params.timeout
+                params.command, stdout_cb, stderr_cb, effective_timeout
             )
 
             if exitcode == 0:
@@ -117,8 +118,8 @@ class Shell(CallableTool2[Params]):
                 )
         except TimeoutError:
             return builder.error(
-                f"Command killed by timeout ({params.timeout}s)",
-                brief=f"Killed by timeout ({params.timeout}s)",
+                f"Command killed by timeout ({effective_timeout}s)",
+                brief=f"Killed by timeout ({effective_timeout}s)",
             )
 
     async def _run_in_background(self, params: Params) -> ToolReturnValue:


### PR DESCRIPTION
## Related Issue

Resolve #625

## Description

Adds a `/timeout` slash command that lets users configure the default timeout for foreground shell commands. This addresses the common frustration of long-running tasks (e.g., `pip install`, `npm install`) being killed at the default 60-second limit.

### Usage

```
/timeout          # Show current timeout (default: 300s)
/timeout 600      # Set timeout to 600 seconds
```

### How it works

- A new `shell_timeout_s` field is added to the `Runtime` dataclass (default: 300s, same as `MAX_FOREGROUND_TIMEOUT`).
- The `/timeout` command updates `runtime.shell_timeout_s` for the current session.
- In the shell tool, the effective timeout is `max(params.timeout, runtime.shell_timeout_s)`. This means:
  - The user's setting acts as a **floor** — commands always get at least this much time.
  - The LLM can still request a higher timeout if the task warrants it.
  - The existing `MAX_FOREGROUND_TIMEOUT` validation on model parameters is preserved.
- Validation: value must be a positive integer.

### Files changed

| File | Change |
|------|--------|
| `src/kimi_cli/soul/agent.py` | Add `shell_timeout_s` field to `Runtime` |
| `src/kimi_cli/soul/slash.py` | Add `/timeout` command |
| `src/kimi_cli/tools/shell/__init__.py` | Use `max(params.timeout, runtime.shell_timeout_s)` |

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
