### PR TITLE
feat: display current directory in terminal title

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -227,8 +227,11 @@ class KimiCLI:
 
     @contextlib.asynccontextmanager
     async def _env(self) -> AsyncGenerator[None]:
+        from kimi_cli.utils.proctitle import update_terminal_title_with_cwd
+
         original_cwd = KaosPath.cwd()
         await kaos.chdir(self._runtime.session.work_dir)
+        update_terminal_title_with_cwd(str(self._runtime.session.work_dir))
         try:
             # to ignore possible warnings from dateparser
             warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -236,6 +239,7 @@ class KimiCLI:
                 yield
         finally:
             await kaos.chdir(original_cwd)
+            update_terminal_title_with_cwd(str(original_cwd))
 
     async def run(
         self,

--- a/src/kimi_cli/utils/proctitle.py
+++ b/src/kimi_cli/utils/proctitle.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
+import os
 import sys
+from pathlib import Path
+
+_APP_NAME = "Kimi Code"
+
+
+def _shorten_home(path: str) -> str:
+    """Replace the home directory prefix with ``~``."""
+    home = str(Path.home())
+    if path == home:
+        return "~"
+    if path.startswith(home + os.sep):
+        return "~" + path[len(home):]
+    return path
 
 
 def set_process_title(title: str) -> None:
@@ -27,7 +41,18 @@ def set_terminal_title(title: str) -> None:
         pass
 
 
-def init_process_name(name: str = "Kimi Code") -> None:
-    """Initialize process name: OS process title + terminal tab title."""
+def update_terminal_title_with_cwd(cwd: str | None = None) -> None:
+    """Update the terminal title to include the current working directory.
+
+    Format: ``Kimi Code — ~/path/to/project``
+    """
+    if cwd is None:
+        cwd = os.getcwd()
+    short_cwd = _shorten_home(cwd)
+    set_terminal_title(f"{_APP_NAME} — {short_cwd}")
+
+
+def init_process_name(name: str = _APP_NAME) -> None:
+    """Initialize process name: OS process title + terminal tab title with cwd."""
     set_process_title(name)
-    set_terminal_title(name)
+    update_terminal_title_with_cwd()


### PR DESCRIPTION
## Related Issue

Resolve #1475

## Description

Since v1.15.0 (#1254), the terminal window/tab title is set to a static `"Kimi Code"` string. This makes it difficult to distinguish between multiple kimi sessions in different projects when working with multiple terminal tabs or windows.

**Changes:**
- Updated `proctitle.py` to include the current working directory in the terminal title
- Format: `Kimi Code — ~/path/to/project` (home directory abbreviated with `~`)
- Added `update_terminal_title_with_cwd()` function that can be called when the cwd changes
- Hooked into the session lifecycle in `app.py` so the title updates when entering/leaving a session's working directory

**Before:** Terminal title shows `Kimi Code` (cannot tell which project)
**After:** Terminal title shows `Kimi Code — ~/projects/myrepo` (each tab identifiable)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
