### PR TITLE
fix(cli): redirect stderr before MCP loading to prevent terminal pollution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Fix MCP server stderr pollution — stderr redirection is now installed before MCP servers start, so subprocess logs (e.g., OAuth debug output from `mcp-remote`) are captured into the log file instead of being printed to the terminal
 - Shell: Fix subprocess hang on interactive prompts — the `Shell` tool now closes stdin immediately and sets `GIT_TERMINAL_PROMPT=0` so commands that require credentials (e.g. `git push` over HTTPS) fail fast instead of blocking until timeout
 - Core: Fix JSON parsing error when LLM tool call arguments contain unescaped control characters — use `json.loads(strict=False)` across all LLM output parsing paths to prevent tool execution failure and session corruption
 - Shell: Auto-trigger agent when background tasks complete while idle — the shell now detects when a background bash command or agent task finishes and automatically starts a new agent turn to process the results, instead of waiting for the user to type something

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Fix MCP server stderr pollution — stderr redirection is now installed before MCP servers start, so subprocess logs (e.g., OAuth debug output from `mcp-remote`) are captured into the log file instead of being printed to the terminal
 - Shell: Fix subprocess hang on interactive prompts — the `Shell` tool now closes stdin immediately and sets `GIT_TERMINAL_PROMPT=0` so commands that require credentials (e.g. `git push` over HTTPS) fail fast instead of blocking until timeout
 - Core: Fix JSON parsing error when LLM tool call arguments contain unescaped control characters — use `json.loads(strict=False)` across all LLM output parsing paths to prevent tool execution failure and session corruption
 - Shell: Auto-trigger agent when background tasks complete while idle — the shell now detects when a background bash command or agent task finishes and automatically starts a new agent turn to process the results, instead of waiting for the user to type something

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,7 @@
 
 ## 未发布
 
+- Core：修复 MCP 服务器 stderr 污染问题——stderr 重定向现在在 MCP 服务器启动前安装，子进程日志（如 `mcp-remote` 的 OAuth 调试输出）将被捕获到日志文件，而非输出到终端
 - Shell：修复子进程遇到交互式提示时挂起的问题——`Shell` 工具现在会立即关闭 stdin 并设置 `GIT_TERMINAL_PROMPT=0`，使需要凭证的命令（如通过 HTTPS 执行 `git push`）快速失败，而非阻塞至超时
 - Core：修复 LLM 工具调用参数包含未转义控制字符时 JSON 解析失败的问题——在所有 LLM 输出解析路径使用 `json.loads(strict=False)`，防止工具执行失败和会话永久损坏
 - Shell：空闲时自动响应后台任务完成——Shell 现在会检测后台 Bash 命令或 Agent 任务的完成，并自动发起新的 Agent 轮次处理结果，无需等待用户输入

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -337,9 +337,10 @@ def kimi(
 
     from .mcp import get_global_mcp_config_file
 
-    # Don't redirect stderr yet. Our stderr redirector replaces fd=2 with a pipe, which
-    # would swallow Click/Typer startup errors (e.g. config parsing / BadParameter).
-    # We re-enable stderr redirection after KimiCLI.create() succeeds.
+    # Don't redirect stderr during argument parsing. Our stderr redirector
+    # replaces fd=2 with a pipe, which would swallow Click/Typer startup errors.
+    # Redirection is installed later, right before KimiCLI.create(), so that
+    # MCP server stderr noise is captured into logs from the start.
     enable_logging(debug, redirect_stderr=False)
 
     def _emit_fatal_error(message: str) -> None:
@@ -526,6 +527,15 @@ def kimi(
                 if changed:
                     session.save_state()
 
+            # Redirect stderr *before* KimiCLI.create() so that MCP server
+            # subprocesses (e.g. mcp-remote OAuth debug logs) write to the log
+            # file instead of polluting the user's terminal.  CLI argument
+            # parsing has already succeeded at this point, so Typer/Click
+            # startup errors are no longer a concern.  Fatal errors from
+            # create() are still visible because _emit_fatal_error() writes to
+            # the saved original stderr fd.
+            redirect_stderr_to_logger()
+
             instance = await KimiCLI.create(
                 session,
                 config=config,
@@ -542,10 +552,6 @@ def kimi(
                 defer_mcp_loading=ui == "shell" and prompt is None,
             )
             startup_progress.stop()
-
-            # Install stderr redirection only after initialization succeeded, so runtime
-            # stderr noise is captured into logs without hiding startup failures.
-            redirect_stderr_to_logger()
             preserve_background_tasks = False
             try:
                 match ui:


### PR DESCRIPTION
## Related Issue

Resolves #1214 — Verbose MCP debug messages printed to console when starting with `-C` flag and OAuth MCP servers.

Also related: #1215 (attempted fix, still open), #1501 (closed without merge).

## Description

MCP server subprocesses (e.g. `mcp-remote`) write debug and OAuth logs to stderr. Previously, `redirect_stderr_to_logger()` was called **after** `KimiCLI.create()`, which meant MCP server stderr output during startup went directly to the user's terminal, polluting the TUI.

### Root Cause

```
enable_logging(debug, redirect_stderr=False)   ← line 343: stderr NOT redirected yet
    ...
instance = await KimiCLI.create(...)           ← line 530: MCP servers start here
    ...                                           stderr noise goes to terminal ❌
redirect_stderr_to_logger()                    ← line 549: too late
```

### Fix

Move `redirect_stderr_to_logger()` to just before `KimiCLI.create()`. At this point CLI argument parsing has already completed, so Typer/Click startup errors are no longer a concern. Fatal errors from `create()` remain visible because `_emit_fatal_error()` writes to the saved original stderr fd (not affected by the redirect).

```
enable_logging(debug, redirect_stderr=False)   ← line 343: still deferred here
    ...
redirect_stderr_to_logger()                    ← line 535: NOW redirected ✅
instance = await KimiCLI.create(...)           ← line 537: MCP stderr → log file
```

### Before / After

Tested with a noisy MCP server that writes 5 debug lines to stderr during startup:

```
# Before (upstream/main):
$ kimi --mcp-config-file noisy.json --yolo -p 'say hi' 2>&1 | cat
[mcp-remote DEBUG] Connecting to OAuth provider... attempt 1
[mcp-remote DEBUG] Connecting to OAuth provider... attempt 2
[mcp-remote DEBUG] Connecting to OAuth provider... attempt 3
[mcp-remote DEBUG] Connecting to OAuth provider... attempt 4
[mcp-remote DEBUG] Connecting to OAuth provider... attempt 5
• Hello! 👋 How can I help you today?

# After (this branch):
$ kimi --mcp-config-file noisy.json --yolo -p 'say hi' 2>&1 | cat
• Hello! 👋 I'm Kimi Code CLI, your software engineering assistant. How can I help you today?
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have run `make gen-changelog` to update the changelog.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
