### PR TITLE
feat: add yolo mode option in approval dialog

### DIFF
--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -411,6 +411,11 @@ class ACPSession:
                         kind="allow_always",
                     ),
                     acp.schema.PermissionOption(
+                        option_id="approve_yolo",
+                        name="Approve all (enable yolo mode)",
+                        kind="allow_always",
+                    ),
+                    acp.schema.PermissionOption(
                         option_id="reject",
                         name="Reject",
                         kind="reject_once",
@@ -435,6 +440,9 @@ class ACPSession:
                 elif option_id == "approve_for_session":
                     logger.debug("Permission granted for session: {action}", action=request.action)
                     request.resolve("approve_for_session")
+                elif option_id == "approve_yolo":
+                    logger.debug("Yolo mode enabled via: {action}", action=request.action)
+                    request.resolve("approve_yolo")
                 else:
                     logger.debug("Permission denied for: {action}", action=request.action)
                     request.resolve("reject")

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -22,7 +22,7 @@ class Request:
     display: list[DisplayBlock]
 
 
-type Response = Literal["approve", "approve_for_session", "reject"]
+type Response = Literal["approve", "approve_for_session", "approve_yolo", "reject"]
 
 
 class ApprovalState:
@@ -153,6 +153,10 @@ class Approval:
                 future.set_result(True)
             case "approve_for_session":
                 self._state.auto_approve_actions.add(request.action)
+                self._state.notify_change()
+                future.set_result(True)
+            case "approve_yolo":
+                self._state.yolo = True
                 self._state.notify_change()
                 future.set_result(True)
             case "reject":

--- a/src/kimi_cli/ui/shell/visualize.py
+++ b/src/kimi_cli/ui/shell/visualize.py
@@ -375,6 +375,7 @@ class _ApprovalRequestPanel:
         self.options: list[tuple[str, ApprovalResponse.Kind]] = [
             ("Approve once", "approve"),
             ("Approve for this session", "approve_for_session"),
+            ("Approve all (enable yolo mode)", "approve_yolo"),
             ("Reject, tell Kimi what to do instead", "reject"),
         ]
         self.selected_index = 0
@@ -1220,7 +1221,11 @@ class _LiveView:
         assert self._current_approval_request_panel is not None
         resp = self._current_approval_request_panel.get_selected_response()
         self._current_approval_request_panel.request.resolve(resp)
-        if resp == "approve_for_session":
+        if resp == "approve_yolo":
+            # yolo mode: approve all queued requests immediately
+            while self._approval_request_queue:
+                self._approval_request_queue.popleft().resolve("approve")
+        elif resp == "approve_for_session":
             to_remove_from_queue: list[ApprovalRequest] = []
             for request in self._approval_request_queue:
                 # approve all queued requests with the same action

--- a/src/kimi_cli/wire/types.py
+++ b/src/kimi_cli/wire/types.py
@@ -208,7 +208,7 @@ class ApprovalResponse(BaseModel):
     Indicates that an approval request has been resolved.
     """
 
-    type Kind = Literal["approve", "approve_for_session", "reject"]
+    type Kind = Literal["approve", "approve_for_session", "approve_yolo", "reject"]
 
     request_id: str
     """The ID of the resolved approval request."""


### PR DESCRIPTION
## Related Issue

Resolve #1414

## Description

When the approval dialog prompts for permission, users currently have three options: "Approve once", "Approve for this session" (per-action), and "Reject". This PR adds a fourth option — **"Approve all (enable yolo mode)"** — that switches the session to yolo mode directly from the dialog, without needing to restart with `--yolo`.

### Changes

| File | Change |
|------|--------|
| `wire/types.py` | Add `"approve_yolo"` to `ApprovalResponse.Kind` |
| `soul/approval.py` | Add `"approve_yolo"` to `Response` type; handle in `resolve_request()` to set `yolo=True` |
| `ui/shell/visualize.py` | Add 4th option to `_ApprovalRequestPanel`; drain pending queue on yolo selection |
| `acp/session.py` | Add yolo option to ACP `request_permission()` flow |

### Behavior

- Selecting "Approve all (enable yolo mode)" sets `ApprovalState.yolo = True` and approves the current request
- All queued approval requests are immediately approved
- Subsequent tool calls skip the approval prompt entirely (same as `--yolo` flag)
- The `on_change` callback is fired so the UI can reflect the mode switch

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
