### PR TITLE
fix(skills): restore --skills-dir override behavior

### DIFF
--- a/src/kimi_cli/skill/__init__.py
+++ b/src/kimi_cli/skill/__init__.py
@@ -90,23 +90,22 @@ async def resolve_skills_roots(
     """
     Resolve layered skill roots in priority order.
 
-    Built-in skills load first when supported by the active KAOS backend,
-    followed by user/project discovery, then any extra directories supplied
-    via ``--skills-dir``, and finally plugin directories.  Extra directories
-    are **appended** to the default discovery chain — they never replace
-    user or project skills.
+    Built-in skills load first when supported by the active KAOS backend.
+    When extra directories are provided via ``--skills-dir``, they **override**
+    user/project discovery.  Plugins are always discoverable.
     """
     from kimi_cli.plugin.manager import get_plugins_dir
 
     roots: list[KaosPath] = []
     if _supports_builtin_skills():
         roots.append(KaosPath.unsafe_from_local_path(get_builtin_skills_dir()))
-    if user_dir := await find_user_skills_dir():
-        roots.append(user_dir)
-    if project_dir := await find_project_skills_dir(work_dir):
-        roots.append(project_dir)
     if extra_skills_dirs:
         roots.extend(extra_skills_dirs)
+    else:
+        if user_dir := await find_user_skills_dir():
+            roots.append(user_dir)
+        if project_dir := await find_project_skills_dir(work_dir):
+            roots.append(project_dir)
     # Plugins are always discoverable
     plugins_path = get_plugins_dir()
     if plugins_path.is_dir():

--- a/tests/core/test_skill.py
+++ b/tests/core/test_skill.py
@@ -190,8 +190,8 @@ async def test_resolve_skills_roots_uses_layers(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_resolve_skills_roots_appends_extra_dirs(tmp_path, monkeypatch):
-    """Extra dirs are appended after user/project, not replacing them."""
+async def test_resolve_skills_roots_extra_dirs_override_discovery(tmp_path, monkeypatch):
+    """Extra dirs override user/project discovery, not append to them."""
     home_dir = tmp_path / "home"
     user_dir = home_dir / ".config" / "agents" / "skills"
     user_dir.mkdir(parents=True)
@@ -216,10 +216,9 @@ async def test_resolve_skills_roots_appends_extra_dirs(tmp_path, monkeypatch):
         ],
     )
 
+    # extra dirs replace user/project discovery
     assert roots == [
         KaosPath.unsafe_from_local_path(get_builtin_skills_dir()),
-        KaosPath.unsafe_from_local_path(user_dir),
-        KaosPath.unsafe_from_local_path(project_dir),
         KaosPath.unsafe_from_local_path(extra_a),
         KaosPath.unsafe_from_local_path(extra_b),
     ]


### PR DESCRIPTION
## Summary
- Reverts `resolve_skills_roots` from append to override semantics
- When `--skills-dir` is provided, it replaces default user/project skill discovery instead of appending, matching 1.25.0 behavior
- Multi-path support (`list[Path]`) is preserved — users can still pass multiple `--skills-dir` flags

## Context
Customer reported `--skills-dir` not working in 1.26.0. The append behavior introduced in #1578 changed the semantics: previously `--skills-dir` would override default discovery, now it only appends. This restore the override behavior users rely on.

## Test plan
- [ ] `kimi --skills-dir ~/custom-skills` only shows built-in + custom skills (not user/project defaults)
- [ ] `kimi` without `--skills-dir` shows normal default discovery
- [ ] Multiple `--skills-dir` flags still work
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
