### PR TITLE
fix: show helpful message when web UI static files are missing

### DIFF
--- a/src/kimi_cli/web/app.py
+++ b/src/kimi_cli/web/app.py
@@ -242,6 +242,26 @@ def create_app(
     # Mount static files as fallback (must be last)
     if STATIC_DIR.exists():
         application.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
+    else:
+        logger.warning(
+            f"Web UI static files not found at {STATIC_DIR}. "
+            "Run 'make build-web' to build the frontend, or install kimi-cli from PyPI."
+        )
+
+        @application.get("/")
+        async def _static_missing() -> HTMLResponse:
+            return HTMLResponse(
+                content=(
+                    "<html><body style='font-family:system-ui;max-width:600px;margin:80px auto;'>"
+                    "<h2>Kimi Code Web UI</h2>"
+                    "<p>The Web UI static files were not found.</p>"
+                    "<p>If you installed from source, run <code>make build-web</code> first.</p>"
+                    "<p>If you installed from PyPI, try <code>pip install --force-reinstall kimi-cli</code>.</p>"
+                    f"<p><small>Expected path: <code>{STATIC_DIR}</code></small></p>"
+                    "</body></html>"
+                ),
+                status_code=200,
+            )
 
     return application
 


### PR DESCRIPTION
## Related Issue

Resolve #1452

## Description

When running `kimi web` from a source checkout without first building the frontend (`make build-web`), the server starts successfully but serves 404 on all routes because `src/kimi_cli/web/static/` does not exist. The user sees only a blank page with no indication of what went wrong.

**Changes:**
- Added a fallback HTML page on `/` that displays when the `static` directory is missing, explaining the issue and providing remediation steps
- Added a warning log at startup when the static directory is not found

**Before:** Server starts → browser opens → 404 on `/` → blank page, no explanation
**After:** Server starts → browser opens → helpful page explaining how to build the frontend

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
