### PR TITLE
fix(wire): snapshot bridge-task dict before iteration during shutdown

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -377,9 +377,9 @@ class KimiCLI:
                         await stop_task
                     with contextlib.suppress(asyncio.CancelledError):
                         await queue_task
-                    for task in approval_bridge_tasks.values():
+                    for task in list(approval_bridge_tasks.values()):
                         task.cancel()
-                    for task in approval_bridge_tasks.values():
+                    for task in list(approval_bridge_tasks.values()):
                         with contextlib.suppress(asyncio.CancelledError):
                             await task
                     approval_bridge_tasks.clear()


### PR DESCRIPTION
## Summary

- Snapshot `approval_bridge_tasks.values()` via `list()` before cancelling/awaiting during `KimiCLI.run()` shutdown
- Each bridge task removes itself from the dict in its `finally` block; iterating `.values()` directly while awaiting causes `RuntimeError: dictionary changed size during iteration`

## Test plan

- [ ] Verify wire-mode shutdown with multiple pending approval bridge tasks does not crash
- [ ] Existing `tests_e2e/test_wire_approvals_tools.py` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
