### PR TITLE
fix: guard trafilatura import to prevent cascading tool load failure on Python 3.13

### DIFF
--- a/src/kimi_cli/tools/web/fetch.py
+++ b/src/kimi_cli/tools/web/fetch.py
@@ -102,9 +102,7 @@ class FetchURL(CallableTool2[Params]):
             # trafilatura unavailable (e.g. charset-normalizer binary
             # incompatible with current Python), return raw HTML trimmed
             builder.write(resp_text[:50000])
-            return builder.ok(
-                "trafilatura is not available; returning raw page content."
-            )
+            return builder.ok("trafilatura is not available; returning raw page content.")
 
         extracted_text = trafilatura.extract(
             resp_text,

--- a/src/kimi_cli/tools/web/fetch.py
+++ b/src/kimi_cli/tools/web/fetch.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import override
 
 import aiohttp
-import trafilatura
 from kosong.tooling import CallableTool2, ToolReturnValue
 from pydantic import BaseModel, Field
 
@@ -13,6 +12,13 @@ from kimi_cli.soul.toolset import get_current_tool_call_or_none
 from kimi_cli.tools.utils import ToolResultBuilder, load_desc
 from kimi_cli.utils.aiohttp import new_client_session
 from kimi_cli.utils.logging import logger
+
+try:
+    import trafilatura
+
+    _has_trafilatura = True
+except Exception:
+    _has_trafilatura = False
 
 
 class Params(BaseModel):
@@ -90,6 +96,14 @@ class FetchURL(CallableTool2[Params]):
             return builder.ok(
                 "The response body is empty.",
                 brief="Empty response body",
+            )
+
+        if not _has_trafilatura:
+            # trafilatura unavailable (e.g. charset-normalizer binary
+            # incompatible with current Python), return raw HTML trimmed
+            builder.write(resp_text[:50000])
+            return builder.ok(
+                "trafilatura is not available; returning raw page content."
             )
 
         extracted_text = trafilatura.extract(


### PR DESCRIPTION
## Summary

On Python 3.13, `charset-normalizer` ships mypyc-compiled `.so` binaries that are incompatible with the interpreter, causing `trafilatura` to fail at import time. Since `web/__init__.py` unconditionally does `from .fetch import FetchURL` (which has a bare `import trafilatura` at module level), the entire `web` package fails to load — taking **SearchWeb** down with it even though SearchWeb has zero trafilatura dependency.

**Changes:**
- Wrap the `trafilatura` import in `try/except`, set a `_has_trafilatura` flag
- When trafilatura is unavailable, `fetch_with_http_get` falls back to returning raw page content (trimmed to 50k chars) instead of crashing
- Service-based fetch path (`_fetch_with_service`) is completely unaffected
- `SearchWeb` now loads normally regardless of the trafilatura situation

## Root Cause

```
charset-normalizer (mypyc .so) incompatible with Python 3.13
  → trafilatura import fails
    → fetch.py fails to load
      → web/__init__.py fails to load
        → both FetchURL AND SearchWeb become "Invalid tools"
```

## Test Plan

- [ ] Verify `SearchWeb` loads on Python 3.13 without the `charset-normalizer` workaround
- [ ] Verify `FetchURL` loads and returns raw content for HTML pages when trafilatura is unavailable
- [ ] Verify existing `FetchURL` behavior unchanged when trafilatura is available
- [ ] Existing tests pass (`pytest tests/tools/test_fetch_url.py`)

Fixes #1572
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
