### PR TITLE
feat(web): support --agent-file option for kimi web command

### DIFF
--- a/src/kimi_cli/cli/web.py
+++ b/src/kimi_cli/cli/web.py
@@ -1,5 +1,6 @@
 """Web UI command for Kimi Code CLI."""
 
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -55,6 +56,10 @@ def web(
             help="Only allow access from local network (default) or allow public access.",
         ),
     ] = True,
+    agent_file: Annotated[
+        Path | None,
+        typer.Option("--agent-file", help="Path to agent spec YAML file."),
+    ] = None,
 ):
     """Run Kimi Code CLI web interface."""
     from kimi_cli.web.app import run_web_server
@@ -77,4 +82,5 @@ def web(
         dangerously_omit_auth=dangerously_omit_auth,
         restrict_sensitive_apis=restrict_sensitive_apis,
         lan_only=lan_only,
+        agent_file=agent_file,
     )

--- a/src/kimi_cli/web/app.py
+++ b/src/kimi_cli/web/app.py
@@ -110,6 +110,7 @@ def _load_env_flag(key: str) -> bool:
 
 
 ENV_LAN_ONLY = "KIMI_WEB_LAN_ONLY"
+ENV_AGENT_FILE = "KIMI_WEB_AGENT_FILE"
 
 
 def create_app(
@@ -235,6 +236,7 @@ def run_web_server(
     dangerously_omit_auth: bool = False,
     restrict_sensitive_apis: bool | None = None,
     lan_only: bool = True,
+    agent_file: Path | None = None,
 ) -> None:
     """Run the web server."""
     import sys
@@ -311,6 +313,11 @@ def run_web_server(
     os.environ[ENV_ENFORCE_ORIGIN] = "1" if (public_mode and not lan_only) else "0"
     os.environ[ENV_RESTRICT_SENSITIVE_APIS] = "1" if restrict_sensitive_apis else "0"
     os.environ[ENV_LAN_ONLY] = "1" if lan_only else "0"
+
+    if agent_file is not None:
+        os.environ[ENV_AGENT_FILE] = str(agent_file.resolve())
+    else:
+        os.environ.pop(ENV_AGENT_FILE, None)
 
     # Determine display URLs
     display_hosts: list[tuple[str, str]] = []

--- a/src/kimi_cli/web/runner/worker.py
+++ b/src/kimi_cli/web/runner/worker.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
@@ -45,16 +47,22 @@ async def run_worker(session_id: UUID) -> None:
                 path=default_mcp_file,
             )
 
+    # Resolve agent file from environment (set by `kimi web --agent-file`)
+    agent_file_str = os.environ.get("KIMI_WEB_AGENT_FILE")
+    agent_file = Path(agent_file_str) if agent_file_str else None
+
     # Create KimiCLI instance with MCP configuration
     try:
-        kimi_cli = await KimiCLI.create(session, mcp_configs=mcp_configs or None)
+        kimi_cli = await KimiCLI.create(
+            session, agent_file=agent_file, mcp_configs=mcp_configs or None
+        )
     except MCPConfigError as exc:
         logger.warning(
             "Invalid MCP config in {path}: {error}. Starting without MCP.",
             path=default_mcp_file,
             error=exc,
         )
-        kimi_cli = await KimiCLI.create(session, mcp_configs=None)
+        kimi_cli = await KimiCLI.create(session, agent_file=agent_file, mcp_configs=None)
 
     # Run in wire stdio mode
     await kimi_cli.run_wire_stdio()


### PR DESCRIPTION

## Related Issue

no

## Description

Add --agent-file parameter to `kimi web` so users can specify a custom agent spec YAML for new sessions. The agent file path is propagated via the KIMI_WEB_AGENT_FILE environment variable from CLI → web server → worker subprocess → KimiCLI.create(). Existing sessions are unaffected as they restore the system prompt from their persisted context.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works: tested locally

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
