### PR TITLE
fix(cli): update --skills-dir help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- CLI: `--skills-dir` now supports multiple directories and overrides default discovery — when specified, the directories replace user/project skills discovery (repeatable flag)
+
 ## 1.27.0 (2026-03-28)
 
 - Shell: Add `/feedback` command — submit feedback directly from the CLI session; the command falls back to opening GitHub Issues on network errors or timeouts

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -287,7 +287,7 @@ def kimi(
             file_okay=False,
             dir_okay=True,
             readable=True,
-            help="Additional skills directories (repeatable). Appended to default discovery.",
+            help="Custom skills directories (repeatable). Overrides default discovery.",
         ),
     ] = None,
     # Loop control


### PR DESCRIPTION
Update the help text for \"--skills-dir\" to accurately reflect its behavior:\n\n- Supports multiple directories (repeatable flag)\n- Overrides default discovery (matching pre-1.27.0 behavior restored by #1605)