### PR TITLE
feat(agent): support Jinja2 include directive in system prompts

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import pydantic
 from jinja2 import Environment as JinjaEnvironment
-from jinja2 import StrictUndefined, TemplateError, UndefinedError
+from jinja2 import FileSystemLoader, StrictUndefined, TemplateError, UndefinedError
 from kaos.path import KaosPath
 from kosong.tooling import Toolset
 
@@ -386,6 +386,7 @@ def _load_system_prompt(
         spec_args=args,
     )
     env = JinjaEnvironment(
+        loader=FileSystemLoader(path.parent),
         keep_trailing_newline=True,
         lstrip_blocks=True,
         trim_blocks=True,

--- a/tests/core/test_load_agent.py
+++ b/tests/core/test_load_agent.py
@@ -43,6 +43,21 @@ def test_load_system_prompt_allows_literal_dollar(builtin_args: BuiltinSystemPro
     assert builtin_args.KIMI_NOW in prompt
 
 
+def test_load_system_prompt_include(builtin_args: BuiltinSystemPromptArgs):
+    """System prompt should support {% include "file.md" %} directives."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        included = tmpdir / "extra.md"
+        included.write_text("Included content here")
+        system_md = tmpdir / "system.md"
+        system_md.write_text('Main prompt. {% include "extra.md" %} End.')
+        prompt = _load_system_prompt(system_md, {}, builtin_args)
+
+    assert "Main prompt." in prompt
+    assert "Included content here" in prompt
+    assert "End." in prompt
+
+
 def test_load_system_prompt_missing_arg_raises(builtin_args: BuiltinSystemPromptArgs):
     """Missing template args should raise a dedicated error."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Add `FileSystemLoader` to the Jinja2 environment in `_load_system_prompt()` so that system prompt templates can use `{% include "file.md" %}` to compose prompts from multiple files.

## Changes

- **`src/kimi_cli/soul/agent.py`**: Added `FileSystemLoader(path.parent)` to the `JinjaEnvironment`, rooted at the directory of the system prompt file. This keeps agent spec directories self-contained — included files are resolved relative to where `system.md` lives.
- **`tests/core/test_load_agent.py`**: Added `test_load_system_prompt_include` to verify that `{% include %}` works correctly.

## Motivation

Previously, the Jinja2 environment had no loader configured, so `{% include %}` would raise a `TemplatesNotFound` error. With this change, agent authors can split large system prompts into reusable fragments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
