### PR TITLE
feat(shell): add /title slash command to rename sessions

### DIFF
--- a/src/kimi_cli/session.py
+++ b/src/kimi_cli/session.py
@@ -87,6 +87,10 @@ class Session:
         self.title = f"Untitled ({self.id})"
         self.updated_at = self.context_file.stat().st_mtime if self.context_file.exists() else 0.0
 
+        if self.state.custom_title:
+            self.title = f"{self.state.custom_title} ({self.id})"
+            return
+
         try:
             async for record in self.wire_file.iter_records():
                 wire_msg = record.to_wire_message()

--- a/src/kimi_cli/session_state.py
+++ b/src/kimi_cli/session_state.py
@@ -30,6 +30,7 @@ class SessionState(BaseModel):
     approval: ApprovalStateData = Field(default_factory=ApprovalStateData)
     dynamic_subagents: list[DynamicSubagentSpec] = Field(default_factory=_default_dynamic_subagents)
     additional_dirs: list[str] = Field(default_factory=list)
+    custom_title: str | None = None
     plan_mode: bool = False
     plan_session_id: str | None = None
     plan_slug: str | None = None

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -431,6 +431,24 @@ async def new(app: Shell, args: str):
     raise Reload(session_id=session.id)
 
 
+@registry.command(name="title")
+async def title(app: Shell, args: str):
+    """Set or show the session title"""
+    soul = ensure_kimi_soul(app)
+    if soul is None:
+        return
+    session = soul.runtime.session
+    if not args.strip():
+        console.print(f"Session title: {session.title}")
+        return
+
+    new_title = args.strip()
+    session.state.custom_title = new_title
+    session.save_state()
+    session.title = f"{new_title} ({session.id})"
+    console.print(f"[green]Session title set to: {new_title}[/green]")
+
+
 @registry.command(name="sessions", aliases=["resume"])
 async def list_sessions(app: Shell, args: str):
     """List sessions and resume optionally"""


### PR DESCRIPTION
## Summary

Adds a `/title` slash command that lets users manually set session titles instead of relying on auto-generated ones.

- `/title My Project` sets the current session title
- `/title` (no args) shows the current title
- Title persists across session restarts via `SessionState.custom_title`

## Changes

Three files, 23 lines total:

- `src/kimi_cli/session_state.py` - Added `custom_title: str | None = None` field to `SessionState`
- `src/kimi_cli/session.py` - `Session.refresh()` now checks `state.custom_title` before falling back to the auto-derived title from the wire file
- `src/kimi_cli/ui/shell/slash.py` - Added `/title` command following the existing `@registry.command()` pattern

## Testing

Verified programmatically:
- `/title` is registered in the slash command registry alongside `/new`, `/sessions`, `/help`
- `SessionState.custom_title` field initializes to `None` and accepts string values
- `Session.refresh()` respects the custom title when set

Fixes #1536

This contribution was developed with AI assistance (Claude Code).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
