### PR TITLE
fix: disable Kitty keyboard protocol to fix Enter key in VS Code terminal

### DIFF
--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -40,7 +40,7 @@ from kimi_cli.utils.logging import open_original_stderr
 from kimi_cli.utils.signals import install_sigint_handler
 from kimi_cli.utils.slashcmd import SlashCommand, SlashCommandCall, parse_slash_command_call
 from kimi_cli.utils.subprocess_env import get_clean_env
-from kimi_cli.utils.term import ensure_new_line, ensure_tty_sane
+from kimi_cli.utils.term import disable_kitty_keyboard_protocol, ensure_new_line, ensure_tty_sane
 from kimi_cli.wire.types import ContentPart, StatusUpdate
 
 
@@ -228,6 +228,8 @@ class Shell:
             _bg_cache.count = sum(1 for v in views if v.spec.kind == "bash")
             _bg_cache.time = now
             return _bg_cache.count
+
+        disable_kitty_keyboard_protocol()
 
         with CustomPromptSession(
             status_provider=lambda: self.soul.status,

--- a/src/kimi_cli/utils/term.py
+++ b/src/kimi_cli/utils/term.py
@@ -6,6 +6,26 @@ import re
 import sys
 import time
 
+# Kitty keyboard protocol pop sequence.
+# Terminals that support the protocol (VS Code ≥ 1.109, Kitty, WezTerm, …)
+# push enhanced key modes on shell startup.  prompt_toolkit does not parse
+# the resulting CSI-u sequences, so keys like Enter arrive as literal "[13u".
+# Emitting the pop sequence ("\x1b[<u") tells the terminal to fall back to
+# legacy key reporting which prompt_toolkit understands.
+_KITTY_KBD_POP = "\x1b[<u"
+
+
+def disable_kitty_keyboard_protocol() -> None:
+    """Disable the Kitty keyboard protocol if the terminal supports it.
+
+    This must be called before prompt_toolkit reads input, otherwise keys
+    like Enter will be misinterpreted as literal characters.
+    """
+    if sys.platform == "win32" or not sys.stdout.isatty():
+        return
+    sys.stdout.write(_KITTY_KBD_POP)
+    sys.stdout.flush()
+
 
 def ensure_new_line() -> None:
     """Ensure the next prompt starts at column 0 regardless of prior command output."""


### PR DESCRIPTION
## Related Issue

Resolve #1437

## Description

Terminals that support the Kitty keyboard protocol (VS Code >= 1.109, Kitty, WezTerm) push enhanced key modes on shell startup, sending keys as CSI-u sequences (e.g., `\x1b[13u` for Enter). `prompt_toolkit` 3.0.x does not parse these sequences, so keys like Enter arrive as literal `[13u` text instead of being recognized as key events.

**Fix:** Added `disable_kitty_keyboard_protocol()` in `src/kimi_cli/utils/term.py` that emits the Kitty keyboard protocol pop sequence (`\x1b[<u`) at shell startup, before `CustomPromptSession` begins reading input. This tells the terminal to fall back to legacy key reporting which `prompt_toolkit` understands.

The pop sequence is a no-op on terminals that don't support the protocol, so this is safe for all environments.

**Changes:**
- `src/kimi_cli/utils/term.py`: Added `disable_kitty_keyboard_protocol()` function
- `src/kimi_cli/ui/shell/__init__.py`: Call it before entering the prompt session

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
