### PR TITLE
fix(shell): prevent Ctrl+W from overwriting system clipboard [WIP]

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -17,11 +17,11 @@ from hashlib import md5
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast, override
 
+import pyperclip
 from kaos.path import KaosPath
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application.current import get_app_or_none
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.clipboard.pyperclip import PyperclipClipboard
 from prompt_toolkit.completion import (
     CompleteEvent,
     Completer,
@@ -1480,15 +1480,16 @@ class CustomPromptSession:
             def _(event: KeyPressEvent) -> None:
                 if self._try_paste_media(event):
                     return
-                clipboard_data = event.app.clipboard.get_data()
-                if clipboard_data is None:  # type: ignore[reportUnnecessaryComparison]
+                try:
+                    text = pyperclip.paste()
+                except Exception:
                     return
-                self._insert_pasted_text(event.current_buffer, clipboard_data.text)
+                if not text:
+                    return
+                self._insert_pasted_text(event.current_buffer, text)
                 event.app.invalidate()
 
-            clipboard = PyperclipClipboard()
-        else:
-            clipboard = None
+        clipboard = None
 
         self._session = PromptSession[str](
             message=self._render_message,


### PR DESCRIPTION
> [!WARNING]
> **WIP** — 核心思路已验证，还需要补充测试和进一步验证边界情况后再标记为 merge ready。

## Summary

Closes #1567

On macOS, pressing `Ctrl+W` (unix-word-rubout) in the kimi-cli prompt overwrites the system clipboard with the deleted word. This happens because `PyperclipClipboard` is passed to `PromptSession`, causing all Emacs-style kill commands (`Ctrl+W`/`K`/`U`) to sync deleted text to the system clipboard via `pyperclip.copy()`.

### Root cause

`PyperclipClipboard` was introduced in commit `0703579` to fix `Ctrl+V` text paste — the default `InMemoryClipboard` cannot read the system clipboard, so `event.app.clipboard.get_data()` returned empty content. However, `PyperclipClipboard` is bidirectional: it also **writes** to the system clipboard on every kill operation.

### Fix

- Replace `PyperclipClipboard` with the default `InMemoryClipboard` (pass `clipboard=None` to `PromptSession`)
- Change the `Ctrl+V` text paste handler to read the system clipboard directly via `pyperclip.paste()` instead of `event.app.clipboard.get_data()`

This approach is consistent with how zsh/bash handle kill operations (internal kill ring only, never touching the system clipboard). For reference, among similar projects using prompt_toolkit (aider, IPython, mycli), none use `PyperclipClipboard`. xonsh uses it but explicitly implements `disable_copy_on_deletion()` to prevent this exact issue.

### Behavior after fix

| Operation | Before | After |
|-----------|--------|-------|
| `Ctrl+W`/`K`/`U` | Writes to system clipboard ❌ | Internal kill ring only ✅ |
| `Ctrl+Y` (yank) | Reads system clipboard | Reads internal kill ring (same as zsh/bash) ✅ |
| `Ctrl+V` (paste) | Reads system clipboard via `PyperclipClipboard` | Reads system clipboard via `pyperclip.paste()` directly ✅ |
| Bracketed paste (terminal Cmd+V) | Unaffected | Unaffected ✅ |

## Test plan

- [ ] Verify `Ctrl+W` no longer overwrites system clipboard
- [ ] Verify `Ctrl+V` still pastes text from system clipboard
- [ ] Verify `Ctrl+V` still pastes images
- [ ] Verify `Ctrl+Y` yanks killed text from internal kill ring
- [ ] Verify bracketed paste (terminal `Cmd+V`) still works
- [ ] Add unit tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
