### PR TITLE
fix(acp): return invalid params for unsupported session mode

### DIFF
--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -322,7 +322,11 @@ class ACPServer:
         )
 
     async def set_session_mode(self, mode_id: str, session_id: str, **kwargs: Any) -> None:
-        assert mode_id == "default", "Only default mode is supported"
+        if session_id not in self.sessions:
+            raise acp.RequestError.invalid_params({"session_id": "Session not found"})
+
+        if mode_id != "default":
+            raise acp.RequestError.invalid_params({"mode_id": "Only default mode is supported"})
 
     async def set_session_model(self, model_id: str, session_id: str, **kwargs: Any) -> None:
         logger.info(

--- a/tests/acp/test_protocol_v1.py
+++ b/tests/acp/test_protocol_v1.py
@@ -162,3 +162,37 @@ async def test_cancel_session(
 
     # cancel should not raise
     await conn.cancel(session_id=session_resp.session_id)
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_rejects_non_default_mode(acp_client, tmp_path):
+    conn, _ = acp_client
+    await conn.initialize(protocol_version=1)
+
+    work_dir = tmp_path / "workdir"
+    work_dir.mkdir(exist_ok=True)
+    session = await conn.new_session(cwd=str(work_dir))
+
+    with pytest.raises(acp.RequestError) as exc_info:
+        await conn.set_session_mode(
+            mode_id="non-default",
+            session_id=session.session_id,
+        )
+
+    assert exc_info.value.code == -32602
+    assert exc_info.value.data == {"mode_id": "Only default mode is supported"}
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_rejects_unknown_session(acp_client):
+    conn, _ = acp_client
+    await conn.initialize(protocol_version=1)
+
+    with pytest.raises(acp.RequestError) as exc_info:
+        await conn.set_session_mode(
+            mode_id="default",
+            session_id="missing-session",
+        )
+
+    assert exc_info.value.code == -32602
+    assert exc_info.value.data == {"session_id": "Session not found"}


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

None.

## Description

This PR improves ACP session mode validation in `set_session_mode`.

Previously, unsupported `mode_id` values were rejected with an `assert`, which could surface as a generic internal error path. This change aligns `set_session_mode` with the existing ACP handler style used in nearby methods such as `set_session_model`, by returning structured `acp.RequestError.invalid_params(...)` errors instead.

Changes:

* return `invalid_params` when `mode_id != "default"`
* return `invalid_params` when `session_id` does not exist
* add ACP protocol tests for:

  * unsupported session mode
  * unknown session id

Validation:

* `uv run pytest tests/acp/test_protocol_v1.py -q`
* `make format`
* `make check`

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
* [ ] I have linked the related issue, if any.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [ ] I have run `make gen-changelog` to update the changelog.
* [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
