### PR TITLE
fix: auto-set reasoning_effort when history contains ThinkPart

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -126,6 +126,17 @@ class OpenAILegacy:
         generation_kwargs: dict[str, Any] = {}
         generation_kwargs.update(self._generation_kwargs)
 
+        # Some providers (e.g. One API) return reasoning_content by default
+        # and then require reasoning_effort on follow-up requests when the
+        # history already contains reasoning content.  When the user hasn't
+        # explicitly set reasoning_effort but the conversation already has
+        # ThinkParts, auto-enable it so the request stays valid.
+        reasoning_effort: ReasoningEffort | Omit = self._reasoning_effort
+        if isinstance(reasoning_effort, Omit) and any(
+            isinstance(part, ThinkPart) for msg in history for part in msg.content
+        ):
+            reasoning_effort = "high"
+
         try:
             response = await self.client.chat.completions.create(
                 model=self.model,
@@ -133,7 +144,7 @@ class OpenAILegacy:
                 tools=(tool_to_openai(tool) for tool in tools),
                 stream=self.stream,
                 stream_options={"include_usage": True} if self.stream else omit,
-                reasoning_effort=self._reasoning_effort,
+                reasoning_effort=reasoning_effort,
                 **generation_kwargs,
             )
             return OpenAILegacyStreamedMessage(response, self._reasoning_key)

--- a/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
@@ -306,3 +306,36 @@ async def test_openai_legacy_with_thinking():
             pass
         body = json.loads(mock.calls.last.request.content.decode())
         assert body["reasoning_effort"] == snapshot("high")
+
+
+async def test_openai_legacy_auto_reasoning_effort_from_history():
+    """When history already has ThinkPart but reasoning_effort is not
+    explicitly set, it should be auto-enabled so providers that require
+    reasoning_effort alongside reasoning_content don't reject the request."""
+    with respx.mock(base_url="https://api.openai.com") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        # No with_thinking() — reasoning_effort is omit by default
+        provider = OpenAILegacy(
+            model="kimi-k2.5",
+            api_key="test-key",
+            stream=False,
+            reasoning_key="reasoning_content",
+        )
+        history = [
+            Message(role="user", content="What is 2+2?"),
+            Message(
+                role="assistant",
+                content=[ThinkPart(think="Let me think..."), TextPart(text="4.")],
+            ),
+            Message(role="user", content="And 3+3?"),
+        ]
+        stream = await provider.generate("", [], history)
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        # reasoning_effort should be auto-set because history has ThinkPart
+        assert body["reasoning_effort"] == snapshot("high")
+        # reasoning_content should still be in the assistant message
+        assert body["messages"][1]["reasoning_content"] == snapshot("Let me think...")


### PR DESCRIPTION
## Summary

Fixes #1616

When a provider (e.g. One API with Kimi-K2.5) returns `reasoning_content` by default, kimi-cli stores it as `ThinkPart` in the conversation history.  On follow-up requests the messages include `reasoning_content` but the request omits `reasoning_effort`, causing a 400 error from providers that require both to be present together:

```
Error code: 400 - thinking is enabled but reasoning_content is missing
in assistant tool call message at index 7
```

**Root cause**: `openai_legacy.py` always passes `reasoning_effort=self._reasoning_effort` which is `omit` by default. When history has `ThinkPart`, the converted messages carry `reasoning_content` but no matching `reasoning_effort` in the request parameters.

**Fix**: In `generate()`, detect `ThinkPart` in history and auto-set `reasoning_effort="high"` when the user hasn't explicitly configured it.  This is consistent with how `model_parameters` and `thinking_effort` already check for `Omit`.

## Changes

- `openai_legacy.py`: Check history for `ThinkPart` before the API call; auto-enable `reasoning_effort` when needed
- `test_openai_legacy.py`: Add snapshot test covering the auto-reasoning scenario

## Test plan

- [ ] Existing `test_openai_legacy_with_thinking` still passes (explicit reasoning_effort unaffected)
- [ ] Existing `test_openai_legacy_reasoning_content` still passes (ThinkPart handling unaffected)
- [ ] New `test_openai_legacy_auto_reasoning_effort_from_history` passes
- [ ] Manual test with One API + Kimi-K2.5 multi-turn conversation no longer 400s
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
