### PR TITLE
fix(shell): expand pasted text placeholders in modal answers before sending to model

### DIFF
--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -847,6 +847,7 @@ class Shell:
                     if self._prompt_session is not None
                     else ""
                 ),
+                text_expander=self._prompt_session._get_placeholder_manager().serialize_for_history,  # pyright: ignore[reportPrivateUsage]
             )
             self._prompt_session.attach_modal(self._approval_modal)
         else:

--- a/src/kimi_cli/ui/shell/approval_panel.py
+++ b/src/kimi_cli/ui/shell/approval_panel.py
@@ -323,10 +323,12 @@ class ApprovalPromptDelegate:
         *,
         on_response: Callable[[ApprovalRequest, ApprovalResponse.Kind, str], None],
         buffer_text_provider: Callable[[], str] | None = None,
+        text_expander: Callable[[str], str] | None = None,
     ) -> None:
         self._panel = ApprovalRequestPanel(request)
         self._on_response = on_response
         self._buffer_text_provider = buffer_text_provider
+        self._text_expander = text_expander
         self._feedback_draft: str = ""
 
     @property
@@ -392,6 +394,8 @@ class ApprovalPromptDelegate:
             if key == "enter" or mapped == KeyEvent.ENTER:
                 text = event.current_buffer.text.strip()
                 if text:
+                    if self._text_expander is not None:
+                        text = self._text_expander(text)
                     self._clear_buffer(event.current_buffer)
                     self._feedback_draft = ""
                     self._panel.request.resolve("reject")

--- a/src/kimi_cli/ui/shell/question_panel.py
+++ b/src/kimi_cli/ui/shell/question_panel.py
@@ -337,12 +337,14 @@ class QuestionPromptDelegate:
         on_advance: Callable[[], QuestionRequestPanel | None],
         on_invalidate: Callable[[], None],
         buffer_text_provider: Callable[[], str] | None = None,
+        text_expander: Callable[[str], str] | None = None,
     ) -> None:
         self._panel: QuestionRequestPanel | None = panel
         self._awaiting_other_input = False
         self._on_advance = on_advance
         self._on_invalidate = on_invalidate
         self._buffer_text_provider = buffer_text_provider
+        self._text_expander = text_expander
 
     @property
     def panel(self) -> QuestionRequestPanel | None:
@@ -543,6 +545,8 @@ class QuestionPromptDelegate:
             self._awaiting_other_input = False
             return
         text = buffer.text.strip()
+        if self._text_expander is not None:
+            text = self._text_expander(text)
         self._clear_buffer(buffer)
         self._awaiting_other_input = False
         all_done = self._panel.submit_other(text)

--- a/src/kimi_cli/ui/shell/visualize.py
+++ b/src/kimi_cli/ui/shell/visualize.py
@@ -1475,6 +1475,7 @@ class _PromptLiveView(_LiveView):
                 on_advance=self._advance_question,
                 on_invalidate=self._flush_prompt_refresh,
                 buffer_text_provider=lambda: self._prompt_session._session.default_buffer.text,  # pyright: ignore[reportPrivateUsage]
+                text_expander=self._prompt_session._get_placeholder_manager().serialize_for_history,  # pyright: ignore[reportPrivateUsage]
             )
             self._prompt_session.attach_modal(self._question_modal)
         else:

--- a/tests/ui_and_conv/test_modal_lifecycle.py
+++ b/tests/ui_and_conv/test_modal_lifecycle.py
@@ -28,6 +28,14 @@ QuestionPromptDelegate = shell_visualize.QuestionPromptDelegate
 # ---------------------------------------------------------------------------
 
 
+class _FakePlaceholderManager:
+    """Minimal placeholder manager stub — serialize_for_history is identity."""
+
+    @staticmethod
+    def serialize_for_history(text: str) -> str:
+        return text
+
+
 def _make_approval_request(request_id: str = "req-1", **kwargs: Any) -> ApprovalRequest:
     defaults = {
         "id": request_id,
@@ -522,6 +530,9 @@ async def test_prompt_live_view_question_modal_attaches_and_detaches() -> None:
         def invalidate(self) -> None:
             pass
 
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
+
     view = _PromptLiveView(
         StatusUpdate(),
         prompt_session=cast(Any, _PromptSession()),
@@ -561,6 +572,9 @@ async def test_prompt_live_view_question_modal_updates_on_advance() -> None:
 
         def invalidate(self) -> None:
             pass
+
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
 
     view = _PromptLiveView(
         StatusUpdate(),
@@ -612,6 +626,9 @@ async def test_prompt_live_view_cleanup_clears_panel_but_modal_detached_in_final
 
         def invalidate(self) -> None:
             pass
+
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
 
     view = _PromptLiveView(
         StatusUpdate(),
@@ -835,6 +852,9 @@ async def test_shell_external_approval_response_syncs_modal(
         def invalidate(self) -> None:
             invalidations.append("inv")
 
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
+
     shell._prompt_session = _PromptSession()  # type: ignore[attr-defined]
 
     # Send both requests
@@ -939,6 +959,7 @@ async def test_prompt_live_view_question_does_not_affect_should_handle_key() -> 
                     "attach_modal": lambda self, d: None,
                     "detach_modal": lambda self, d: None,
                     "invalidate": lambda self: None,
+                    "_get_placeholder_manager": lambda self: _FakePlaceholderManager(),
                 },
             )(),
         ),
@@ -977,6 +998,7 @@ async def test_prompt_live_view_render_body_no_awaiting_other_hint() -> None:
                     "attach_modal": lambda self, d: None,
                     "detach_modal": lambda self, d: None,
                     "invalidate": lambda self: None,
+                    "_get_placeholder_manager": lambda self: _FakePlaceholderManager(),
                 },
             )(),
         ),

--- a/tests/ui_and_conv/test_prompt_clipboard.py
+++ b/tests/ui_and_conv/test_prompt_clipboard.py
@@ -342,3 +342,52 @@ def test_handle_bracketed_paste_keeps_normalized_text_in_shell_mode() -> None:
 
     assert buffer.inserted == ["line1\nline2\nline3"]
     assert app.invalidated is True
+
+
+async def test_question_delegate_expands_placeholders_on_submit() -> None:
+    """When submitting 'other' input in a question panel, pasted text
+    placeholders should be expanded to full text via text_expander."""
+    from unittest.mock import patch
+
+    from kimi_cli.ui.shell.question_panel import QuestionPromptDelegate, QuestionRequestPanel
+    from kimi_cli.wire.types import QuestionItem, QuestionRequest
+
+    full_text = "\n".join([f"line{i}" for i in range(1, 20)])
+    expand_calls: list[str] = []
+
+    def fake_expander(text: str) -> str:
+        expand_calls.append(text)
+        return text.replace("[Pasted text #1 +19 lines]", full_text)
+
+    question = QuestionItem(question="Review?", options=[], other_label="Revise")
+    request = QuestionRequest(id="q1", tool_call_id="tc1", questions=[question])
+    panel = QuestionRequestPanel(request)
+
+    delegate = QuestionPromptDelegate(
+        panel,
+        on_advance=lambda: None,
+        on_invalidate=lambda: None,
+        text_expander=fake_expander,
+    )
+    # Select the "Other" option
+    panel.select_index(len(panel._options) - 1)
+
+    # Simulate submitting placeholder text via submit_other
+    submitted_texts: list[str] = []
+    original_submit_other = panel.submit_other
+
+    def capture_submit_other(text: str) -> bool:
+        submitted_texts.append(text)
+        return original_submit_other(text)
+
+    buffer = _DummyBuffer()
+    buffer.text = "prefix [Pasted text #1 +19 lines]"  # type: ignore[attr-defined]
+    buffer.set_document = lambda *a, **kw: None  # type: ignore[attr-defined]
+
+    with patch.object(panel, "submit_other", capture_submit_other):
+        delegate._submit_other_input(cast("Buffer", buffer))
+
+    assert len(expand_calls) == 1
+    assert expand_calls[0] == "prefix [Pasted text #1 +19 lines]"
+    assert len(submitted_texts) == 1
+    assert full_text in submitted_texts[0]

--- a/tests/ui_and_conv/test_shell_task_slash.py
+++ b/tests/ui_and_conv/test_shell_task_slash.py
@@ -20,6 +20,14 @@ from kimi_cli.ui.shell import slash as shell_slash
 from kimi_cli.wire.types import ApprovalRequest
 
 
+class _FakePlaceholderManager:
+    """Minimal placeholder manager stub — serialize_for_history is identity."""
+
+    @staticmethod
+    def serialize_for_history(text: str) -> str:
+        return text
+
+
 def _make_shell_app(runtime: Runtime, tmp_path: Path) -> SimpleNamespace:
     agent = Agent(
         name="Test Agent",
@@ -222,6 +230,9 @@ async def test_shell_background_approval_with_prompt_session_uses_prompt_modal(
         def invalidate(self) -> None:
             invalidations.append("invalidate")
 
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
+
     shell._prompt_session = _PromptSession()  # type: ignore[attr-defined]
 
     request = ApprovalRequest(
@@ -286,6 +297,9 @@ async def test_shell_prompt_approval_modal_keeps_current_request_when_new_reques
 
         def invalidate(self) -> None:
             return None
+
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
 
     shell._prompt_session = _PromptSession()  # type: ignore[attr-defined]
 
@@ -359,6 +373,9 @@ async def test_shell_prompt_approval_modal_advances_fifo_after_current_response(
 
         def invalidate(self) -> None:
             return None
+
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
 
     shell._prompt_session = _PromptSession()  # type: ignore[attr-defined]
 
@@ -704,6 +721,9 @@ async def test_shell_background_approval_modal_includes_display_blocks(
         def invalidate(self) -> None:
             return None
 
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
+
     shell._prompt_session = _PromptSession()  # type: ignore[attr-defined]
 
     request = ApprovalRequest(
@@ -778,6 +798,9 @@ async def test_shell_background_approval_renders_subagent_metadata(
 
         def invalidate(self) -> None:
             return None
+
+        def _get_placeholder_manager(self) -> _FakePlaceholderManager:
+            return _FakePlaceholderManager()
 
     shell._prompt_session = _PromptSession()  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Description

When users paste long text (≥1000 chars or ≥15 lines) into modal inputs — such as ExitPlanMode's "Revise" feedback, AskUserQuestion's "Other" answer, or approval panel's "Reject + feedback" — the text was placeholderized (e.g., `[Pasted text #1 +16 lines]`) to keep the UI clean, but the placeholder was never expanded before being sent to the model. The model would see the placeholder token instead of the actual pasted content.

**Root cause:** `_insert_pasted_text` placeholderizes long text in AGENT mode, but the modal answer submission paths (`QuestionPromptDelegate._submit_other_input`, `ApprovalPromptDelegate.handle_running_prompt_key`) read the buffer text with the placeholder and pass it through without resolution. Only the main prompt path calls `resolve_command()` to expand placeholders.

**Fix:** Add a `text_expander: Callable[[str], str]` callback to both `QuestionPromptDelegate` and `ApprovalPromptDelegate`. On submission, expand placeholders via `PromptPlaceholderManager.serialize_for_history` before passing the answer text to the model. This keeps the UI showing the compact placeholder while ensuring the model receives the full text.

Test stubs in `test_modal_lifecycle.py` and `test_shell_task_slash.py` are updated to include `_get_placeholder_manager()` to match the new call path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
