### PR TITLE
fix(build): include lazy CLI subcommands in PyInstaller hiddenimports

### DIFF
--- a/src/kimi_cli/utils/pyinstaller.py
+++ b/src/kimi_cli/utils/pyinstaller.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-hiddenimports = collect_submodules("kimi_cli.tools") + ["setproctitle"]
+from kimi_cli.cli._lazy_group import LazySubcommandGroup
+
+lazy_cli_hiddenimports = sorted(
+    {
+        module_name
+        for module_name, _attribute_name, _help in LazySubcommandGroup.lazy_subcommands.values()
+    }
+)
+
+hiddenimports = collect_submodules("kimi_cli.tools") + lazy_cli_hiddenimports + ["setproctitle"]
 datas = (
     collect_data_files(
         "kimi_cli",

--- a/tests/utils/test_pyinstaller_utils.py
+++ b/tests/utils/test_pyinstaller_utils.py
@@ -145,6 +145,11 @@ def test_pyinstaller_hiddenimports():
 
     assert sorted(hiddenimports) == snapshot(
         [
+            "kimi_cli.cli.export",
+            "kimi_cli.cli.info",
+            "kimi_cli.cli.mcp",
+            "kimi_cli.cli.vis",
+            "kimi_cli.cli.web",
             "kimi_cli.tools",
             "kimi_cli.tools.ask_user",
             "kimi_cli.tools.background",


### PR DESCRIPTION
## Summary

This PR fixes packaged-binary runtime failures for lazy-loaded CLI subcommands.

After lazy-loading of CLI subcommands was introduced in `82425a0c`, PyInstaller no longer collected those dynamically imported modules automatically.
As a result, bundled binaries could fail with `ModuleNotFoundError` when running subcommands like `kimi web` or `kimi info`.

## Changes

  - Add lazy CLI subcommand modules to PyInstaller `hiddenimports`.
  - Derive the list from `LazySubcommandGroup.lazy_subcommands` so it stays in sync automatically.
  - Update `test_pyinstaller_hiddenimports` snapshot to cover the lazy CLI modules.

## Affected Commands (packaged binary)

  - `kimi info`
  - `kimi export`
  - `kimi mcp`
  - `kimi vis`
  - `kimi web`

## Verification

  - `uv run pytest tests/utils/test_pyinstaller_utils.py -k hiddenimports -vv`
  - `uv run pyinstaller kimi.spec`
  - `dist/kimi web --help`
  - `dist/kimi info --help`

## Impact

  - Keeps lazy-loading startup optimizations intact.
  - Fixes packaged runtime import errors for lazy subcommands.
  - Low risk: packaging-time import manifest change only.
