### PR TITLE
fix: add path validation and fallback for Windows PowerShell detection

### DIFF
--- a/src/kimi_cli/utils/environment.py
+++ b/src/kimi_cli/utils/environment.py
@@ -33,10 +33,21 @@ class Environment:
 
         if os_kind == "Windows":
             shell_name = "Windows PowerShell"
-            system_root = os.environ.get("SystemRoot", r"C:\Windows")
-            shell_path = KaosPath(
-                os.path.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
-            )
+            system_root = os.environ.get("SYSTEMROOT", r"C:\Windows")
+            possible_paths = [
+                KaosPath(
+                    os.path.join(
+                        system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
+                    )
+                ),
+            ]
+            fallback_path = KaosPath("powershell.exe")
+            for path in possible_paths:
+                if await path.is_file():
+                    shell_path = path
+                    break
+            else:
+                shell_path = fallback_path
         else:
             possible_paths = [
                 KaosPath("/bin/bash"),

--- a/tests/utils/test_utils_environment.py
+++ b/tests/utils/test_utils_environment.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 import pytest
@@ -25,12 +26,21 @@ async def test_environment_detection(monkeypatch):
     assert str(env.shell_path) == "/usr/bin/bash"
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="Skipping test on non-Windows")
+@pytest.mark.skipif(platform.system() == "Windows", reason="Skipping test on Windows")
 async def test_environment_detection_windows(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     monkeypatch.setattr(platform, "machine", lambda: "AMD64")
     monkeypatch.setattr(platform, "version", lambda: "10.0.19044")
-    monkeypatch.setenv("SystemRoot", r"C:\Windows")
+    monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+
+    expected = os.path.join(
+        r"C:\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
+    )
+
+    async def _mock_is_file(self: KaosPath) -> bool:
+        return str(self) == expected
+
+    monkeypatch.setattr(KaosPath, "is_file", _mock_is_file)
 
     from kimi_cli.utils.environment import Environment
 
@@ -39,4 +49,26 @@ async def test_environment_detection_windows(monkeypatch):
     assert env.os_arch == "AMD64"
     assert env.os_version == "10.0.19044"
     assert env.shell_name == "Windows PowerShell"
-    assert str(env.shell_path) == r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+    assert str(env.shell_path) == expected
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Skipping test on Windows")
+async def test_environment_detection_windows_fallback(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(platform, "machine", lambda: "AMD64")
+    monkeypatch.setattr(platform, "version", lambda: "10.0.19044")
+    monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+
+    async def _mock_is_file(self: KaosPath) -> bool:
+        return False
+
+    monkeypatch.setattr(KaosPath, "is_file", _mock_is_file)
+
+    from kimi_cli.utils.environment import Environment
+
+    env = await Environment.detect()
+    assert env.os_kind == "Windows"
+    assert env.os_arch == "AMD64"
+    assert env.os_version == "10.0.19044"
+    assert env.shell_name == "Windows PowerShell"
+    assert str(env.shell_path) == "powershell.exe"


### PR DESCRIPTION
## Summary
- Add `is_file()` validation for Windows PowerShell path before use, mirroring the existing Unix shell detection pattern
- Fall back to bare `powershell.exe` (PATH-based resolution) when the full path doesn't exist
- Fix Windows test `skipif` condition so tests run on Linux/macOS CI (previously only ran on Windows)
- Add fallback test case covering the scenario where PowerShell isn't at the standard path
- Use uppercase `SYSTEMROOT` env var name to satisfy ruff SIM112 lint rule

Follow-up to #1703.

## Test plan
- [x] `test_environment_detection_windows` — validates full path resolution with mocked `is_file()`
- [x] `test_environment_detection_windows_fallback` — validates fallback to bare `powershell.exe` when path doesn't exist
- [x] All 3 environment tests pass on macOS CI
- [x] `make check-kimi-cli` passes (ruff + pyright)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
