### PR TITLE
feat(shell): highlight user input with bright blue and separator for better visibility

### DIFF
--- a/src/kimi_cli/ui/shell/echo.py
+++ b/src/kimi_cli/ui/shell/echo.py
@@ -1,17 +1,31 @@
 from __future__ import annotations
 
+import shutil
+
 from kosong.message import Message
+from rich.console import Group
 from rich.text import Text
 
 from kimi_cli.ui.shell.prompt import PROMPT_SYMBOL
 from kimi_cli.utils.message import message_stringify
 
 
-def render_user_echo(message: Message) -> Text:
+def _separator_line() -> Text:
+    """Return a dashed separator line that spans the full terminal width."""
+    try:
+        width = shutil.get_terminal_size().columns
+    except OSError:
+        width = 80
+    return Text("-" * width, style="grey50")
+
+
+def render_user_echo(message: Message) -> Group:
     """Render a user message as literal shell transcript text."""
-    return Text(f"{PROMPT_SYMBOL} {message_stringify(message)}")
+    user_line = Text(f"{PROMPT_SYMBOL} {message_stringify(message)}", style="#007AFF")
+    return Group(user_line, _separator_line())
 
 
-def render_user_echo_text(text: str) -> Text:
+def render_user_echo_text(text: str) -> Group:
     """Render the local prompt text exactly as the user saw it in the buffer."""
-    return Text(f"{PROMPT_SYMBOL} {text}")
+    user_line = Text(f"{PROMPT_SYMBOL} {text}", style="#007AFF")
+    return Group(user_line, _separator_line())

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1598,6 +1598,8 @@ class CustomPromptSession:
         buffer_container.filter = buffer_container.filter & Condition(
             self._should_render_input_buffer
         )
+        if hasattr(buffer_container, "content") and isinstance(buffer_container.content, Window):
+            buffer_container.content.style = "class:user-input"
         self._prompt_buffer_container = buffer_container
 
     def _should_show_slash_completion_menu(self) -> bool:

--- a/src/kimi_cli/ui/theme.py
+++ b/src/kimi_cli/ui/theme.py
@@ -102,6 +102,7 @@ def _task_browser_style_light() -> PTKStyle:
 
 
 _PROMPT_STYLE_DARK = {
+    "user-input": "fg:#007AFF",
     "bottom-toolbar": "noreverse",
     "running-prompt-placeholder": "fg:#7c8594 italic",
     "running-prompt-separator": "fg:#4a5568",
@@ -116,6 +117,7 @@ _PROMPT_STYLE_DARK = {
 }
 
 _PROMPT_STYLE_LIGHT = {
+    "user-input": "fg:#007AFF",
     "bottom-toolbar": "noreverse",
     "running-prompt-placeholder": "fg:#6b7280 italic",
     "running-prompt-separator": "fg:#d1d5db",

--- a/tests/ui_and_conv/test_replay.py
+++ b/tests/ui_and_conv/test_replay.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from kosong.message import Message
+from rich.console import Group
 
 import kimi_cli.ui.shell.replay as replay_module
 from kimi_cli.soul.message import system_reminder
@@ -32,6 +33,12 @@ def _make_notification_message(notification_id: str = "n1") -> Message:
             )
         ],
     )
+
+
+def _get_first_renderable_plain(text):
+    if isinstance(text, Group) and text.renderables:
+        return getattr(text.renderables[0], "plain", str(text.renderables[0]))
+    return getattr(text, "plain", str(text))
 
 
 def test_build_replay_turns_from_history_ignores_notifications() -> None:
@@ -82,7 +89,7 @@ async def test_replay_recent_history_excludes_notifications(
     monkeypatch.setattr(
         replay_module.console,
         "print",
-        lambda text: printed.append(getattr(text, "plain", str(text))),
+        lambda text: printed.append(_get_first_renderable_plain(text)),
     )
 
     async def fake_visualize(*_args, **_kwargs) -> None:
@@ -165,7 +172,7 @@ async def test_replay_recent_history_falls_back_to_history_when_wire_misses_stee
     monkeypatch.setattr(
         replay_module.console,
         "print",
-        lambda text: printed.append(getattr(text, "plain", str(text))),
+        lambda text: printed.append(_get_first_renderable_plain(text)),
     )
 
     async def fake_visualize(*_args, **_kwargs) -> None:
@@ -235,7 +242,7 @@ async def test_replay_recent_history_falls_back_to_history_when_duplicate_text_s
     monkeypatch.setattr(
         replay_module.console,
         "print",
-        lambda text: printed.append(getattr(text, "plain", str(text))),
+        lambda text: printed.append(_get_first_renderable_plain(text)),
     )
 
     async def fake_visualize(*_args, **_kwargs) -> None:

--- a/tests/ui_and_conv/test_shell_prompt_echo.py
+++ b/tests/ui_and_conv/test_shell_prompt_echo.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 from typing import cast
 
 from kosong.message import Message
+from rich.console import Group
+from rich.text import Text
 
 import kimi_cli.ui.shell as shell_module
 from kimi_cli.soul import Soul
@@ -25,6 +27,18 @@ def _noop(app: object, args: str) -> None:
     pass
 
 
+def _assert_user_echo(rendered: object, expected_plain: str) -> None:
+    assert isinstance(rendered, Group)
+    assert len(rendered.renderables) == 2
+    user_line, separator = rendered.renderables
+    assert isinstance(user_line, Text)
+    assert isinstance(separator, Text)
+    assert user_line.plain == expected_plain
+    assert str(user_line.style) == "#007AFF"
+    assert separator.plain
+    assert set(separator.plain) == {"-"}
+
+
 def _make_shell(*command_names: str) -> Shell:
     commands = [
         SlashCommand(
@@ -44,7 +58,8 @@ def test_echo_agent_input_prints_stringified_user_message(monkeypatch) -> None:
 
     Shell._echo_agent_input(_make_user_input("hi"))
 
-    assert [getattr(t, "plain", t) for t in printed] == ["✨ hi"]
+    assert len(printed) == 1
+    _assert_user_echo(printed[0], "✨ hi")
 
 
 def test_echo_agent_input_uses_display_command_for_placeholders(monkeypatch) -> None:
@@ -60,13 +75,14 @@ def test_echo_agent_input_uses_display_command_for_placeholders(monkeypatch) -> 
 
     Shell._echo_agent_input(user_input)
 
-    assert [getattr(t, "plain", t) for t in printed] == ["✨ [Pasted text #1 +3 lines]"]
+    assert len(printed) == 1
+    _assert_user_echo(printed[0], "✨ [Pasted text #1 +3 lines]")
 
 
 def test_render_user_echo_preserves_literal_brackets() -> None:
     rendered = render_user_echo(Message(role="user", content=[TextPart(text="[brackets]")]))
 
-    assert rendered.plain == "✨ [brackets]"
+    _assert_user_echo(rendered, "✨ [brackets]")
 
 
 def test_render_user_echo_preserves_image_placeholder_literal() -> None:
@@ -77,7 +93,7 @@ def test_render_user_echo_preserves_image_placeholder_literal() -> None:
         )
     )
 
-    assert rendered.plain == "✨ [image]"
+    _assert_user_echo(rendered, "✨ [image]")
 
 
 def test_render_user_echo_preserves_audio_placeholder_literal() -> None:
@@ -92,7 +108,7 @@ def test_render_user_echo_preserves_audio_placeholder_literal() -> None:
         )
     )
 
-    assert rendered.plain == "✨ [audio:clip]"
+    _assert_user_echo(rendered, "✨ [audio:clip]")
 
 
 def test_render_user_echo_preserves_video_placeholder_literal() -> None:
@@ -105,7 +121,7 @@ def test_render_user_echo_preserves_video_placeholder_literal() -> None:
         )
     )
 
-    assert rendered.plain == "✨ [video]"
+    _assert_user_echo(rendered, "✨ [video]")
 
 
 def test_render_user_echo_preserves_mixed_content_order() -> None:
@@ -121,7 +137,7 @@ def test_render_user_echo_preserves_mixed_content_order() -> None:
         )
     )
 
-    assert rendered.plain == "✨ look [image][audio][video]"
+    _assert_user_echo(rendered, "✨ look [image][audio][video]")
 
 
 def test_should_echo_agent_input_for_plain_agent_message() -> None:

--- a/tests/ui_and_conv/test_shell_run_placeholders.py
+++ b/tests/ui_and_conv/test_shell_run_placeholders.py
@@ -68,6 +68,15 @@ def _make_fake_soul():
     )
 
 
+def _get_first_renderable_plain(text):
+    """Extract plain text from first renderable of a Group, or fallback to str."""
+    from rich.console import Group
+
+    if isinstance(text, Group) and text.renderables:
+        return getattr(text.renderables[0], "plain", str(text.renderables[0]))
+    return getattr(text, "plain", str(text))
+
+
 def _noop(app: object, args: str) -> None:
     pass
 
@@ -118,7 +127,9 @@ def _patched_shell_run(monkeypatch):
     monkeypatch.setattr(
         shell_module.console,
         "print",
-        lambda text="": printed.append(getattr(text, "plain", str(text))),
+        lambda *args, **_kw: printed.extend(
+            _get_first_renderable_plain(text) for text in (args or ("",))
+        ),
     )
     return printed
 

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -6,10 +6,19 @@ from typing import Any, cast
 import pytest
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.document import Document
+from rich.console import Group
 from rich.text import Text
 
 from kimi_cli.ui.shell.prompt import PromptMode, UserInput
 from kimi_cli.wire.types import ApprovalRequest, StatusUpdate, SteerInput, TextPart
+
+
+def _get_first_renderable_plain(text):
+    """Extract plain text from first renderable of a Group, or fallback to str."""
+    if isinstance(text, Group) and text.renderables:
+        return getattr(text.renderables[0], "plain", str(text.renderables[0]))
+    return getattr(text, "plain", str(text))
+
 
 shell_visualize = importlib.import_module("kimi_cli.ui.shell.visualize")
 # Sub-modules for monkeypatching internal names (Live, _keyboard_listener, console)
@@ -180,7 +189,7 @@ def test_live_view_renders_steer_input_as_user_echo(monkeypatch) -> None:
     monkeypatch.setattr(view, "cleanup", lambda *, is_interrupt: cleaned.append(is_interrupt))
 
     def _capture_print(*args, **_kwargs):
-        printed.append(getattr(args[0], "plain", str(args[0])) if args else "")
+        printed.append(_get_first_renderable_plain(args[0]) if args else "")
 
     monkeypatch.setattr(
         shell_visualize.console,
@@ -202,7 +211,7 @@ def test_live_view_flushes_current_output_before_printing_steer_input(monkeypatc
     monkeypatch.setattr(view, "flush_finished_tool_calls", lambda: order.append("flush_tools"))
 
     def _capture_print(*args, **_kwargs):
-        order.append(("print", getattr(args[0], "plain", str(args[0])) if args else ""))
+        order.append(("print", _get_first_renderable_plain(args[0]) if args else ""))
 
     monkeypatch.setattr(
         shell_visualize.console,
@@ -230,7 +239,7 @@ def test_prompt_live_view_handle_immediate_steer_prints_blank_line(monkeypatch) 
     printed: list[str] = []
 
     def _capture_print(*args, **_kwargs):
-        printed.append(getattr(args[0], "plain", str(args[0])) if args else "")
+        printed.append(_get_first_renderable_plain(args[0]) if args else "")
 
     monkeypatch.setattr(
         shell_visualize.console,


### PR DESCRIPTION
## Description

Improve visual distinction of user messages in the shell UI by highlighting user input with bright blue color (#007AFF) and adding a full-width separator line below each user input.

### Changes

- **echo.py**:
  - Apply bright blue color (`#007AFF`) to user echo text for unified visual identity
  - Add a full-width dashed separator line below user input for clear visual separation
  - Update return type from `Text` to `Group` to accommodate the new layout

- **prompt.py**:
  - Add `user-input` style class with `fg:#007AFF` to match the terminal icon color

### Test Plan

- [x] `make check` passes (ruff + pyright)
- [x] `make test` passes (13/13 tests in test_shell_prompt_echo.py)
- [x] Manual test: Verified user input appears in bright blue #007AFF
- [x] Manual test: Verified separator line displays correctly

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have tested these changes locally.
- [x] I have run `make gen-changelog` to update the changelog.