### PR TITLE
fix(web): prevent toolbar buttons from triggering form submit

### DIFF
--- a/web/src/features/chat/global-config-controls.tsx
+++ b/web/src/features/chat/global-config-controls.tsx
@@ -203,6 +203,7 @@ export function GlobalConfigControls({
   return (
     <div className={cn("flex items-center gap-1", className)}>
       <Button
+        type="button"
         variant="ghost"
         size="icon"
         className="size-9 border-0"
@@ -217,6 +218,7 @@ export function GlobalConfigControls({
       <ModelSelector open={isSelectorOpen} onOpenChange={setIsSelectorOpen}>
         <ModelSelectorTrigger asChild>
           <Button
+            type="button"
             variant="ghost"
             size="sm"
             className="h-9 max-w-[160px] justify-start gap-2 border-0"
@@ -308,6 +310,7 @@ export function GlobalConfigControls({
 
       {lastBusySkip && lastBusySkip.length > 0 ? (
         <Button
+          type="button"
           variant="outline"
           size="icon"
           className="size-9"
@@ -322,6 +325,7 @@ export function GlobalConfigControls({
 
       {error ? (
         <Button
+          type="button"
           variant="outline"
           size="icon"
           className="size-9"


### PR DESCRIPTION
## Related Issue

Resolve #1428

## Description

The attachment button, model selector, and other toolbar buttons in the prompt composer footer are rendered inside the `PromptInput` form element. Without an explicit `type="button"`, HTML buttons default to `type="submit"` ([MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type)), causing the form to submit (sending the message) when any toolbar button is clicked.

**Fix:** Added `type="button"` to all four toolbar buttons in `GlobalConfigControls`:
1. Attach files button (the primary bug)
2. Model selector button
3. Force restart busy sessions button
4. Reload global config button

**Before:** Clicking the attachment button sends the current input text as a message
**After:** Clicking the attachment button opens the file dialog without submitting

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
