### PR TITLE
feat: adapt tool argument display width to terminal size

### DIFF
--- a/src/kimi_cli/tools/__init__.py
+++ b/src/kimi_cli/tools/__init__.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from typing import cast
 
 import streamingjson  # type: ignore[reportMissingTypeStubs]
@@ -8,10 +9,21 @@ from kosong.utils.typing import JsonType
 from kimi_cli.utils.string import shorten_middle
 
 
+# Overhead chars in tool headline: bullet + "Used " + tool_name + " (" + ")"
+_HEADLINE_OVERHEAD = 25
+
+
 class SkipThisTool(Exception):
     """Raised when a tool decides to skip itself from the loading process."""
 
     pass
+
+
+def _get_argument_display_width() -> int:
+    """Calculate available width for the key argument based on terminal size."""
+    cols = shutil.get_terminal_size((80, 24)).columns
+    width = max(30, cols - _HEADLINE_OVERHEAD)
+    return width
 
 
 def extract_key_argument(json_content: str | streamingjson.Lexer, tool_name: str) -> str | None:
@@ -98,7 +110,7 @@ def extract_key_argument(json_content: str | streamingjson.Lexer, tool_name: str
                 key_argument = "".join(content)
             else:
                 key_argument = json_content
-    key_argument = shorten_middle(key_argument, width=50)
+    key_argument = shorten_middle(key_argument, width=_get_argument_display_width())
     return key_argument
 
 

--- a/tests/tools/test_extract_key_argument.py
+++ b/tests/tools/test_extract_key_argument.py
@@ -40,8 +40,9 @@ class TestExtractKeyArgument:
         long_url = "https://example.com/" + "a" * 200
         result = extract_key_argument(f'{{"url": "{long_url}"}}', "FetchURL")
         assert result is not None
-        # shorten_middle(text, width=50) -> text[:25] + "..." + text[-25:]  => length 53
-        assert len(result) <= 53
+        # Dynamic width based on terminal size; result should be truncated
+        assert len(result) < len(long_url)
+        assert "..." in result
 
     def test_unknown_tool_returns_raw_content(self):
         result = extract_key_argument('{"a": 1}', "UnknownTool")


### PR DESCRIPTION
## Related Issue

Resolve #1492

## Description

The tool headline (e.g. `Used Shell (cd /home/yamert89/workspa...report -q 2>&1 | tail -10)`) previously truncated the key argument to a hardcoded 50 characters, regardless of terminal width. This made commands appear overly truncated on wide terminals, making it hard to see what's actually running.

**Root cause:** `extract_key_argument()` in `tools/__init__.py` called `shorten_middle(key_argument, width=50)` with a fixed width.

**Fix:** The display width is now computed dynamically from the terminal width via `shutil.get_terminal_size()`, subtracting the fixed headline overhead (~25 chars for bullet, `Used `, tool name, and parentheses). A minimum width of 30 characters is enforced for readability on very narrow terminals.

**Before (120-col terminal):**
```
Used Shell (cd /home/yamert89/workspa...report -q 2>&1 | tail -10)
```

**After (120-col terminal):**
```
Used Shell (cd /home/yamert89/workspace/project && git log ...te | head -20 && echo report -q 2>&1 | tail -10)
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
