### PR TITLE
fix(wire): reject steer messages after turn ends

### DIFF
--- a/src/kimi_cli/wire/server.py
+++ b/src/kimi_cli/wire/server.py
@@ -79,6 +79,8 @@ class WireServer:
         # soul running stuffs
         self._soul = soul
         self._cancel_event: asyncio.Event | None = None
+        self._turn_active: bool = False
+        """True only while the soul is actively running a turn (between run_soul start and return)."""
         self._pending_requests: dict[str, Request] = {}
         """Maps JSON RPC message IDs to pending `Request`s."""
         self._client_supports_question: bool = False
@@ -540,6 +542,7 @@ class WireServer:
             )
 
         self._cancel_event = asyncio.Event()
+        self._turn_active = True
         try:
             runtime = self._soul.runtime if isinstance(self._soul, KimiSoul) else None
             await run_soul(
@@ -580,6 +583,9 @@ class WireServer:
                 result={"status": Statuses.CANCELLED},
             )
         finally:
+            # Mark the turn as inactive immediately so concurrent steer/cancel
+            # handlers see the correct state before _cancel_event is cleared.
+            self._turn_active = False
             # Clean up any remaining pending requests from this turn.
             # After run_soul() returns, the soul and all subagents are done,
             # so any unresolved requests are stale.
@@ -609,7 +615,7 @@ class WireServer:
     async def _handle_steer(
         self, msg: JSONRPCSteerMessage
     ) -> JSONRPCSuccessResponse | JSONRPCErrorResponse:
-        if not isinstance(self._soul, KimiSoul) or not self._is_streaming:
+        if not isinstance(self._soul, KimiSoul) or not self._turn_active:
             return JSONRPCErrorResponse(
                 id=msg.id,
                 error=JSONRPCErrorObject(

--- a/tests/core/test_wire_server_steer.py
+++ b/tests/core/test_wire_server_steer.py
@@ -66,6 +66,7 @@ async def test_handle_steer_queues_input_when_streaming(
 
     monkeypatch.setattr(soul, "steer", lambda user_input: queued.append(user_input))
     server._cancel_event = asyncio.Event()
+    server._turn_active = True
 
     response = await server._handle_steer(
         JSONRPCSteerMessage(
@@ -77,6 +78,31 @@ async def test_handle_steer_queues_input_when_streaming(
     assert isinstance(response, JSONRPCSuccessResponse)
     assert response.result == {"status": Statuses.STEERED}
     assert queued == [[TextPart(text="follow-up")]]
+
+
+@pytest.mark.asyncio
+async def test_handle_steer_rejects_after_turn_ends(
+    runtime: Runtime,
+    tmp_path: Path,
+) -> None:
+    """Steer sent after run_soul() returns but before _cancel_event is cleared should be rejected."""
+    soul = _make_soul(runtime, tmp_path)
+    server = WireServer(soul)
+
+    # Simulate the state after run_soul() returns but before finally cleanup:
+    # _cancel_event is still set (not yet None), but _turn_active is False.
+    server._cancel_event = asyncio.Event()
+    server._turn_active = False
+
+    response = await server._handle_steer(
+        JSONRPCSteerMessage(
+            id="1",
+            params=JSONRPCSteerMessage.Params(user_input=[TextPart(text="too late")]),
+        )
+    )
+
+    assert isinstance(response, JSONRPCErrorResponse)
+    assert response.error.code == ErrorCodes.INVALID_STATE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix a race condition in `WireServer._handle_steer()` where steer messages sent after `run_soul()` returns but before `_cancel_event` cleanup would be accepted with `status=steered` but never consumed — silently lost
- Add `_turn_active` flag to precisely track soul execution lifecycle, replacing the `_is_streaming` check (which relied on `_cancel_event is not None`) for steer gating
- Add test covering the tail-window race scenario

## Problem

`_is_streaming` is derived from `_cancel_event is not None`. Since `_cancel_event` is only cleared in the `finally` block of `_handle_prompt()`, there's a window between `run_soul()` returning and the `finally` cleanup where:

1. Client receives `TurnEnd` event
2. Client sends a steer message
3. `_handle_steer()` sees `_is_streaming == True` and accepts it
4. `soul.steer()` queues the message
5. But the turn is already over — the steer is never consumed
6. At next turn start, `_agent_loop()` discards it as "stale"

Since `_read_loop()` dispatches inbound JSON-RPC messages concurrently via `asyncio.create_task`, the ordering between `_handle_prompt`'s finally block and `_handle_steer` is scheduler-dependent.

## Fix

Add a `_turn_active: bool` flag that is:
- Set to `True` when `_handle_prompt()` starts `run_soul()`
- Set to `False` immediately when `run_soul()` returns (before `finally` cleanup)

`_handle_steer()` now checks `_turn_active` instead of `_is_streaming`, closing the tail window.

## Test plan

- [x] New test: `test_handle_steer_rejects_after_turn_ends` — simulates the exact race window
- [x] Existing test updated: `test_handle_steer_queues_input_when_streaming` — sets `_turn_active = True`
- [x] All 6 wire server steer tests pass
- [x] All 12 kimisoul steer tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
