### PR TITLE
1. 加载全局配置: 首先尝试加载 ~/.kimi/AGENTS.md 或 ~/.kimi/agents.md || 1. Load global configuration: First try to load ~/.kimi/AGENTS.md or ~/.kimi/agents.md

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -61,15 +61,48 @@ class BuiltinSystemPromptArgs:
 
 
 async def load_agents_md(work_dir: KaosPath) -> str | None:
-    paths = [
+    # Load global AGENTS.md from ~/.kimi/AGENTS.md
+    global_paths = [
+        KaosPath.home() / ".kimi" / "AGENTS.md",
+        KaosPath.home() / ".kimi" / "agents.md",
+    ]
+    global_content: str | None = None
+    for path in global_paths:
+        if await path.is_file():
+            logger.info("Loaded global agents.md: {path}", path=path)
+            global_content = (await path.read_text()).strip()
+            break
+    
+    # Load local AGENTS.md from work_dir
+    local_paths = [
         work_dir / "AGENTS.md",
         work_dir / "agents.md",
     ]
-    for path in paths:
+    local_content: str | None = None
+    for path in local_paths:
         if await path.is_file():
-            logger.info("Loaded agents.md: {path}", path=path)
-            return (await path.read_text()).strip()
-    logger.info("No AGENTS.md found in {work_dir}", work_dir=work_dir)
+            logger.info("Loaded local agents.md: {path}", path=path)
+            local_content = (await path.read_text()).strip()
+            break
+    
+    # Merge contents if both exist
+    if global_content and local_content:
+        merged = f"""# Global AGENTS.md (from ~/.kimi/)
+
+{global_content}
+
+---
+
+# Local AGENTS.md (from {work_dir})
+
+{local_content}"""
+        return merged
+    elif global_content:
+        return global_content
+    elif local_content:
+        return local_content
+    
+    logger.info("No AGENTS.md found in {work_dir} or ~/.kimi/", work_dir=work_dir)
     return None
 
 


### PR DESCRIPTION
1. 加载全局配置: 首先尝试加载 ~/.kimi/AGENTS.md 或 ~/.kimi/agents.md
2. 加载本地配置: 然后尝试加载工作目录的 AGENTS.md 或 agents.md
3. 智能合并: • 如果两者都存在，会合并内容，并用标题区分来源： # Global AGENTS.md (from ~/.kimi/)

    [全局规则内容]

    ---

    # Local AGENTS.md (from [工作目录])

    [本地规则内容]
  • 如果只有其中一个存在，只返回那个的内容
  • 如果都不存在，返回 None

使用方法

只需在 ~/.kimi/AGENTS.md 创建你的全局个人规则文件，CLI 启动时会自动加载：

mkdir -p ~/.kimi
echo "# 我的全局规则" > ~/.kimi/AGENTS.md

这样每次启动 Kimi CLI 时，无论在哪个工作目录，都会自动加载你的全局个人规则。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
1. Load global configuration: First try to load ~/.kimi/AGENTS.md or ~/.kimi/agents.md
2. Load local configuration: Then try to load AGENTS.md or agents.md in the working directory
3. Smart merge: • If both exist, the content will be merged and the source will be distinguished with titles: # Global AGENTS.md (from ~/.kimi/)

    [Global rule content]

    ---

    # Local AGENTS.md (from [working directory])

    [Content of local rules]
  • If only one of them exists, only the contents of that one are returned
  • If neither exists, return None

How to use

Just create your global personal rules file in ~/.kimi/AGENTS.md and it will be loaded automatically when the CLI starts:

mkdir -p ~/.kimi
echo "#My global rules" > ~/.kimi/AGENTS.md

In this way, every time you start Kimi CLI, your global personal rules will be automatically loaded no matter which working directory you are in.
