### PR TITLE
feat(ui): add light theme support

### DIFF
--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -169,6 +169,15 @@ class MCPConfig(BaseModel):
     )
 
 
+class UIConfig(BaseModel):
+    """UI configuration."""
+
+    theme: Literal["dark", "light", "auto"] = Field(
+        default="dark",
+        description="Color theme for the UI. Options: 'dark', 'light', 'auto'",
+    )
+
+
 class Config(BaseModel):
     """Main configuration structure."""
 
@@ -202,6 +211,7 @@ class Config(BaseModel):
     )
     services: Services = Field(default_factory=Services, description="Services configuration")
     mcp: MCPConfig = Field(default_factory=MCPConfig, description="MCP configuration")
+    ui: UIConfig = Field(default_factory=UIConfig, description="UI configuration")
 
     @model_validator(mode="after")
     def validate_model(self) -> Self:

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -34,6 +34,7 @@ from kimi_cli.ui.shell.prompt import (
 from kimi_cli.ui.shell.replay import replay_recent_history
 from kimi_cli.ui.shell.slash import registry as shell_slash_registry
 from kimi_cli.ui.shell.slash import shell_mode_registry
+from kimi_cli.ui.shell.theme import detect_terminal_theme, get_theme_colors, set_theme
 from kimi_cli.ui.shell.update import LATEST_VERSION_FILE, UpdateResult, do_update, semver_tuple
 from kimi_cli.ui.shell.visualize import (
     ApprovalPromptDelegate,
@@ -153,6 +154,13 @@ class Shell:
             **{cmd.name: cmd for cmd in soul.available_slash_commands},
             **{cmd.name: cmd for cmd in shell_slash_registry.list_commands()},
         }
+        # Initialize theme from config
+        if isinstance(soul, KimiSoul):
+            theme = soul.runtime.config.ui.theme
+            if theme == "auto":
+                set_theme(detect_terminal_theme())
+            else:
+                set_theme(theme)
         """Shell-level slash commands + soul-level slash commands. Name to command mapping."""
 
     @property
@@ -414,7 +422,9 @@ class Shell:
                         continue
 
                     if event.kind == "interrupt":
-                        console.print("[grey50]Tip: press Ctrl-D or send 'exit' to quit[/grey50]")
+                        colors = get_theme_colors()
+                        msg = "Tip: press Ctrl-D or send 'exit' to quit"
+                        console.print(f"[{colors.message_info}]{msg}[/{colors.message_info}]")
                         resume_prompt.set()
                         continue
 
@@ -938,8 +948,13 @@ class WelcomeInfoItem:
 
 
 def _print_welcome_info(name: str, info_items: list[WelcomeInfoItem]) -> None:
+    colors = get_theme_colors()
     head = Text.from_markup("Welcome to Kimi Code CLI!")
-    help_text = Text.from_markup("[grey50]Send /help for help information.[/grey50]")
+    help_text = Text.from_markup(
+        f"[{colors.toolbar_text_secondary}]"
+        f"Send /help for help information."
+        f"[/{colors.toolbar_text_secondary}]"
+    )
 
     # Use Table for precise width control
     logo = Text.from_markup(_LOGO)

--- a/src/kimi_cli/ui/shell/approval_panel.py
+++ b/src/kimi_cli/ui/shell/approval_panel.py
@@ -16,6 +16,7 @@ from rich.text import Text
 
 from kimi_cli.ui.shell.console import console, render_to_ansi
 from kimi_cli.ui.shell.keyboard import KeyEvent
+from kimi_cli.ui.shell.theme import get_theme_colors
 from kimi_cli.utils.rich.diff_render import (
     collect_diff_hunks,
     render_diff_panel,
@@ -123,15 +124,17 @@ class ApprovalRequestPanel:
             elif isinstance(block, BriefDisplayBlock) and block.text:
                 text = block.text.rstrip("\n")
                 line_count = text.count("\n") + 1
+                style = get_theme_colors().approval_metadata
                 self._content_blocks.append(
-                    ApprovalContentBlock(text=text, lines=line_count, style="grey50")
+                    ApprovalContentBlock(text=text, lines=line_count, style=style)
                 )
                 if non_diff_budget > 0:
                     truncated = text
                     if line_count > non_diff_budget:
                         truncated = "\n".join(text.split("\n")[:non_diff_budget])
                         self._non_diff_truncated = True
-                    self._preview_renderables.append(Text(truncated, style="grey50"))
+                    style = get_theme_colors().approval_metadata
+                    self._preview_renderables.append(Text(truncated, style=style))
                     non_diff_budget -= min(line_count, non_diff_budget)
                 else:
                     self._non_diff_truncated = True
@@ -145,11 +148,12 @@ class ApprovalRequestPanel:
 
     def render(self, *, feedback_text: str | None = None) -> RenderableType:
         """Render the approval menu as a bordered panel."""
+        colors = get_theme_colors()
         content_lines: list[RenderableType] = [
             Text.from_markup(
-                "[yellow]"
+                f"[{colors.approval_warning}]"
                 f"{escape(self.request.sender)} is requesting approval to "
-                f"{escape(self.request.action)}:[/yellow]"
+                f"{escape(self.request.action)}:[/{colors.approval_warning}]"
             )
         ]
         content_lines.extend(self._render_source_metadata_lines())
@@ -158,8 +162,10 @@ class ApprovalRequestPanel:
         # Render preview (diff + non-diff in original display order)
         content_lines.extend(self._preview_renderables)
 
+        colors = get_theme_colors()
         if self.has_expandable_content and self._non_diff_truncated:
-            content_lines.append(Text("... (truncated, ctrl-e to expand)", style="dim italic"))
+            msg = "... (truncated, ctrl-e to expand)"
+            content_lines.append(Text(msg, style=f"{colors.dim} italic"))
 
         lines: list[RenderableType] = []
         if content_lines:
@@ -169,6 +175,7 @@ class ApprovalRequestPanel:
         show_inline_feedback = feedback_text is not None and self.is_feedback_selected
 
         # Add menu options with number key labels
+        colors = get_theme_colors()
         if lines:
             lines.append(Text(""))
         for i, (option_text, _) in enumerate(self.options):
@@ -177,17 +184,21 @@ class ApprovalRequestPanel:
             if i == self.selected_index:
                 if is_feedback_option and show_inline_feedback:
                     input_display = escape(feedback_text) if feedback_text else ""
-                    lines.append(
-                        Text.from_markup(
-                            f"[cyan]\u2192 \\[{num}] Reject: {input_display}\u2588[/cyan]"
-                        )
+                    markup = (
+                        f"[{colors.approval_selected}]\u2192 \\[{num}] "
+                        f"Reject: {input_display}\u2588"
+                        f"[/{colors.approval_selected}]"
                     )
+                    lines.append(Text.from_markup(markup))
                 else:
-                    lines.append(Text(f"\u2192 [{num}] {option_text}", style="cyan"))
+                    style = colors.approval_selected
+                    lines.append(Text(f"\u2192 [{num}] {option_text}", style=style))
             else:
-                lines.append(Text(f"  [{num}] {option_text}", style="grey50"))
+                style = colors.approval_unselected
+                lines.append(Text(f"  [{num}] {option_text}", style=style))
 
         # Keyboard hints
+        colors = get_theme_colors()
         lines.append(Text(""))
         if show_inline_feedback:
             hint = "  Type your feedback, then press Enter to submit."
@@ -195,12 +206,13 @@ class ApprovalRequestPanel:
             hint = "  \u25b2/\u25bc select  1/2/3/4 choose  \u21b5 confirm"
             if self.has_expandable_content:
                 hint += "  ctrl-e expand"
-        lines.append(Text(hint, style="dim"))
+        lines.append(Text(hint, style=colors.approval_hint))
 
+        colors = get_theme_colors()
         return Panel(
             Group(*lines),
-            border_style="bold yellow",
-            title="[bold yellow]\u26a0 ACTION REQUIRED[/bold yellow]",
+            border_style=colors.approval_border,
+            title=f"[{colors.approval_title}]\u26a0 ACTION REQUIRED[/{colors.approval_title}]",
             title_align="left",
             padding=(0, 1),
         )
@@ -231,9 +243,11 @@ class ApprovalRequestPanel:
             else:
                 assert self.request.agent_id is not None
                 subagent_text = self.request.agent_id
-            lines.append(Text(f"Subagent: {subagent_text}", style="grey50"))
+            style = get_theme_colors().approval_metadata
+            lines.append(Text(f"Subagent: {subagent_text}", style=style))
         if self.request.source_description:
-            lines.append(Text(f"Task: {self.request.source_description}", style="grey50"))
+            style = get_theme_colors().approval_metadata
+            lines.append(Text(f"Task: {self.request.source_description}", style=style))
         return lines
 
     def move_up(self):
@@ -255,12 +269,13 @@ class ApprovalRequestPanel:
 
 def show_approval_in_pager(panel: ApprovalRequestPanel) -> None:
     """Show the full approval request content in a pager."""
+    colors = get_theme_colors()
     with console.screen(), console.pager(styles=True):
         console.print(
             Text.from_markup(
-                "[yellow]⚠ "
+                f"[{colors.approval_warning}]⚠ "
                 f"{escape(panel.request.sender)} is requesting approval to "
-                f"{escape(panel.request.action)}:[/yellow]"
+                f"{escape(panel.request.action)}:[/{colors.approval_warning}]"
             )
         )
         console.print()
@@ -289,7 +304,8 @@ def show_approval_in_pager(panel: ApprovalRequestPanel) -> None:
                 rendered_any = True
                 idx += 1
             elif isinstance(block, BriefDisplayBlock) and block.text:
-                console.print(Text(block.text.rstrip("\n"), style="grey50"))
+                style = get_theme_colors().approval_metadata
+                console.print(Text(block.text.rstrip("\n"), style=style))
                 rendered_any = True
                 idx += 1
             else:

--- a/src/kimi_cli/ui/shell/mcp_status.py
+++ b/src/kimi_cli/ui/shell/mcp_status.py
@@ -7,6 +7,7 @@ from rich.console import Group, RenderableType
 from rich.spinner import Spinner
 from rich.text import Text
 
+from kimi_cli.ui.shell.theme import get_theme_colors
 from kimi_cli.utils.rich.columns import BulletColumns
 from kimi_cli.wire.types import MCPServerSnapshot, MCPStatusSnapshot
 
@@ -25,16 +26,16 @@ def render_mcp_console(snapshot: MCPStatusSnapshot) -> RenderableType:
         color = _status_color(server.status)
         server_text = f"[{color}]{server.name}[/{color}]"
         if server.status == "unauthorized":
-            server_text += f" [grey50](unauthorized - run: kimi mcp auth {server.name})[/grey50]"
+            server_text += f" [dim](unauthorized - run: kimi mcp auth {server.name})[/dim]"
         elif server.status != "connected":
-            server_text += f" [grey50]({server.status})[/grey50]"
+            server_text += f" [dim]({server.status})[/dim]"
 
         lines: list[RenderableType] = [Text.from_markup(server_text)]
         for tool_name in server.tools:
             lines.append(
                 BulletColumns(
-                    Text.from_markup(f"[grey50]{tool_name}[/grey50]"),
-                    bullet_style="grey50",
+                    Text.from_markup(f"[dim]{tool_name}[/dim]"),
+                    bullet_style="dim",
                 )
             )
         renderables.append(BulletColumns(Group(*lines), bullet_style=color))
@@ -46,11 +47,12 @@ def render_mcp_prompt(snapshot: MCPStatusSnapshot, *, now: float | None = None) 
     if not snapshot.loading:
         return FormattedText([])
 
+    colors = get_theme_colors()
     fragments: list[tuple[str, str]] = []
     prefix = f"{_spinner_frame(now)} " if snapshot.loading else ""
     fragments.append(
         (
-            "fg:#d4d4d4",
+            f"fg:{colors.toolbar_text}",
             (
                 f"{prefix}MCP Servers: "
                 f"{snapshot.connected}/{snapshot.total} connected, {snapshot.tools} tools"
@@ -63,7 +65,7 @@ def render_mcp_prompt(snapshot: MCPStatusSnapshot, *, now: float | None = None) 
         fragments.append((_prompt_status_style(server.status), f"• {server.name}"))
         detail = _prompt_server_detail(server)
         if detail:
-            fragments.append(("fg:#7c8594", detail))
+            fragments.append((f"fg:{colors.prompt_placeholder}", detail))
         fragments.append(("", "\n"))
 
     return FormattedText(fragments)

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -62,6 +62,7 @@ from kimi_cli.ui.shell.placeholders import (
     normalize_pasted_text,
     sanitize_surrogates,
 )
+from kimi_cli.ui.shell.theme import get_prompt_toolkit_style, get_theme_colors
 from kimi_cli.utils.clipboard import (
     grab_media_from_clipboard,
     is_clipboard_available,
@@ -1498,21 +1499,7 @@ class CustomPromptSession:
             clipboard=clipboard,
             history=history,
             bottom_toolbar=self._render_bottom_toolbar,
-            style=Style.from_dict(
-                {
-                    "bottom-toolbar": "noreverse",
-                    "running-prompt-placeholder": "fg:#7c8594 italic",
-                    "running-prompt-separator": "fg:#4a5568",
-                    "slash-completion-menu": "",
-                    "slash-completion-menu.separator": "fg:#4a5568",
-                    "slash-completion-menu.marker": "fg:#4a5568",
-                    "slash-completion-menu.marker.current": "fg:#4f9fff",
-                    "slash-completion-menu.command": "fg:#a6adba",
-                    "slash-completion-menu.meta": "fg:#7c8594",
-                    "slash-completion-menu.command.current": "fg:#6fb7ff bold",
-                    "slash-completion-menu.meta.current": "fg:#56a4ff",
-                }
-            ),
+            style=Style.from_dict(get_prompt_toolkit_style()),
         )
         self._session.default_buffer.read_only = Condition(
             lambda: (
@@ -1775,8 +1762,9 @@ class CustomPromptSession:
 
     def _render_agent_prompt_label(self) -> FormattedText:
         status = self._status_provider()
+        colors = get_theme_colors()
         if status.plan_mode:
-            return FormattedText([("fg:#00aaff", f"{PROMPT_SYMBOL_PLAN} ")])
+            return FormattedText([(f"fg:{colors.prompt_plan_mode}", f"{PROMPT_SYMBOL_PLAN} ")])
         symbol = PROMPT_SYMBOL_THINKING if self._thinking else PROMPT_SYMBOL
         return FormattedText([("", f"{symbol} ")])
 
@@ -2004,7 +1992,8 @@ class CustomPromptSession:
 
         fragments: list[tuple[str, str]] = []
 
-        fragments.append(("fg:#4d4d4d", "─" * columns))
+        colors = get_theme_colors()
+        fragments.append((f"fg:{colors.toolbar_border}", "─" * columns))
         fragments.append(("", "\n"))
 
         remaining = columns
@@ -2017,11 +2006,12 @@ class CustomPromptSession:
 
         # Status flags: yolo / plan
         status = self._status_provider()
+        colors = get_theme_colors()
         if status.yolo_enabled:
-            fragments.extend([("bold fg:#ffff00", "yolo"), ("", "  ")])
+            fragments.extend([("bold " + colors.status_yolo, "yolo"), ("", "  ")])
             remaining -= 6  # "yolo" = 4, "  " = 2
         if status.plan_mode:
-            fragments.extend([("bold fg:#00aaff", "plan"), ("", "  ")])
+            fragments.extend([("bold " + colors.status_plan, "plan"), ("", "  ")])
             remaining -= 6
 
         # Mode indicator (agent / shell) + model name + thinking indicator.
@@ -2059,7 +2049,7 @@ class CustomPromptSession:
             cwd_text = _truncate_right(cwd, max(0, remaining - 2))
             cwd_w = _display_width(cwd_text)
         if cwd_text and remaining >= cwd_w + 2:
-            fragments.extend([("fg:#666666", cwd_text), ("", "  ")])
+            fragments.extend([(f"fg:{colors.status_cwd}", cwd_text), ("", "  ")])
             remaining -= cwd_w + 2
 
         # Active background bash task count
@@ -2070,7 +2060,7 @@ class CustomPromptSession:
             bg_text = f"⚙ bash: {bg_count}"
             bg_width = _display_width(bg_text)
             if remaining >= bg_width + 2:
-                fragments.extend([("fg:#888888", bg_text), ("", "  ")])
+                fragments.extend([(f"fg:{colors.status_bg_task}", bg_text), ("", "  ")])
                 remaining -= bg_width + 2
 
         # Tips fill remaining space on line 1
@@ -2078,7 +2068,7 @@ class CustomPromptSession:
         if tip_text and _display_width(tip_text) > remaining:
             tip_text = self._get_one_rotating_tip()
         if tip_text and _display_width(tip_text) <= remaining:
-            fragments.append(("fg:#555555", tip_text))
+            fragments.append((f"fg:{colors.status_tips}", tip_text))
 
         # ── line 2: toast (left) + context (right) — always rendered ──────
         fragments.append(("", "\n"))

--- a/src/kimi_cli/ui/shell/question_panel.py
+++ b/src/kimi_cli/ui/shell/question_panel.py
@@ -15,6 +15,7 @@ from rich.text import Text
 
 from kimi_cli.ui.shell.console import console, render_to_ansi
 from kimi_cli.ui.shell.keyboard import KeyEvent
+from kimi_cli.ui.shell.theme import get_theme_colors
 from kimi_cli.utils.rich.markdown import Markdown
 from kimi_cli.wire.types import QuestionRequest
 
@@ -118,12 +119,14 @@ class QuestionRequestPanel:
                 elif qi.question in self._answers:
                     icon, style = "\u2713", "green"
                 else:
-                    icon, style = "\u25cb", "grey50"
+                    icon, style = "\u25cb", "dim"
                 tab_parts.append(f"[{style}]({icon}) {label}[/{style}]")
             lines.append(Text.from_markup("  ".join(tab_parts)))
             lines.append(Text(""))
 
-        lines.append(Text.from_markup(f"[yellow]? {escape(q.question)}[/yellow]"))
+        colors = get_theme_colors()
+        markup = f"[{colors.message_warning}]? {escape(q.question)}[/{colors.message_warning}]"
+        lines.append(Text.from_markup(markup))
         if q.multi_select:
             lines.append(Text("  (SPACE to toggle, ENTER to submit)", style="dim italic"))
         lines.append(Text(""))
@@ -144,23 +147,32 @@ class QuestionRequestPanel:
             if q.multi_select:
                 checked = "\u2713" if i in self._multi_selected else " "
                 prefix = f"\\[{checked}]"
+                colors = get_theme_colors()
                 if i == self._selected_index:
-                    option_line = Text.from_markup(f"[cyan]{prefix} {escape(label)}[/cyan]")
+                    markup = f"[{colors.highlight}]{prefix} {escape(label)}[/{colors.highlight}]"
+                    option_line = Text.from_markup(markup)
                 else:
-                    option_line = Text.from_markup(f"[grey50]{prefix} {escape(label)}[/grey50]")
+                    option_line = Text.from_markup(f"[dim]{prefix} {escape(label)}[/dim]")
             else:
+                colors = get_theme_colors()
                 if i == self._selected_index:
                     if is_other and show_inline_input:
                         input_display = escape(other_input_text) if other_input_text else ""
-                        option_line = Text.from_markup(
-                            f"[cyan]\u2192 \\[{num}] {escape(label)}: {input_display}\u2588[/cyan]"
+                        markup = (
+                            f"[{colors.highlight}]\u2192 \\[{num}] "
+                            f"{escape(label)}: {input_display}\u2588"
+                            f"[/{colors.highlight}]"
                         )
+                        option_line = Text.from_markup(markup)
                     else:
-                        option_line = Text.from_markup(
-                            f"[cyan]\u2192 \\[{num}] {escape(label)}[/cyan]"
+                        markup = (
+                            f"[{colors.highlight}]\u2192 \\[{num}] "
+                            f"{escape(label)}"
+                            f"[/{colors.highlight}]"
                         )
+                        option_line = Text.from_markup(markup)
                 else:
-                    option_line = Text.from_markup(f"[grey50]  \\[{num}] {escape(label)}[/grey50]")
+                    option_line = Text.from_markup(f"[dim]  \\[{num}] {escape(label)}[/dim]")
             lines.append(option_line)
 
             if description and not (is_other and show_inline_input):
@@ -181,10 +193,11 @@ class QuestionRequestPanel:
                 )
             )
 
+        colors = get_theme_colors()
         return Panel(
             Group(*lines),
-            border_style="bold cyan",
-            title="[bold cyan]? QUESTION[/bold cyan]",
+            border_style=f"bold {colors.highlight}",
+            title=f"[bold {colors.highlight}]? QUESTION[/bold {colors.highlight}]",
             title_align="left",
             padding=(0, 1),
         )
@@ -292,15 +305,20 @@ class QuestionRequestPanel:
 
 
 def show_question_body_in_pager(panel: QuestionRequestPanel) -> None:
+    colors = get_theme_colors()
     with console.screen(), console.pager(styles=True):
-        console.print(Text.from_markup(f"[yellow]? {escape(panel.current_question_text)}[/yellow]"))
+        text = panel.current_question_text
+        markup = f"[{colors.message_warning}]? {escape(text)}[/{colors.message_warning}]"
+        console.print(Text.from_markup(markup))
         console.print()
         for renderable in panel.render_full_body():
             console.print(renderable)
 
 
 async def prompt_other_input(question_text: str) -> str:
-    console.print(Text.from_markup(f"\n[yellow]? {escape(question_text)}[/yellow]"))
+    colors = get_theme_colors()
+    markup = f"\n[{colors.message_warning}]? {escape(question_text)}[/{colors.message_warning}]"
+    console.print(Text.from_markup(markup))
     console.print(Text("  Enter your answer:", style="dim"))
     try:
         session: PromptSession[str] = PromptSession()

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from prompt_toolkit.shortcuts.choice_input import ChoiceInput
 
@@ -16,6 +16,7 @@ from kimi_cli.soul.kimisoul import KimiSoul
 from kimi_cli.ui.shell.console import console
 from kimi_cli.ui.shell.mcp_status import render_mcp_console
 from kimi_cli.ui.shell.task_browser import TaskBrowserApp
+from kimi_cli.ui.shell.theme import get_current_theme, set_theme
 from kimi_cli.utils.changelog import CHANGELOG
 from kimi_cli.utils.datetime import format_relative_time
 from kimi_cli.utils.slashcmd import SlashCommand, SlashCommandRegistry
@@ -620,6 +621,88 @@ async def mcp(app: Shell, args: str):
         snapshot = soul.status.mcp_status
         if snapshot is not None:
             live.update(render_mcp_console(snapshot), refresh=True)
+
+
+@registry.command
+@shell_mode_registry.command
+async def theme(app: Shell, args: str):
+    """Switch between dark and light theme"""
+    from rich.text import Text
+
+    from kimi_cli.config import load_config, save_config
+
+    soul = ensure_kimi_soul(app)
+    if soul is None:
+        return
+    config = soul.runtime.config
+
+    # Check if config can be persisted
+    if not config.is_from_default_location:
+        console.print(
+            "[yellow]Theme switching requires the default config file; "
+            "restart without --config/--config-file.[/yellow]"
+        )
+        return
+
+    original_theme = get_current_theme()
+
+    console.print()
+    console.print(Text("Theme", style="bold"))
+    console.print()
+    console.print("Choose the text style that looks best with your terminal")
+    console.print()
+
+    # Build choices with markers
+    dark_marker = " ✔" if original_theme == "dark" else ""
+    light_marker = " ✔" if original_theme == "light" else ""
+
+    choices: list[tuple[str, str]] = [
+        ("dark", f"Dark mode{dark_marker}"),
+        ("light", f"Light mode{light_marker}"),
+    ]
+
+    try:
+        selection = await ChoiceInput(
+            message="Select a theme (↑↓ navigate, Enter select, Ctrl+C cancel):",
+            options=choices,
+            default=original_theme,
+        ).prompt_async()
+    except (EOFError, KeyboardInterrupt):
+        console.print("[grey50]Theme picker dismissed[/grey50]")
+        return
+
+    if not selection:
+        console.print("[grey50]Theme picker dismissed[/grey50]")
+        return
+
+    if selection == original_theme:
+        console.print(f"[yellow]Theme is already set to {selection} mode[/yellow]")
+        return
+
+    # Cast to Literal for type safety
+    new_theme: Literal["dark", "light"] = selection  # type: ignore[assignment]
+
+    # Apply theme and persist immediately
+    set_theme(new_theme)
+
+    # Invalidate prompt session to refresh UI with new theme colors
+    # Access protected member for internal use within the same package
+    prompt_session = getattr(app, "_prompt_session", None)
+    if prompt_session is not None:
+        prompt_session.invalidate()
+
+    # Persist to config file
+    try:
+        config_for_save = load_config()
+        config_for_save.ui.theme = new_theme  # type: ignore[assignment]
+        save_config(config_for_save)
+        console.print(f"[green]Theme set to {new_theme}[/green]")
+    except (Exception, OSError) as exc:
+        # Revert on save failure
+        set_theme(original_theme)
+        if prompt_session is not None:
+            prompt_session.invalidate()
+        console.print(f"[red]Failed to save config: {exc}[/red]")
 
 
 from . import (  # noqa: E402

--- a/src/kimi_cli/ui/shell/task_browser.py
+++ b/src/kimi_cli/ui/shell/task_browser.py
@@ -481,6 +481,33 @@ def _task_timing_label(view: TaskView, *, now: float | None = None) -> str | Non
 
 
 def _task_browser_style() -> Style:
+    from kimi_cli.ui.shell.theme import is_light_theme
+
+    if is_light_theme():
+        # Light theme styles
+        return Style.from_dict(
+            {
+                "header": "bg:#e5e7eb #1f2937",
+                "header.title": "bg:#e5e7eb #0066cc bold",
+                "header.meta": "bg:#e5e7eb #6b7280",
+                "status.running": "bg:#e5e7eb #15803d bold",
+                "status.success": "bg:#e5e7eb #15803d",
+                "status.warning": "bg:#e5e7eb #b45309",
+                "status.error": "bg:#e5e7eb #dc2626",
+                "status.info": "bg:#e5e7eb #2563eb",
+                "task-list": "bg:#f3f4f6 #374151",
+                "task-list.checked": "bg:#dbeafe #1e40af bold",
+                "frame.border": "#3b82f6",
+                "frame.label": "bg:#f9fafb #0066cc bold",
+                "footer": "bg:#f3f4f6 #4b5563",
+                "footer.key": "bg:#f3f4f6 #0066cc bold",
+                "footer.text": "bg:#f3f4f6 #4b5563",
+                "footer.warning": "bg:#fee2e2 #991b1b bold",
+                "footer.meta": "bg:#f3f4f6 #6b7280",
+            }
+        )
+
+    # Dark theme styles (default)
     return Style.from_dict(
         {
             "header": "bg:#1f2937 #e5e7eb",

--- a/src/kimi_cli/ui/shell/theme.py
+++ b/src/kimi_cli/ui/shell/theme.py
@@ -1,0 +1,271 @@
+"""Theme configuration and color definitions for the shell UI.
+
+This module provides theme support for Kimi Code CLI, including both dark and light
+themes. The theme is configurable via the config file.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+# Theme state (using a mutable container to avoid import snapshot issues)
+_theme_state: dict[str, Literal["dark", "light"]] = {"theme": "dark"}
+
+
+def detect_terminal_theme() -> Literal["dark", "light"]:
+    """Auto-detect terminal theme based on environment variables.
+
+    Checks COLORFGBG and TERM_BACKGROUND environment variables to determine
+    if the terminal has a light or dark background.
+
+    Returns:
+        "light" if terminal appears to have light background, "dark" otherwise.
+    """
+    colorfgbg = os.environ.get("COLORFGBG", "")
+    term_bg = os.environ.get("TERM_BACKGROUND")
+    # COLORFGBG format: "fg;bg" where bg is 0-15
+    # bg 0-8 = dark, 9-15 = light
+    is_light = False
+    if term_bg == "light":
+        is_light = True
+    elif colorfgbg:
+        parts = colorfgbg.split(";")
+        if len(parts) >= 2:
+            try:
+                bg = int(parts[1])
+                is_light = bg >= 9
+            except ValueError:
+                pass
+    return "light" if is_light else "dark"
+
+
+def get_current_theme() -> Literal["dark", "light"]:
+    """Get the current theme name."""
+    return _theme_state["theme"]
+
+
+def is_light_theme() -> bool:
+    """Check if the current theme is light."""
+    return _theme_state["theme"] == "light"
+
+
+@dataclass(frozen=True)
+class ThemeColors:
+    """Color definitions for a theme.
+
+    All colors are defined as Rich color names or hex codes.
+    """
+
+    # Toolbar colors
+    toolbar_border: str
+    toolbar_text: str
+    toolbar_text_secondary: str
+    toolbar_text_dim: str
+
+    # Prompt colors
+    prompt_separator: str
+    prompt_placeholder: str
+    prompt_plan_mode: str
+
+    # Slash completion menu colors
+    slash_menu_separator: str
+    slash_menu_marker: str
+    slash_menu_marker_current: str
+    slash_menu_command: str
+    slash_menu_command_current: str
+    slash_menu_meta: str
+    slash_menu_meta_current: str
+
+    # Status colors
+    status_yolo: str
+    status_plan: str
+    status_cwd: str
+    status_git: str
+    status_bg_task: str
+    status_tips: str
+
+    # Message colors
+    message_info: str
+    message_warning: str
+    message_error: str
+    message_success: str
+
+    # Approval panel colors
+    approval_border: str
+    approval_title: str
+    approval_warning: str
+    approval_selected: str
+    approval_unselected: str
+    approval_hint: str
+    approval_metadata: str
+
+    # Usage panel colors
+    usage_border: str
+    usage_label: str
+    usage_text: str
+    usage_dim: str
+
+    # General UI colors
+    dim: str
+    highlight: str
+    accent: str
+
+    # Diff colors
+    diff_add_bg: str
+    diff_del_bg: str
+    diff_add_hl: str
+    diff_del_hl: str
+
+
+# Dark theme colors (default)
+DARK_THEME = ThemeColors(
+    # Toolbar
+    toolbar_border="#4d4d4d",
+    toolbar_text="#888888",
+    toolbar_text_secondary="#666666",
+    toolbar_text_dim="#555555",
+    # Prompt
+    prompt_separator="#4a5568",
+    prompt_placeholder="#7c8594",
+    prompt_plan_mode="#00aaff",
+    # Slash completion menu
+    slash_menu_separator="#4a5568",
+    slash_menu_marker="#4a5568",
+    slash_menu_marker_current="#4f9fff",
+    slash_menu_command="#a6adba",
+    slash_menu_command_current="#6fb7ff",
+    slash_menu_meta="#7c8594",
+    slash_menu_meta_current="#56a4ff",
+    # Status
+    status_yolo="#ffff00",
+    status_plan="#00aaff",
+    status_cwd="#666666",
+    status_git="#666666",
+    status_bg_task="#888888",
+    status_tips="#555555",
+    # Messages
+    message_info="cyan",
+    message_warning="yellow",
+    message_error="red",
+    message_success="green",
+    # Approval panel
+    approval_border="bold yellow",
+    approval_title="bold yellow",
+    approval_warning="yellow",
+    approval_selected="cyan",
+    approval_unselected="grey50",
+    approval_hint="dim",
+    approval_metadata="grey50",
+    # Usage panel
+    usage_border="wheat4",
+    usage_label="cyan",
+    usage_text="",
+    usage_dim="grey50",
+    # General
+    dim="dim",
+    highlight="cyan",
+    accent="dodger_blue1",
+    # Diff
+    diff_add_bg="#12261e",
+    diff_del_bg="#2d1214",
+    diff_add_hl="#1a4a2e",
+    diff_del_hl="#5c1a1d",
+)
+
+# Light theme colors
+LIGHT_THEME = ThemeColors(
+    # Toolbar
+    toolbar_border="#c0c0c0",
+    toolbar_text="#555555",
+    toolbar_text_secondary="#666666",
+    toolbar_text_dim="#888888",
+    # Prompt
+    prompt_separator="#a0a0a0",
+    prompt_placeholder="#707070",
+    prompt_plan_mode="#0066cc",
+    # Slash completion menu
+    slash_menu_separator="#a0a0a0",
+    slash_menu_marker="#808080",
+    slash_menu_marker_current="#0066cc",
+    slash_menu_command="#333333",
+    slash_menu_command_current="#0066cc",
+    slash_menu_meta="#666666",
+    slash_menu_meta_current="#0066cc",
+    # Status
+    status_yolo="#cc8800",
+    status_plan="#0066cc",
+    status_cwd="#555555",
+    status_git="#555555",
+    status_bg_task="#666666",
+    status_tips="#888888",
+    # Messages
+    message_info="blue",
+    message_warning="dark_orange",
+    message_error="dark_red",
+    message_success="dark_green",
+    # Approval panel
+    approval_border="bold dark_orange",
+    approval_title="bold dark_orange",
+    approval_warning="dark_orange",
+    approval_selected="blue",
+    approval_unselected="grey50",
+    approval_hint="dim",
+    approval_metadata="grey50",
+    # Usage panel
+    usage_border="grey50",
+    usage_label="blue",
+    usage_text="",
+    usage_dim="grey50",
+    # General
+    dim="dim",
+    highlight="blue",
+    accent="blue",
+    # Diff
+    diff_add_bg="#d4edda",
+    diff_del_bg="#f8d7da",
+    diff_add_hl="#90EE90",
+    diff_del_hl="#FFB6C1",
+)
+
+
+def get_theme_colors() -> ThemeColors:
+    """Get the current theme colors.
+
+    Returns the color scheme based on the current theme setting.
+    """
+    if _theme_state["theme"] == "light":
+        return LIGHT_THEME
+    return DARK_THEME
+
+
+def set_theme(new_theme: Literal["dark", "light"]) -> None:
+    """Set the current theme.
+
+    Args:
+        new_theme: The theme to use, either "dark" or "light".
+    """
+    _theme_state["theme"] = new_theme
+
+
+def get_prompt_toolkit_style() -> dict[str, str]:
+    """Get the prompt_toolkit style dictionary for the current theme.
+
+    Returns:
+        A dictionary mapping style classes to color definitions.
+    """
+    colors = get_theme_colors()
+    return {
+        "bottom-toolbar": "noreverse",
+        "running-prompt-placeholder": f"fg:{colors.prompt_placeholder} italic",
+        "running-prompt-separator": f"fg:{colors.prompt_separator}",
+        "slash-completion-menu": "",
+        "slash-completion-menu.separator": f"fg:{colors.slash_menu_separator}",
+        "slash-completion-menu.marker": f"fg:{colors.slash_menu_marker}",
+        "slash-completion-menu.marker.current": f"fg:{colors.slash_menu_marker_current}",
+        "slash-completion-menu.command": f"fg:{colors.slash_menu_command}",
+        "slash-completion-menu.meta": f"fg:{colors.slash_menu_meta}",
+        "slash-completion-menu.command.current": f"fg:{colors.slash_menu_command_current} bold",
+        "slash-completion-menu.meta.current": f"fg:{colors.slash_menu_meta_current}",
+    }

--- a/src/kimi_cli/ui/shell/usage.py
+++ b/src/kimi_cli/ui/shell/usage.py
@@ -19,6 +19,7 @@ from kimi_cli.config import LLMModel
 from kimi_cli.soul.kimisoul import KimiSoul
 from kimi_cli.ui.shell.console import console
 from kimi_cli.ui.shell.slash import registry
+from kimi_cli.ui.shell.theme import get_theme_colors
 from kimi_cli.utils.aiohttp import new_client_session
 from kimi_cli.utils.datetime import format_duration
 
@@ -226,10 +227,13 @@ def _to_int(value: Any) -> int | None:
 
 
 def _build_usage_panel(summary: UsageRow | None, limits: list[UsageRow]) -> Panel:
+    colors = get_theme_colors()
     rows = ([summary] if summary else []) + limits
     if not rows:
         return Panel(
-            Text("No usage data", style="grey50"), title="API Usage", border_style="wheat4"
+            Text("No usage data", style=colors.usage_dim),
+            title="API Usage",
+            border_style=colors.usage_border,
         )
 
     # Calculate label width for alignment
@@ -240,27 +244,29 @@ def _build_usage_panel(summary: UsageRow | None, limits: list[UsageRow]) -> Pane
     for row in rows:
         lines.append(_format_row(row, label_width))
 
+    colors = get_theme_colors()
     return Panel(
         Group(*lines),
         title="API Usage",
-        border_style="wheat4",
+        border_style=colors.usage_border,
         padding=(0, 2),
         expand=False,
     )
 
 
 def _format_row(row: UsageRow, label_width: int) -> RenderableType:
+    colors = get_theme_colors()
     ratio = (row.limit - row.used) / row.limit if row.limit > 0 else 0
     color = _ratio_color(ratio)
 
-    label = Text(f"{row.label:<{label_width}}  ", style="cyan")
+    label = Text(f"{row.label:<{label_width}}  ", style=colors.usage_label)
     bar = ProgressBar(total=row.limit or 1, completed=row.used, width=20, complete_style=color)
 
     detail = Text()
     percent = ratio * 100
     detail.append(f"  {percent:.0f}% left", style="bold")
     if row.reset_hint:
-        detail.append(f"  ({row.reset_hint})", style="grey50")
+        detail.append(f"  ({row.reset_hint})", style=colors.usage_dim)
 
     t = Table.grid(padding=0)
     t.add_column(width=label_width + 2)

--- a/src/kimi_cli/utils/rich/diff_render.py
+++ b/src/kimi_cli/utils/rich/diff_render.py
@@ -25,10 +25,37 @@ from kimi_cli.utils.rich.syntax import KimiSyntax
 # Style constants
 # ---------------------------------------------------------------------------
 
-_ADD_BG = Style(bgcolor="#12261e")
-_DEL_BG = Style(bgcolor="#2d1214")
-_ADD_HL = Style(bgcolor="#1a4a2e")  # deeper green for inline word-level changes
-_DEL_HL = Style(bgcolor="#5c1a1d")  # deeper red for inline word-level changes
+# Note: These are evaluated lazily to avoid circular imports
+# and to support runtime theme switching.
+# Colors are retrieved from theme.py for consistency.
+
+
+def _get_theme_colors():
+    """Get theme colors, importing lazily to avoid circular imports."""
+    from kimi_cli.ui.shell.theme import get_theme_colors
+
+    return get_theme_colors()
+
+
+def _get_add_bg() -> Style:
+    """Get background style for added lines."""
+    return Style(bgcolor=_get_theme_colors().diff_add_bg)
+
+
+def _get_del_bg() -> Style:
+    """Get background style for deleted lines."""
+    return Style(bgcolor=_get_theme_colors().diff_del_bg)
+
+
+def _get_add_hl() -> Style:
+    """Get highlight style for inline additions."""
+    return Style(bgcolor=_get_theme_colors().diff_add_hl)
+
+
+def _get_del_hl() -> Style:
+    """Get highlight style for inline deletions."""
+    return Style(bgcolor=_get_theme_colors().diff_del_hl)
+
 
 _INLINE_DIFF_MIN_RATIO = 0.5  # skip inline diff when lines are too dissimilar
 
@@ -172,9 +199,9 @@ def _apply_inline_diff(
         new_text = _highlight(highlighter, new_code)
         for op, i1, i2, j1, j2 in sm.get_opcodes():
             if op in ("delete", "replace"):
-                old_text.stylize(_DEL_HL, i1, i2)
+                old_text.stylize(_get_del_hl(), i1, i2)
             if op in ("insert", "replace"):
-                new_text.stylize(_ADD_HL, j1, j2)
+                new_text.stylize(_get_add_hl(), j1, j2)
         del_lines[j].content = old_text
         del_lines[j].is_inline_paired = True
         add_lines[j].content = new_text
@@ -183,6 +210,10 @@ def _apply_inline_diff(
 
 def _highlight_hunk(highlighter: KimiSyntax, hunk: list[DiffLine]) -> None:
     """Highlight all lines in a hunk, applying inline diff for paired -/+ blocks."""
+    # Clear cached content to ensure theme colors are re-applied
+    for dl in hunk:
+        dl.content = None
+
     # First pass: find consecutive -/+ blocks and apply inline diff
     i = 0
     while i < len(hunk):
@@ -303,24 +334,27 @@ def render_diff_panel(
         for dl in hunk:
             assert dl.content is not None
             if dl.kind == DiffLineKind.ADD:
+                bg_style = _get_add_bg()
                 table.add_row(
                     Text(str(dl.new_num)),
                     Text(" + ", style="green"),
                     dl.content,
-                    style=_ADD_BG,
+                    style=bg_style,
                 )
             elif dl.kind == DiffLineKind.DELETE:
+                bg_style = _get_del_bg()
                 table.add_row(
                     Text(str(dl.old_num)),
                     Text(" - ", style="red"),
                     dl.content,
-                    style=_DEL_BG,
+                    style=bg_style,
                 )
             else:
                 table.add_row(
                     Text(str(dl.new_num), style="dim"),
                     Text("   "),
                     dl.content,
+                    style=Style(),
                 )
 
     return Panel(
@@ -329,6 +363,7 @@ def render_diff_panel(
         title_align="left",
         border_style="dim",
         padding=(0, 1),
+        style=Style(),
     )
 
 
@@ -374,16 +409,33 @@ def render_diff_preview(
 
     result: list[RenderableType] = [_build_diff_header(path, added, removed)]
 
-    for dl in shown:
-        assert dl.content is not None
-        line = Text()
-        ln = dl.old_num if dl.kind == DiffLineKind.DELETE else dl.new_num
-        line.append(str(ln).rjust(num_width), style="dim")
-        marker_style = "green" if dl.kind == DiffLineKind.ADD else "red"
-        marker_char = "+" if dl.kind == DiffLineKind.ADD else "-"
-        line.append(f" {marker_char} ", style=marker_style)
-        line.append_text(dl.content)
-        result.append(line)
+    if shown:
+        # Use Table to ensure background color fills entire row (like render_diff_panel)
+        table = Table(
+            show_header=False,
+            box=None,
+            padding=(0, 0),
+            show_edge=False,
+            expand=True,
+        )
+        table.add_column(justify="right", width=num_width, no_wrap=True)
+        table.add_column(width=3, no_wrap=True)
+        table.add_column(ratio=1)
+
+        for dl in shown:
+            assert dl.content is not None
+            bg_style = _get_add_bg() if dl.kind == DiffLineKind.ADD else _get_del_bg()
+            line_num = dl.new_num if dl.kind == DiffLineKind.ADD else dl.old_num
+            sign = " + " if dl.kind == DiffLineKind.ADD else " - "
+            sign_style = "green" if dl.kind == DiffLineKind.ADD else "red"
+            table.add_row(
+                Text(str(line_num)),
+                Text(sign, style=sign_style),
+                dl.content,
+                style=bg_style,
+            )
+
+        result.append(table)
 
     if remaining > 0:
         result.append(Text(f"... {remaining} more lines (ctrl-e to expand)", style="dim italic"))

--- a/src/kimi_cli/utils/rich/syntax.py
+++ b/src/kimi_cli/utils/rich/syntax.py
@@ -25,7 +25,9 @@ from rich.style import Style
 from rich.syntax import ANSISyntaxTheme, Syntax, SyntaxTheme
 
 KIMI_ANSI_THEME_NAME = "kimi-ansi"
-KIMI_ANSI_THEME = ANSISyntaxTheme(
+
+# Dark theme (default) - uses terminal's default foreground (white/light gray on dark bg)
+KIMI_ANSI_THEME_DARK = ANSISyntaxTheme(
     {
         PygmentsToken: Style(color="default"),
         PygmentsText: Style(color="default"),
@@ -77,17 +79,77 @@ KIMI_ANSI_THEME = ANSISyntaxTheme(
     }
 )
 
+# Light theme - uses dark colors for visibility on light backgrounds
+KIMI_ANSI_THEME_LIGHT = ANSISyntaxTheme(
+    {
+        PygmentsToken: Style(color="black"),
+        PygmentsText: Style(color="black"),
+        Comment: Style(color="grey50", italic=True),
+        Keyword: Style(color="dark_magenta"),
+        Keyword.Constant: Style(color="dark_cyan"),
+        Keyword.Declaration: Style(color="dark_magenta"),
+        Keyword.Namespace: Style(color="dark_magenta"),
+        Keyword.Pseudo: Style(color="dark_magenta"),
+        Keyword.Reserved: Style(color="dark_magenta"),
+        Keyword.Type: Style(color="dark_magenta"),
+        Name: Style(color="black"),
+        Name.Attribute: Style(color="dark_cyan"),
+        Name.Builtin: Style(color="dark_orange3"),
+        Name.Builtin.Pseudo: Style(color="dark_cyan"),
+        Name.Builtin.Type: Style(color="dark_orange3", bold=True),
+        Name.Class: Style(color="dark_orange3", bold=True),
+        Name.Constant: Style(color="dark_cyan"),
+        Name.Decorator: Style(color="dark_cyan", bold=True),
+        Name.Entity: Style(color="dark_orange3"),
+        Name.Exception: Style(color="dark_orange3", bold=True),
+        Name.Function: Style(color="dark_cyan", bold=True),
+        Name.Label: Style(color="dark_cyan"),
+        Name.Namespace: Style(color="dark_magenta"),
+        Name.Other: Style(color="dark_cyan", bold=True),
+        Name.Property: Style(color="dark_cyan"),
+        Name.Tag: Style(color="dark_green"),
+        Name.Variable: Style(color="dark_orange3"),
+        PygmentsLiteral: Style(color="dark_blue"),
+        PygmentsLiteral.Date: Style(color="dark_blue"),
+        String: Style(color="dark_blue"),
+        String.Doc: Style(color="dark_blue", italic=True),
+        String.Interpol: Style(color="dark_blue"),
+        String.Affix: Style(color="dark_cyan"),
+        Number: Style(color="dark_cyan"),
+        Operator: Style(color="black"),
+        Operator.Word: Style(color="dark_magenta"),
+        Punctuation: Style(color="black"),
+        Generic.Deleted: Style(color="dark_red"),
+        Generic.Emph: Style(italic=True),
+        Generic.Error: Style(color="red", bold=True),
+        Generic.Heading: Style(color="dark_cyan", bold=True),
+        Generic.Inserted: Style(color="dark_green"),
+        Generic.Output: Style(color="grey50"),
+        Generic.Prompt: Style(color="dark_cyan"),
+        Generic.Strong: Style(bold=True),
+        Generic.Subheading: Style(color="dark_cyan"),
+        Generic.Traceback: Style(color="red", bold=True),
+    }
+)
+
+# Backward compatibility alias
+KIMI_ANSI_THEME = KIMI_ANSI_THEME_DARK
+
 
 def resolve_code_theme(theme: str | SyntaxTheme) -> str | SyntaxTheme:
     if isinstance(theme, str) and theme.lower() == KIMI_ANSI_THEME_NAME:
-        return KIMI_ANSI_THEME
+        from kimi_cli.ui.shell.theme import is_light_theme
+
+        return KIMI_ANSI_THEME_LIGHT if is_light_theme() else KIMI_ANSI_THEME_DARK
     return theme
 
 
 class KimiSyntax(Syntax):
     def __init__(self, code: str, lexer: str, **kwargs: Any) -> None:
         if "theme" not in kwargs or kwargs["theme"] is None:
-            kwargs["theme"] = KIMI_ANSI_THEME
+            from kimi_cli.ui.shell.theme import is_light_theme
+
+            kwargs["theme"] = KIMI_ANSI_THEME_LIGHT if is_light_theme() else KIMI_ANSI_THEME_DARK
         super().__init__(code, lexer, **kwargs)
 
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -50,6 +50,7 @@ def test_default_config_dump():
             },
             "services": {"moonshot_search": None, "moonshot_fetch": None},
             "mcp": {"client": {"tool_call_timeout_ms": 60000}},
+            "ui": {"theme": "dark"},
         }
     )
 


### PR DESCRIPTION
## Summary
Add light theme support to Kimi CLI, allowing users to choose between dark and light color schemes based on their terminal background.

## Changes

### Theme System (`theme.py`)
- Add `ThemeColors` dataclass defining color schemes for both dark and light themes
- Implement `detect_terminal_theme()` for automatic theme detection via `COLORFGBG` and `TERM_BACKGROUND` environment variables
- Add `set_theme()` and `get_theme_colors()` for runtime theme management
- Define `DARK_THEME` and `LIGHT_THEME` color palettes including diff colors

### Configuration (`config.py`)
- Add `UIConfig` class with `theme` field supporting `"dark"`, `"light"`, or `"auto"`
- Theme configuration persists to `~/.kimi/config.toml`

### UI Components Updates
- **`approval_panel.py`** - Use theme-aware colors for approval UI
- **`mcp_status.py`** - Theme-aware MCP status display
- **`prompt.py`** - Theme-aware prompt styling
- **`question_panel.py`** - Theme-aware question panel colors
- **`task_browser.py`** - Theme-aware task browser with `is_light_theme()` helper
- **`usage.py`** - Theme-aware usage display

### Interactive Theme Switching (`slash.py`)
- Add `/theme` slash command for interactive theme selection
- Shows current theme with checkmark indicator
- Persists selection to config file immediately
- Reverts on save failure

### Diff Rendering (`diff_render.py`)
- Convert static color constants to lazy theme-aware functions
- `_get_add_bg()`, `_get_del_bg()`, `_get_add_hl()`, `_get_del_hl()`
- Update `render_diff_panel()` and `render_diff_preview()` to use theme colors
- Clear cached content on theme change to ensure colors are re-applied

### Syntax Highlighting (`syntax.py`)
- Add `KIMI_ANSI_THEME_LIGHT` with dark colors for visibility on light backgrounds
- `KimiSyntax` automatically selects appropriate theme based on current setting
- `resolve_code_theme()` returns light/dark theme based on `is_light_theme()`

### Shell Integration (`__init__.py`)
- Initialize theme from config on shell startup
- Use `detect_terminal_theme()` when config is set to `"auto"`

## Usage

1. **Auto-detection** (default): Set `ui.theme = "auto"` in config
2. **Manual**: Set `ui.theme = "dark"` or `ui.theme = "light"` in `~/.kimi/config.toml`
3. **Runtime**: Use `/theme` command to switch interactively

Fixes #1660
