### PR TITLE
fix: auto-resolve QuestionRequest in yolo/print mode to prevent hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Fix `QuestionRequest` hanging in print mode — `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` now auto-resolve when running in non-interactive (yolo) mode, preventing indefinite tool call hangs in `--print` sessions
+
 ## 1.25.0 (2026-03-23)
 
 - Core: Add plugin system (Skills + Tools) — plugins extend Kimi Code CLI with custom tools packaged as `plugin.json`; tools are commands that run in isolated subprocesses and return their stdout to the agent; plugins support automatic credential injection via `inject` configuration

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Fix `QuestionRequest` hanging in print mode — `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` now auto-resolve when running in non-interactive (yolo) mode, preventing indefinite tool call hangs in `--print` sessions
+
 ## 1.25.0 (2026-03-23)
 
 - Core: Add plugin system (Skills + Tools) — plugins extend Kimi Code CLI with custom tools packaged as `plugin.json`; tools are commands that run in isolated subprocesses and return their stdout to the agent; plugins support automatic credential injection via `inject` configuration

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Core：修复 Print 模式下 `QuestionRequest` 导致挂起的问题——`AskUserQuestion`、`EnterPlanMode` 和 `ExitPlanMode` 在非交互（yolo）模式下自动处理，避免 `--print` 会话中工具调用无限挂起
+
 ## 1.25.0 (2026-03-23)
 
 - Core：新增插件系统（Skills + Tools）——插件通过 `plugin.json` 为 Kimi Code CLI 扩展自定义工具；工具是在独立子进程中运行的命令，其 stdout 返回给 Agent；插件支持通过 `inject` 配置自动注入凭证

--- a/src/kimi_cli/soul/dynamic_injections/yolo_mode.py
+++ b/src/kimi_cli/soul/dynamic_injections/yolo_mode.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from kosong.message import Message
+
+from kimi_cli.soul.dynamic_injection import DynamicInjection, DynamicInjectionProvider
+
+if TYPE_CHECKING:
+    from kimi_cli.soul.kimisoul import KimiSoul
+
+_YOLO_INJECTION_TYPE = "yolo_mode"
+
+_YOLO_PROMPT = (
+    "You are running in non-interactive mode. The user cannot answer questions "
+    "or provide feedback during execution.\n"
+    "- Do NOT call AskUserQuestion. If you need to make a decision, make your "
+    "best judgment and proceed.\n"
+    "- For EnterPlanMode / ExitPlanMode, they will be auto-approved. You can use "
+    "them normally but expect no user feedback."
+)
+
+
+class YoloModeInjectionProvider(DynamicInjectionProvider):
+    """Injects a one-time reminder when yolo mode is active."""
+
+    def __init__(self) -> None:
+        self._injected: bool = False
+
+    async def get_injections(
+        self,
+        history: Sequence[Message],
+        soul: KimiSoul,
+    ) -> list[DynamicInjection]:
+        if not soul.is_yolo:
+            return []
+        if self._injected:
+            return []
+        self._injected = True
+        return [DynamicInjection(type=_YOLO_INJECTION_TYPE, content=_YOLO_PROMPT)]

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -58,6 +58,7 @@ from kimi_cli.soul.dynamic_injection import (
     normalize_history,
 )
 from kimi_cli.soul.dynamic_injections.plan_mode import PlanModeInjectionProvider
+from kimi_cli.soul.dynamic_injections.yolo_mode import YoloModeInjectionProvider
 from kimi_cli.soul.message import check_message, system, system_reminder, tool_result_to_message
 from kimi_cli.soul.slash import registry as soul_slash_registry
 from kimi_cli.soul.toolset import KimiToolset
@@ -156,6 +157,7 @@ class KimiSoul:
             self._ensure_plan_session_id()
         self._injection_providers: list[DynamicInjectionProvider] = [
             PlanModeInjectionProvider(),
+            YoloModeInjectionProvider(),
         ]
         if self._runtime.role == "root":
             self._runtime.notifications.ack_ids("llm", extract_notification_ids(context.history))
@@ -179,6 +181,11 @@ class KimiSoul:
         if self._runtime.llm is None:
             return None
         return self._runtime.llm.capabilities
+
+    @property
+    def is_yolo(self) -> bool:
+        """Whether yolo (auto-approve / non-interactive) mode is enabled."""
+        return self._approval.is_yolo()
 
     @property
     def plan_mode(self) -> bool:
@@ -233,14 +240,21 @@ class KimiSoul:
 
         exit_tool = self._agent.toolset.find("ExitPlanMode")
         if isinstance(exit_tool, ExitPlanMode):
-            exit_tool.bind(self.toggle_plan_mode, path_getter, checker)
+            exit_tool.bind(self.toggle_plan_mode, path_getter, checker, self._approval.is_yolo)
 
         # EnterPlanMode has a special bind() method
         from kimi_cli.tools.plan.enter import EnterPlanMode
 
         enter_tool = self._agent.toolset.find("EnterPlanMode")
         if isinstance(enter_tool, EnterPlanMode):
-            enter_tool.bind(self.toggle_plan_mode, path_getter, checker)
+            enter_tool.bind(self.toggle_plan_mode, path_getter, checker, self._approval.is_yolo)
+
+        # AskUserQuestion — bind yolo checker for auto-dismiss
+        from kimi_cli.tools.ask_user import AskUserQuestion
+
+        ask_tool = self._agent.toolset.find("AskUserQuestion")
+        if isinstance(ask_tool, AskUserQuestion):
+            ask_tool.bind_approval(self._approval.is_yolo)
 
     def _ensure_plan_session_id(self) -> None:
         """Allocate a stable plan session ID on first activation."""

--- a/src/kimi_cli/tools/ask_user/__init__.py
+++ b/src/kimi_cli/tools/ask_user/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import override
 from uuid import uuid4
@@ -63,8 +64,27 @@ class AskUserQuestion(CallableTool2[Params]):
     description: str = _BASE_DESCRIPTION
     params: type[Params] = Params
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._is_yolo: Callable[[], bool] | None = None
+
+    def bind_approval(self, is_yolo: Callable[[], bool]) -> None:
+        """Late-bind yolo checker so we can auto-dismiss in non-interactive mode."""
+        self._is_yolo = is_yolo
+
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
+        if self._is_yolo and self._is_yolo():
+            return ToolReturnValue(
+                is_error=False,
+                output=(
+                    '{"answers": {}, "note": "Running in non-interactive'
+                    ' (yolo) mode. Make your own decision."}'
+                ),
+                message="Non-interactive mode, auto-dismissed.",
+                display=[BriefDisplayBlock(text="Auto-dismissed (yolo)")],
+            )
+
         wire = get_wire_or_none()
         if wire is None:
             return ToolError(

--- a/src/kimi_cli/tools/plan/__init__.py
+++ b/src/kimi_cli/tools/plan/__init__.py
@@ -82,17 +82,20 @@ class ExitPlanMode(CallableTool2[Params]):
         self._toggle_callback: Callable[[], Awaitable[bool]] | None = None
         self._plan_file_path_getter: Callable[[], Path | None] | None = None
         self._plan_mode_checker: Callable[[], bool] | None = None
+        self._is_yolo: Callable[[], bool] | None = None
 
     def bind(
         self,
         toggle_callback: Callable[[], Awaitable[bool]],
         plan_file_path_getter: Callable[[], Path | None],
         plan_mode_checker: Callable[[], bool],
+        is_yolo: Callable[[], bool] | None = None,
     ) -> None:
         """Late-bind soul callbacks after KimiSoul is constructed."""
         self._toggle_callback = toggle_callback
         self._plan_file_path_getter = plan_file_path_getter
         self._plan_mode_checker = plan_mode_checker
+        self._is_yolo = is_yolo
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
@@ -120,6 +123,21 @@ class ExitPlanMode(CallableTool2[Params]):
                 message=f"No plan file found. Write your plan to {plan_path} first, "
                 "then call ExitPlanMode.",
                 brief="No plan file",
+            )
+
+        # In yolo mode, auto-approve the plan
+        if self._is_yolo and self._is_yolo():
+            await self._toggle_callback()
+            return ToolReturnValue(
+                is_error=False,
+                output=(
+                    f"Plan approved (auto-approved in non-interactive mode). "
+                    f"Plan mode deactivated. All tools are now available.\n"
+                    f"Plan saved to: {plan_path}\n\n"
+                    f"## Approved Plan:\n{plan_content}"
+                ),
+                message="Plan approved (auto)",
+                display=[BriefDisplayBlock(text="Plan approved (auto)")],
             )
 
         # Present plan to user via QuestionRequest

--- a/src/kimi_cli/tools/plan/enter.py
+++ b/src/kimi_cli/tools/plan/enter.py
@@ -37,17 +37,20 @@ class EnterPlanMode(CallableTool2[Params]):
         self._toggle_callback: Callable[[], Awaitable[bool]] | None = None
         self._plan_file_path_getter: Callable[[], Path | None] | None = None
         self._plan_mode_checker: Callable[[], bool] | None = None
+        self._is_yolo: Callable[[], bool] | None = None
 
     def bind(
         self,
         toggle_callback: Callable[[], Awaitable[bool]],
         plan_file_path_getter: Callable[[], Path | None],
         plan_mode_checker: Callable[[], bool],
+        is_yolo: Callable[[], bool] | None = None,
     ) -> None:
         """Late-bind soul callbacks after KimiSoul is constructed."""
         self._toggle_callback = toggle_callback
         self._plan_file_path_getter = plan_file_path_getter
         self._plan_mode_checker = plan_mode_checker
+        self._is_yolo = is_yolo
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
@@ -62,6 +65,24 @@ class EnterPlanMode(CallableTool2[Params]):
             return ToolError(
                 message="EnterPlanMode is not properly initialized.",
                 brief="Not initialized",
+            )
+
+        # In yolo mode, auto-approve entering plan mode
+        if self._is_yolo and self._is_yolo():
+            await self._toggle_callback()
+            plan_path = self._plan_file_path_getter()
+            return ToolReturnValue(
+                is_error=False,
+                output=(
+                    f"Plan mode activated (auto-approved in non-interactive mode).\n"
+                    f"Plan file: {plan_path}\n"
+                    f"Workflow: explore with Glob/Grep/ReadFile → design approach → "
+                    f"modify the plan file with WriteFile or StrReplaceFile "
+                    f"(create it with WriteFile first if it does not exist) → "
+                    f"call ExitPlanMode.\n"
+                ),
+                message="Plan mode on (auto)",
+                display=[BriefDisplayBlock(text="Plan mode on (auto)")],
             )
 
         # Present confirmation dialog to user via QuestionRequest

--- a/tests/core/test_kimisoul_ralph_loop.py
+++ b/tests/core/test_kimisoul_ralph_loop.py
@@ -16,12 +16,20 @@ from pydantic import BaseModel
 from kimi_cli.llm import LLM, ModelCapability
 from kimi_cli.soul import run_soul
 from kimi_cli.soul.agent import Agent, Runtime
+from kimi_cli.soul.approval import Approval
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.kimisoul import KimiSoul
 from kimi_cli.tools.utils import ToolRejectedError
 from kimi_cli.utils.aioqueue import QueueShutDown
 from kimi_cli.wire import Wire
 from kimi_cli.wire.types import TurnBegin
+
+
+@pytest.fixture
+def approval() -> Approval:
+    """Override global yolo=True fixture; ralph loop tests don't need yolo."""
+    return Approval(yolo=False)
+
 
 T = TypeVar("T")
 RALPH_IMAGE_URL = "https://example.com/test.png"

--- a/tests/core/test_kimisoul_steer.py
+++ b/tests/core/test_kimisoul_steer.py
@@ -12,6 +12,7 @@ import kimi_cli.soul.kimisoul as kimisoul_module
 from kimi_cli.llm import LLM, ModelCapability
 from kimi_cli.soul import LLMNotSupported, run_soul
 from kimi_cli.soul.agent import Agent, Runtime
+from kimi_cli.soul.approval import Approval
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.dynamic_injection import DynamicInjection
 from kimi_cli.soul.kimisoul import KimiSoul
@@ -19,6 +20,12 @@ from kimi_cli.soul.message import is_system_reminder_message
 from kimi_cli.utils.aioqueue import QueueShutDown
 from kimi_cli.wire import Wire
 from kimi_cli.wire.types import ImageURLPart, SteerInput, StepBegin, TextPart, TurnBegin, TurnEnd
+
+
+@pytest.fixture
+def approval() -> Approval:
+    """Override global yolo=True fixture; steer tests don't need yolo."""
+    return Approval(yolo=False)
 
 
 def _make_soul(runtime: Runtime, tmp_path: Path) -> KimiSoul:

--- a/tests/core/test_plan_mode.py
+++ b/tests/core/test_plan_mode.py
@@ -11,6 +11,7 @@ from kosong.tooling.empty import EmptyToolset
 from pydantic import ValidationError
 
 from kimi_cli.soul.agent import Agent, Runtime
+from kimi_cli.soul.approval import Approval
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.kimisoul import KimiSoul
 from kimi_cli.soul.toolset import KimiToolset
@@ -30,6 +31,12 @@ from kimi_cli.wire.types import QuestionNotSupported, QuestionRequest, ToolCall
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def approval() -> Approval:
+    """Override global yolo=True fixture; plan mode tests don't need yolo."""
+    return Approval(yolo=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_yolo_injection.py
+++ b/tests/core/test_yolo_injection.py
@@ -1,0 +1,54 @@
+"""Tests for YoloModeInjectionProvider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kimi_cli.soul.dynamic_injections.yolo_mode import (
+    _YOLO_INJECTION_TYPE,
+    _YOLO_PROMPT,
+    YoloModeInjectionProvider,
+)
+
+
+def _mock_soul(is_yolo: bool) -> MagicMock:
+    soul = MagicMock()
+    soul.is_yolo = is_yolo
+    return soul
+
+
+async def test_injects_when_yolo_enabled():
+    """Should return one injection on first call when yolo is active."""
+    provider = YoloModeInjectionProvider()
+    result = await provider.get_injections([], _mock_soul(is_yolo=True))
+
+    assert len(result) == 1
+    assert result[0].type == _YOLO_INJECTION_TYPE
+    assert result[0].content == _YOLO_PROMPT
+    assert "AskUserQuestion" in result[0].content
+
+
+async def test_no_injection_when_yolo_disabled():
+    """Should return empty list when yolo is not active."""
+    provider = YoloModeInjectionProvider()
+    result = await provider.get_injections([], _mock_soul(is_yolo=False))
+    assert result == []
+
+
+async def test_injection_lifecycle():
+    """Full lifecycle: off -> on (injects) -> on (no re-inject) -> off -> on (no re-inject)."""
+    provider = YoloModeInjectionProvider()
+
+    # yolo off: nothing
+    assert await provider.get_injections([], _mock_soul(is_yolo=False)) == []
+
+    # yolo on: injects once
+    result = await provider.get_injections([], _mock_soul(is_yolo=True))
+    assert len(result) == 1
+
+    # yolo still on: no re-inject
+    assert await provider.get_injections([], _mock_soul(is_yolo=True)) == []
+
+    # yolo off then on again: no re-inject
+    assert await provider.get_injections([], _mock_soul(is_yolo=False)) == []
+    assert await provider.get_injections([], _mock_soul(is_yolo=True)) == []

--- a/tests/e2e/test_shell_modal_e2e.py
+++ b/tests/e2e/test_shell_modal_e2e.py
@@ -268,7 +268,7 @@ def test_question_single_select_via_number_key(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:
@@ -318,7 +318,7 @@ def test_question_escape_dismisses_with_empty_answer(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:
@@ -378,7 +378,7 @@ def test_question_multi_step_with_tab_navigation(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:
@@ -670,7 +670,7 @@ def test_question_single_question_returns_to_prompt(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:
@@ -727,7 +727,7 @@ def test_question_multi_select_with_space_and_enter(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:
@@ -917,7 +917,7 @@ def test_two_question_tools_in_same_turn(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:

--- a/tests/e2e/test_shell_pty_e2e.py
+++ b/tests/e2e/test_shell_pty_e2e.py
@@ -405,7 +405,7 @@ def test_shell_question_roundtrip_with_other_answer(tmp_path: Path) -> None:
         config_path=config_path,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
 
     try:

--- a/tests/tools/test_ask_user.py
+++ b/tests/tools/test_ask_user.py
@@ -176,3 +176,77 @@ async def test_ask_user_no_tool_call(ask_user_tool: AskUserQuestion):
     finally:
         wire.shutdown()
         _current_wire.reset(wire_token)
+
+
+# ---------------------------------------------------------------------------
+# Yolo mode tests
+# ---------------------------------------------------------------------------
+
+
+async def test_ask_user_yolo_auto_dismiss():
+    """In yolo mode, auto-dismiss without wire or tool_call context (short-circuits everything)."""
+    tool = AskUserQuestion()
+    tool.bind_approval(is_yolo=lambda: True)
+
+    # Deliberately do NOT set wire or tool_call — yolo should short-circuit before needing them
+    wire_token = _current_wire.set(None)
+    try:
+        result = await tool(_make_params())
+        assert not result.is_error
+        assert isinstance(result.output, str)
+        parsed = json.loads(result.output)
+        assert parsed["answers"] == {}
+        assert "yolo" in parsed.get("note", "").lower()
+    finally:
+        _current_wire.reset(wire_token)
+
+
+async def test_ask_user_unbound_falls_through():
+    """When bind_approval is never called (backward compat), falls through to normal flow."""
+    tool = AskUserQuestion()
+    # Do NOT call bind_approval — _is_yolo stays None
+
+    wire_token = _current_wire.set(None)
+    tool_call = ToolCall(
+        id="tc-unbound",
+        function=ToolCall.FunctionBody(name="AskUserQuestion", arguments=None),
+    )
+    tc_token = current_tool_call.set(tool_call)
+    try:
+        result = await tool(_make_params())
+        assert result.is_error
+        assert "Wire" in result.message
+    finally:
+        current_tool_call.reset(tc_token)
+        _current_wire.reset(wire_token)
+
+
+async def test_ask_user_yolo_dynamic_toggle():
+    """When yolo is toggled off dynamically, tool should fall through to normal flow."""
+    yolo_state = {"enabled": True}
+    tool = AskUserQuestion()
+    tool.bind_approval(is_yolo=lambda: yolo_state["enabled"])
+
+    # First call: yolo on -> auto-dismiss
+    result = await tool(_make_params())
+    assert not result.is_error
+    assert isinstance(result.output, str)
+    assert "yolo" in result.output.lower()
+
+    # Toggle yolo off
+    yolo_state["enabled"] = False
+
+    # Second call: yolo off -> needs wire (which isn't set -> error)
+    wire_token = _current_wire.set(None)
+    tool_call = ToolCall(
+        id="tc-toggle",
+        function=ToolCall.FunctionBody(name="AskUserQuestion", arguments=None),
+    )
+    tc_token = current_tool_call.set(tool_call)
+    try:
+        result = await tool(_make_params())
+        assert result.is_error
+        assert "Wire" in result.message
+    finally:
+        current_tool_call.reset(tc_token)
+        _current_wire.reset(wire_token)

--- a/tests/tools/test_plan_yolo.py
+++ b/tests/tools/test_plan_yolo.py
@@ -1,0 +1,260 @@
+"""Tests for EnterPlanMode / ExitPlanMode yolo auto-approve behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kimi_cli.soul import _current_wire
+from kimi_cli.tools.plan import ExitPlanMode, PlanOption
+from kimi_cli.tools.plan import Params as ExitParams
+from kimi_cli.tools.plan.enter import EnterPlanMode
+from kimi_cli.tools.plan.enter import Params as EnterParams
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_toggle(tracker: dict):
+    """Create an async toggle callback that records invocation."""
+
+    async def toggle() -> bool:
+        tracker["called"] = True
+        return True
+
+    return toggle
+
+
+@pytest.fixture
+def enter_tool() -> EnterPlanMode:
+    return EnterPlanMode()
+
+
+@pytest.fixture
+def exit_tool() -> ExitPlanMode:
+    return ExitPlanMode()
+
+
+# ---------------------------------------------------------------------------
+# EnterPlanMode
+# ---------------------------------------------------------------------------
+
+
+async def test_enter_plan_yolo(enter_tool: EnterPlanMode):
+    """Yolo auto-approves without wire or tool_call (short-circuits everything)."""
+    tracker: dict = {}
+    enter_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: Path("/tmp/plan.md"),
+        plan_mode_checker=lambda: False,
+        is_yolo=lambda: True,
+    )
+
+    wire_token = _current_wire.set(None)
+    try:
+        result = await enter_tool(EnterParams())
+        assert not result.is_error
+        assert tracker.get("called")
+        assert "auto" in result.message.lower()
+    finally:
+        _current_wire.reset(wire_token)
+
+
+async def test_enter_plan_yolo_already_in_plan_mode(enter_tool: EnterPlanMode):
+    """Guard 'already in plan mode' fires before yolo check."""
+    tracker: dict = {}
+    enter_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: Path("/tmp/plan.md"),
+        plan_mode_checker=lambda: True,  # already in plan mode
+        is_yolo=lambda: True,
+    )
+
+    result = await enter_tool(EnterParams())
+    assert result.is_error
+    assert "Already in plan mode" in result.message
+    assert not tracker.get("called")
+
+
+async def test_enter_plan_is_yolo_none(enter_tool: EnterPlanMode):
+    """When is_yolo is not passed (backward compat), falls through to normal flow."""
+    tracker: dict = {}
+    enter_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: Path("/tmp/plan.md"),
+        plan_mode_checker=lambda: False,
+    )
+
+    wire_token = _current_wire.set(None)
+    try:
+        result = await enter_tool(EnterParams())
+        assert result.is_error
+        assert "Wire" in result.message
+        assert not tracker.get("called")
+    finally:
+        _current_wire.reset(wire_token)
+
+
+async def test_enter_plan_yolo_dynamic_toggle(enter_tool: EnterPlanMode):
+    """When yolo toggles off, falls through to normal flow."""
+    yolo_state = {"enabled": True}
+    plan_mode_state = {"active": False}
+    tracker: dict = {}
+
+    async def toggle() -> bool:
+        tracker["called"] = True
+        plan_mode_state["active"] = True
+        return True
+
+    enter_tool.bind(
+        toggle_callback=toggle,
+        plan_file_path_getter=lambda: Path("/tmp/plan.md"),
+        plan_mode_checker=lambda: plan_mode_state["active"],
+        is_yolo=lambda: yolo_state["enabled"],
+    )
+
+    # Call 1: yolo on -> auto-approve
+    result = await enter_tool(EnterParams())
+    assert not result.is_error
+    assert tracker.get("called")
+
+    # Reset for second attempt
+    plan_mode_state["active"] = False
+    tracker.clear()
+    yolo_state["enabled"] = False
+
+    # Call 2: yolo off, no wire -> wire error
+    wire_token = _current_wire.set(None)
+    try:
+        result = await enter_tool(EnterParams())
+        assert result.is_error
+        assert "Wire" in result.message
+    finally:
+        _current_wire.reset(wire_token)
+
+
+# ---------------------------------------------------------------------------
+# ExitPlanMode
+# ---------------------------------------------------------------------------
+
+
+async def test_exit_plan_yolo(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Yolo auto-approves the plan without wire or tool_call."""
+    tracker: dict = {}
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("# Test Plan\n- Step 1\n- Step 2")
+
+    exit_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: plan_file,
+        plan_mode_checker=lambda: True,
+        is_yolo=lambda: True,
+    )
+
+    wire_token = _current_wire.set(None)
+    try:
+        result = await exit_tool(ExitParams())
+        assert not result.is_error
+        assert tracker.get("called")
+        assert "Test Plan" in result.output
+        assert "auto" in result.message.lower()
+    finally:
+        _current_wire.reset(wire_token)
+
+
+async def test_exit_plan_yolo_with_options(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Yolo auto-approve works even when options are provided (options ignored)."""
+    tracker: dict = {}
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("# Plan\n## Option A\n## Option B")
+
+    exit_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: plan_file,
+        plan_mode_checker=lambda: True,
+        is_yolo=lambda: True,
+    )
+
+    result = await exit_tool(
+        ExitParams(
+            options=[
+                PlanOption(label="Approach A", description="Fast"),
+                PlanOption(label="Approach B", description="Thorough"),
+            ]
+        )
+    )
+    assert not result.is_error
+    assert tracker.get("called")
+
+
+async def test_exit_plan_yolo_no_plan_file(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Yolo does NOT bypass the 'no plan file' guard."""
+    tracker: dict = {}
+    exit_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: tmp_path / "nonexistent.md",
+        plan_mode_checker=lambda: True,
+        is_yolo=lambda: True,
+    )
+
+    result = await exit_tool(ExitParams())
+    assert result.is_error
+    assert "No plan file" in result.message
+    assert not tracker.get("called")
+
+
+async def test_exit_plan_yolo_empty_plan_file(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Yolo does NOT bypass the 'empty plan file' guard."""
+    tracker: dict = {}
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("")
+
+    exit_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: plan_file,
+        plan_mode_checker=lambda: True,
+        is_yolo=lambda: True,
+    )
+
+    result = await exit_tool(ExitParams())
+    assert result.is_error
+    assert not tracker.get("called")
+
+
+async def test_exit_plan_yolo_not_in_plan_mode(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Guard 'not in plan mode' fires before yolo check."""
+    tracker: dict = {}
+    exit_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: tmp_path / "plan.md",
+        plan_mode_checker=lambda: False,
+        is_yolo=lambda: True,
+    )
+
+    result = await exit_tool(ExitParams())
+    assert result.is_error
+    assert "Not in plan mode" in result.message
+    assert not tracker.get("called")
+
+
+async def test_exit_plan_is_yolo_none(exit_tool: ExitPlanMode, tmp_path: Path):
+    """When is_yolo is not passed (backward compat), falls through to normal flow."""
+    tracker: dict = {}
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("# Plan content")
+
+    exit_tool.bind(
+        toggle_callback=_make_toggle(tracker),
+        plan_file_path_getter=lambda: plan_file,
+        plan_mode_checker=lambda: True,
+    )
+
+    wire_token = _current_wire.set(None)
+    try:
+        result = await exit_tool(ExitParams())
+        assert result.is_error
+        assert "Wire" in result.message
+    finally:
+        _current_wire.reset(wire_token)

--- a/tests_e2e/test_wire_question.py
+++ b/tests_e2e/test_wire_question.py
@@ -73,7 +73,7 @@ def test_question_request_answer(tmp_path) -> None:
         config_text=None,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,  # yolo to skip approval for other tools
+        yolo=False,  # yolo to skip approval for other tools
     )
     try:
         send_initialize(wire, capabilities={"supports_question": True})
@@ -140,7 +140,7 @@ def test_question_request_error_response(tmp_path) -> None:
         config_text=None,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
     try:
         send_initialize(wire, capabilities={"supports_question": True})
@@ -235,7 +235,7 @@ def test_ask_user_tool_hidden_when_question_not_supported(tmp_path) -> None:
         config_text=None,
         work_dir=work_dir,
         home_dir=home_dir,
-        yolo=True,
+        yolo=False,
     )
     try:
         # Initialize WITHOUT supports_question (defaults to false)

--- a/tests_e2e/test_wire_sessions.py
+++ b/tests_e2e/test_wire_sessions.py
@@ -152,17 +152,19 @@ def test_continue_session_appends(tmp_path) -> None:
         "context_after": context_after,
         "wire_before": wire_before,
         "wire_after": wire_after,
-    } == snapshot({"context_before": 5, "context_after": 9, "wire_before": 6, "wire_after": 11})
+    } == snapshot({"context_before": 6, "context_after": 11, "wire_before": 6, "wire_after": 11})
     assert _read_roles(context_file) == snapshot(
         [
             "_system_prompt",
             "_checkpoint",
             "user",
             "_checkpoint",
+            "user",
             "assistant",
             "_checkpoint",
             "user",
             "_checkpoint",
+            "user",
             "assistant",
         ]
     )
@@ -243,7 +245,7 @@ def test_clear_context_rotates(tmp_path) -> None:
     )
     assert rotated == snapshot(["context_1.jsonl"])
     assert _read_roles(session_dir / rotated[0]) == snapshot(
-        ["_system_prompt", "_checkpoint", "user", "_checkpoint", "assistant"]
+        ["_system_prompt", "_checkpoint", "user", "_checkpoint", "user", "assistant"]
     )
 
 
@@ -300,8 +302,8 @@ def test_manual_compact(tmp_path) -> None:
                     "method": "event",
                     "type": "StatusUpdate",
                     "payload": {
-                        "context_usage": 1e-05,
-                        "context_tokens": 1,
+                        "context_usage": 0.00118,
+                        "context_tokens": 118,
                         "max_context_tokens": 100000,
                         "token_usage": None,
                         "message_id": None,

--- a/tests_e2e/test_wire_skills_mcp.py
+++ b/tests_e2e/test_wire_skills_mcp.py
@@ -129,7 +129,8 @@ def test_skill_prompt_injects_skill_text(tmp_path) -> None:
     context_file = _session_dir(home_dir, work_dir, session_id) / "context.jsonl"
     user_texts = _read_user_texts(context_file)
     assert user_texts
-    assert _normalize_newlines(user_texts[-1]) == _normalize_newlines(skill_text.strip())
+    normalized_skill = _normalize_newlines(skill_text.strip())
+    assert any(_normalize_newlines(t) == normalized_skill for t in user_texts)
 
 
 def test_flow_skill(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Auto-resolve `QuestionRequest` for `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` when running in yolo mode, preventing tool calls from hanging indefinitely in `--print` mode
- Add `YoloModeInjectionProvider` dynamic prompt injection to guide the model not to call `AskUserQuestion` in non-interactive mode
- Add `is_yolo` property to `KimiSoul` for clean access to yolo state from injection providers

## Background
When running `kimi --print --output-format=stream-json --command $prompt`, yolo mode is implicitly enabled. `ApprovalRequest` is auto-approved, but `QuestionRequest` had no corresponding auto-handling — it was silently ignored by the print visualizer's `case _: pass`, causing tool calls to hang forever.

## Changes
- **`AskUserQuestion`**: Added `bind_approval(is_yolo)` — returns empty answers `{}` in yolo mode (same format as user dismiss)
- **`EnterPlanMode`**: Added `is_yolo` param to `bind()` — auto-approves entering plan mode
- **`ExitPlanMode`**: Added `is_yolo` param to `bind()` — auto-approves plan after reading plan file
- **`KimiSoul`**: Binds `is_yolo` to all three tools; registers `YoloModeInjectionProvider`
- **`YoloModeInjectionProvider`**: One-time system prompt injection telling the model not to use `AskUserQuestion`

## Test plan
- [x] `make check` passes (ruff + pyright)
- [x] 21 new/updated unit tests covering yolo auto-resolve, guard priority, backward compatibility, dynamic toggle, and injection lifecycle
- [x] Manual E2E: `kimi --print --output-format=stream-json --command` with prompts triggering AskUserQuestion and EnterPlanMode/ExitPlanMode — no hang, correct auto-resolve
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
