### PR TITLE
fix(acp): parse shell command for terminal/create to fix acpx compatibility

### DIFF
--- a/src/kimi_cli/acp/tools.py
+++ b/src/kimi_cli/acp/tools.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import suppress
+import shlex
 
 import acp
 from kaos import get_current_kaos
@@ -88,8 +89,13 @@ class Terminal(CallableTool2[ShellParams]):
         timed_out = False
 
         try:
+            # Parse command string into command and args for ACP
+            parts = shlex.split(params.command)
+            cmd = parts[0] if parts else ""
+            args = parts[1:] if len(parts) > 1 else []
             resp = await self._acp_conn.create_terminal(
-                command=params.command,
+                command=cmd,
+                args=args,
                 session_id=self._acp_session_id,
                 output_byte_limit=builder.max_chars,
             )


### PR DESCRIPTION
## Problem

When using acpx (Agent Client Protocol client) with kimi-cli, shell commands with arguments fail with "Internal error".

**Example:**
```bash
acpx --approve-all kimi prompt "Run ls -la"
```

**Error:**
```
[error] RUNTIME: Internal error
[tool] Shell: ls -la (failed)
  output:
    Error running tool: Internal error
```

The root cause is that kimi-cli sends the entire command as a single string to the ACP client's `terminal/create` method:
```json
{"command": "ls -la", "args": []}
```

acpx then tries to spawn a binary literally named "ls -la" (with spaces), which doesn't exist, resulting in `ENOENT`.

## ACP Specification

According to the [ACP spec](https://agentclientprotocol.com/protocol/terminals), `CreateTerminalRequest` has:
- `command`: The executable to run (string)
- `args`: Array of command arguments (string[])

The spec expects these to be separate fields, not a combined command string.

## Solution

Parse the shell command string using `shlex.split()` before sending to ACP:

**Before:**
```python
resp = await self._acp_conn.create_terminal(
    command=params.command,  # "ls -la"
    ...
)
```

**After:**
```python
parts = shlex.split(params.command)  # ["ls", "-la"]
cmd = parts[0]  # "ls"
args = parts[1:]  # ["-la"]
resp = await self._acp_conn.create_terminal(
    command=cmd,
    args=args,
    ...
)
```

This properly separates the executable from its arguments, allowing acpx to spawn the command correctly.

## Testing

Tested with:
```bash
acpx --approve-all kimi exec "Run ls -la"
```

**Result:** Command now executes successfully instead of failing with "Internal error".

## Related

Fixes compatibility with ACP clients like acpx that expect proper command/args separation per the ACP specification.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
