### PR TITLE
fix(ids): update task ID format and validation regex

### DIFF
--- a/src/kimi_cli/background/ids.py
+++ b/src/kimi_cli/background/ids.py
@@ -4,14 +4,16 @@ import secrets
 
 from .models import TaskKind
 
-_TASK_ID_PREFIXES: dict[TaskKind, str] = {
-    "bash": "b",
-    "agent": "a",
-}
 _ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+_TASK_ID_PREFIXES: dict[TaskKind, str] = {
+    "bash": "bash",
+    "agent": "agent",
+}
 
 
 def generate_task_id(kind: TaskKind) -> str:
     prefix = _TASK_ID_PREFIXES[kind]
     suffix = "".join(secrets.choice(_ALPHABET) for _ in range(8))
-    return f"{prefix}{suffix}"
+    return f"{prefix}-{suffix}"

--- a/src/kimi_cli/background/store.py
+++ b/src/kimi_cli/background/store.py
@@ -16,7 +16,7 @@ from .models import (
     TaskView,
 )
 
-_VALID_TASK_ID = re.compile(r"^[a-z0-9]{2,20}$")
+_VALID_TASK_ID = re.compile(r"^[a-z0-9][a-z0-9\-]{1,24}$")
 
 
 def _validate_task_id(task_id: str) -> None:

--- a/tests/background/test_ids.py
+++ b/tests/background/test_ids.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from kimi_cli.background.ids import generate_task_id
+from kimi_cli.background.store import _VALID_TASK_ID
+
+
+class TestTaskIdValidation:
+    def test_generated_ids_pass_store_validation(self):
+        """Ensure ids.py and store.py stay in sync."""
+        for kind in ("bash", "agent"):
+            task_id = generate_task_id(kind)
+            assert _VALID_TASK_ID.match(task_id), f"{task_id!r} should pass validation"
+
+    @pytest.mark.parametrize(
+        "task_id",
+        [
+            "b1234567",
+            "a1234567",
+            "bmissing01",
+        ],
+    )
+    def test_old_format_ids_still_accepted(self, task_id):
+        assert _VALID_TASK_ID.match(task_id), f"old format {task_id!r} should still be valid"
+
+    @pytest.mark.parametrize(
+        "task_id",
+        [
+            "",
+            "x",
+            "-bash",
+            "BASH-123",
+            "bash_123",
+            "../escape",
+            "a" * 26,
+        ],
+    )
+    def test_invalid_ids_rejected(self, task_id):
+        assert not _VALID_TASK_ID.match(task_id), f"{task_id!r} should be rejected"

--- a/tests/background/test_manager.py
+++ b/tests/background/test_manager.py
@@ -33,7 +33,7 @@ def test_create_bash_task_persists_starting_state(runtime, monkeypatch):
         cwd=str(runtime.session.work_dir),
     )
 
-    assert view.spec.id.startswith("b")
+    assert view.spec.id.startswith("bash-")
     assert view.runtime.status == "starting"
     assert view.runtime.worker_pid == 4242
 
@@ -157,7 +157,7 @@ async def test_create_agent_task_persists_starting_state(runtime, monkeypatch):
         model_override=None,
     )
 
-    assert view.spec.id.startswith("a")
+    assert view.spec.id.startswith("agent-")
     assert view.spec.kind == "agent"
     assert view.runtime.status == "starting"
     assert view.spec.kind_payload["agent_id"] == "a1234567"


### PR DESCRIPTION
## Description

Background task IDs were previously generated as single-letter prefix + random string (e.g., `b5x9km2p`, `aqwpzz12`), which were hard to read and didn't clearly indicate task type.

Changed the format to `{kind}-{random}` (e.g., `bash-a3x9km2p`, `agent-xyz12345`), making task IDs human-readable at a glance. Updated the store validation regex to allow hyphens while maintaining backward compatibility with old-format IDs.

Added tests to verify the cross-module contract between ID generation and store validation, old format backward compatibility, and invalid ID rejection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
