### PR TITLE
docs: fix subject-verb agreement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for being interested in contributing to Kimi Code CLI!
 
 We welcome all kinds of contributions, including bug fixes, features, document improvements, typo fixes, etc. To maintain a high-quality codebase and user experience, we provide the following guidelines for contributions:
 
-1. We only merge pull requests that aligns with our roadmap. For any pull request that introduces changes larger than 100 lines of code, we highly recommend discussing with us by [raising an issue](https://github.com/MoonshotAI/kimi-cli/issues) or in an existing issue before you start working on it. Otherwise your pull request may be closed or ignored without review.
+1. We only merge pull requests that align with our roadmap. For any pull request that introduces changes larger than 100 lines of code, we highly recommend discussing with us by [raising an issue](https://github.com/MoonshotAI/kimi-cli/issues) or in an existing issue before you start working on it. Otherwise your pull request may be closed or ignored without review.
 2. We insist on high code quality. Please ensure your code is as good as, if not better than, the code written by frontier coding agents. Changes may be requested before your pull request can be merged.
 
 ## Prek hooks


### PR DESCRIPTION
<!--
  Thank you for your contribution to Kimi Code CLI!
  Please make sure you already discussed the feature or bugfix you are proposing in an
  issue with the maintainers.
  Please understand that if you have not gotten confirmation from the maintainers, your
  pull request may be closed or ignored without further review due to limited bandwidth.

  See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
  -->

  ## Related Issue

  N/A (minor grammar fix)

  ## Description

  Fix subject-verb agreement: "pull requests that aligns" → "pull requests that align"
  (plural subject requires plural verb).

  ## Checklist

  - [x] I have read the  [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
  - [ ] I have linked the related issue, if any.
  - [ ] I have added tests that prove my fix is effective or that my feature works.
  - [ ] I have run `make gen-changelog` to update the changelog.
  - [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
