### PR TITLE
feat(cli): improve export session UX

### DIFF
--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -185,16 +185,17 @@ kimi logout
 
 ### `kimi export`
 
-Export the data of a specified session as a ZIP file. The ZIP contains all files in the session directory (`context.jsonl`, `wire.jsonl`, `state.json`, etc.).
+Export session data as a ZIP file. The ZIP contains all files in the session directory (`context.jsonl`, `wire.jsonl`, `state.json`, etc.).
 
 ```sh
-kimi export <session_id> [-o <output_path>]
+kimi export [<session_id>] [-o <output_path>] [--yes]
 ```
 
 | Argument / Option | Description |
 |--------|-------------|
-| `<session_id>` | Session ID to export |
+| `<session_id>` | Session ID to export. If omitted, the CLI previews the previous session for the current working directory and asks for confirmation before exporting |
 | `--output, -o` | Output ZIP file path (defaults to `session-<id>.zip` in the current directory) |
+| `--yes, -y` | Skip the confirmation prompt when exporting the default previous session |
 
 ::: info Added
 Added in version 1.20.

--- a/docs/en/reference/kimi-vis.md
+++ b/docs/en/reference/kimi-vis.md
@@ -66,7 +66,7 @@ At the top of the session detail page, you can use `Open Dir` to open the curren
 You can export session data as a ZIP file for offline analysis or sharing.
 
 - **ZIP download**: Click the download button in the session explorer or session detail page to download the session directory as a ZIP file
-- **CLI export**: Use the `kimi export <session_id>` command to export a specified session as a ZIP file
+- **CLI export**: Use `kimi export [<session_id>]` to export a session as a ZIP file; when `<session_id>` is omitted, the CLI previews the previous session for the current working directory and asks for confirmation
 
 ### Session import
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- CLI: Improve `kimi export` session export UX — `kimi export` now previews the previous session for the current working directory and asks for confirmation, showing the session ID, title, and last user-message time; adds `--yes` to skip confirmation; also fixes explicit session-ID invocations where `--output` after the argument was incorrectly parsed as a subcommand
 - Grep: Add `include_ignored` parameter to search files excluded by `.gitignore` — when set to `true`, ripgrep's `--no-ignore` flag is enabled, allowing searches in files like `.env` or `node_modules` that are normally gitignored; defaults to `false` to preserve existing behavior
 - Core: Add sensitive file protection to Grep and Read tools — `.env`, SSH private keys (`id_rsa`, `id_ed25519`, `id_ecdsa`), and cloud credentials (`.aws/credentials`, `.gcp/credentials`) are now detected and blocked; Grep filters them from results with a warning, Read rejects them outright; `.env.example`/`.env.sample`/`.env.template` are exempted
 - Core: Fix parallel foreground subagent approval requests hanging the session — in interactive shell mode, `_set_active_approval_sink` no longer flushes pending approval requests to the live view sink (which cannot render approval modals); requests stay in the pending queue for the prompt modal path; also adds a 300-second timeout to `wait_for_response` so that any unresolved approval request eventually raises `ApprovalCancelledError` instead of hanging forever

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -185,16 +185,17 @@ kimi logout
 
 ### `kimi export`
 
-将指定会话的数据导出为 ZIP 文件。ZIP 中包含会话目录下的所有文件（`context.jsonl`、`wire.jsonl`、`state.json` 等）。
+将会话数据导出为 ZIP 文件。ZIP 中包含会话目录下的所有文件（`context.jsonl`、`wire.jsonl`、`state.json` 等）。
 
 ```sh
-kimi export <session_id> [-o <output_path>]
+kimi export [<session_id>] [-o <output_path>] [--yes]
 ```
 
 | 参数 / 选项 | 说明 |
 |------|------|
-| `<session_id>` | 要导出的会话 ID |
+| `<session_id>` | 要导出的会话 ID。省略时，CLI 会预览并确认当前工作目录的上一个会话，然后再导出 |
 | `--output, -o` | 输出 ZIP 文件路径（默认为当前目录下的 `session-<id>.zip`） |
+| `--yes, -y` | 跳过默认会话的确认提示，直接导出 |
 
 ::: info 新增
 新增于 1.20 版本。

--- a/docs/zh/reference/kimi-vis.md
+++ b/docs/zh/reference/kimi-vis.md
@@ -66,7 +66,7 @@ kimi vis -n
 可以将会话数据导出为 ZIP 文件，方便离线分析或分享。
 
 - **ZIP 下载**：在会话浏览器和会话详情页中点击下载按钮，即可将会话目录打包为 ZIP 文件下载
-- **CLI 导出**：使用 `kimi export <session_id>` 命令将指定会话导出为 ZIP 文件
+- **CLI 导出**：使用 `kimi export [<session_id>]` 命令导出会话为 ZIP 文件；省略 `<session_id>` 时会预览并确认当前工作目录的上一个会话
 
 ### 会话导入
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,7 @@
 
 ## 未发布
 
+- CLI：改进 `kimi export` 会话导出体验——`kimi export` 现在默认预览并确认当前工作目录的上一个会话，显示会话 ID、标题和最后一条用户消息时间；新增 `--yes` 跳过确认；同时修复显式会话 ID 时 `--output` 放在参数后面会被错误解析为子命令的问题
 - Grep：新增 `include_ignored` 参数，支持搜索被 `.gitignore` 排除的文件——设为 `true` 时启用 ripgrep 的 `--no-ignore` 标志，可搜索构建产物或 `node_modules` 等通常被忽略的文件；敏感文件（如 `.env`）仍由敏感文件保护层过滤；默认 `false`，不影响现有行为
 - Core：为 Grep 和 Read 工具添加敏感文件保护——`.env`、SSH 私钥（`id_rsa`、`id_ed25519`、`id_ecdsa`）和云凭据（`.aws/credentials`、`.gcp/credentials`）会被检测并拦截；Grep 从结果中过滤并显示警告，Read 直接拒绝读取；`.env.example`/`.env.sample`/`.env.template` 不受影响
 - Core：修复并行 foreground 子 Agent 审批请求导致会话挂死的问题——在交互式 Shell 模式下，`_set_active_approval_sink` 不再将待处理的审批请求 flush 到 live view sink（该 sink 无法渲染审批弹窗）；请求保留在 pending 队列中由 prompt modal 路径处理；同时为 `wait_for_response` 增加 300 秒超时，确保未被 resolve 的审批请求最终抛出 `ApprovalCancelledError` 而非永久挂起

--- a/src/kimi_cli/cli/export.py
+++ b/src/kimi_cli/cli/export.py
@@ -2,18 +2,52 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import zipfile
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
+from kaos.path import KaosPath
+
+from kimi_cli.wire.file import WireFileMetadata, parse_wire_file_line
+from kimi_cli.wire.types import TurnBegin
+
+if TYPE_CHECKING:
+    from kimi_cli.session import Session
 
 cli = typer.Typer(help="Export session data.")
 
 
-def _find_session_by_id(session_id: str) -> Path | None:
-    """Find a session directory by session ID across all work directories."""
+async def _find_session_in_work_dir(work_dir: KaosPath, session_id: str) -> Session | None:
+    from kimi_cli.session import Session
+
+    return await Session.find(work_dir, session_id)
+
+
+async def _load_previous_session(work_dir: KaosPath) -> Session | None:
+    from kimi_cli.session import Session
+
+    return await Session.continue_(work_dir)
+
+
+def _resolve_work_dir(ctx: typer.Context) -> KaosPath:
+    root_ctx = ctx.find_root()
+    local_work_dir = root_ctx.params.get("local_work_dir")
+    if local_work_dir is None:
+        return KaosPath.cwd()
+    return KaosPath.unsafe_from_local_path(local_work_dir)
+
+
+def _find_session_by_id(session_id: str, *, work_dir: KaosPath | None = None) -> Path | None:
+    """Find a session directory by ID, preferring the current work directory."""
+    if work_dir is not None:
+        session = asyncio.run(_find_session_in_work_dir(work_dir, session_id))
+        if session is not None:
+            return session.dir
+
     from kimi_cli.share import get_share_dir
 
     sessions_root = get_share_dir() / "sessions"
@@ -30,12 +64,58 @@ def _find_session_by_id(session_id: str) -> Path | None:
     return None
 
 
-@cli.callback(invoke_without_command=True)
+def _last_user_message_timestamp(session_dir: Path) -> float | None:
+    wire_file = session_dir / "wire.jsonl"
+    if not wire_file.exists():
+        return None
+
+    last_turn_begin: float | None = None
+    try:
+        with wire_file.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = parse_wire_file_line(line)
+                except Exception:
+                    continue
+                if isinstance(parsed, WireFileMetadata):
+                    continue
+                if isinstance(parsed.to_wire_message(), TurnBegin):
+                    last_turn_begin = parsed.timestamp
+    except OSError:
+        return None
+
+    return last_turn_begin
+
+
+def _format_message_timestamp(timestamp: float | None) -> str:
+    if timestamp is None:
+        return "(no user message)"
+    return datetime.fromtimestamp(timestamp, UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _confirm_previous_session(session: Session) -> bool:
+    last_user_message = _format_message_timestamp(_last_user_message_timestamp(session.dir))
+
+    typer.echo("About to export the previous session for this working directory:")
+    typer.echo()
+    typer.echo(f"Work dir: {session.work_dir}")
+    typer.echo(f"Session ID: {session.id}")
+    typer.echo(f"Title: {session.title}")
+    typer.echo(f"Last user message: {last_user_message}")
+    typer.echo()
+    return typer.confirm("Export this session?", default=False)
+
+
+@cli.command(name="export")
 def export(
+    ctx: typer.Context,
     session_id: Annotated[
-        str,
-        typer.Argument(help="Session ID to export."),
-    ],
+        str | None,
+        typer.Argument(help="Session ID to export. Defaults to the previous session."),
+    ] = None,
     output: Annotated[
         Path | None,
         typer.Option(
@@ -44,12 +124,33 @@ def export(
             help="Output ZIP file path. Default: session-{id}.zip in current directory.",
         ),
     ] = None,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip confirmation when exporting the previous session by default.",
+        ),
+    ] = False,
 ) -> None:
     """Export a session as a ZIP archive."""
-    session_dir = _find_session_by_id(session_id)
-    if session_dir is None:
-        typer.echo(f"Error: session '{session_id}' not found.", err=True)
-        raise typer.Exit(code=1)
+    work_dir = _resolve_work_dir(ctx)
+
+    if session_id is None:
+        session = asyncio.run(_load_previous_session(work_dir))
+        if session is None:
+            typer.echo("Error: no previous session found for the working directory.", err=True)
+            raise typer.Exit(code=1)
+        if not yes and not _confirm_previous_session(session):
+            typer.echo("Export cancelled.")
+            return
+        session_id = session.id
+        session_dir = session.dir
+    else:
+        session_dir = _find_session_by_id(session_id, work_dir=work_dir)
+        if session_dir is None:
+            typer.echo(f"Error: session '{session_id}' not found.", err=True)
+            raise typer.Exit(code=1)
 
     # Collect files
     files = sorted(f for f in session_dir.iterdir() if f.is_file())

--- a/tests/core/test_export_cli.py
+++ b/tests/core/test_export_cli.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+import zipfile
+from pathlib import Path
+
+import pytest
+from kaos.path import KaosPath
+from kosong.message import Message
+from typer.testing import CliRunner
+
+from kimi_cli.cli import cli
+from kimi_cli.cli.export import _format_message_timestamp
+from kimi_cli.metadata import load_metadata, save_metadata
+from kimi_cli.session import Session
+from kimi_cli.wire.types import TextPart, TurnBegin
+
+
+@pytest.fixture
+def isolated_share_dir(monkeypatch, tmp_path: Path) -> Path:
+    share_dir = tmp_path / "share"
+    share_dir.mkdir()
+
+    def _get_share_dir() -> Path:
+        share_dir.mkdir(parents=True, exist_ok=True)
+        return share_dir
+
+    monkeypatch.setattr("kimi_cli.share.get_share_dir", _get_share_dir)
+    monkeypatch.setattr("kimi_cli.metadata.get_share_dir", _get_share_dir)
+    return share_dir
+
+
+@pytest.fixture
+def work_dir(tmp_path: Path) -> KaosPath:
+    path = tmp_path / "work"
+    path.mkdir()
+    return KaosPath.unsafe_from_local_path(path)
+
+
+def _write_context_message(context_file: Path, text: str) -> None:
+    message = Message(role="user", content=[TextPart(text=text)])
+    context_file.write_text(message.model_dump_json(exclude_none=True) + "\n", encoding="utf-8")
+
+
+async def _create_previous_session(work_dir: KaosPath) -> tuple[Session, float]:
+    session = await Session.create(work_dir)
+    _write_context_message(session.context_file, "export me")
+
+    first_ts = 1_700_000_000.0
+    last_ts = 1_700_000_100.0
+    await session.wire_file.append_message(
+        TurnBegin(user_input=[TextPart(text="previous export target")]),
+        timestamp=first_ts,
+    )
+    await session.wire_file.append_message(
+        TurnBegin(user_input=[TextPart(text="latest user message")]),
+        timestamp=last_ts,
+    )
+    await session.refresh()
+
+    metadata = load_metadata()
+    work_dir_meta = metadata.get_work_dir_meta(work_dir)
+    assert work_dir_meta is not None
+    work_dir_meta.last_session_id = session.id
+    save_metadata(metadata)
+
+    return session, last_ts
+
+
+def test_export_previous_session_requires_confirmation(
+    isolated_share_dir: Path, work_dir: KaosPath, tmp_path: Path
+) -> None:
+    session, last_ts = asyncio.run(_create_previous_session(work_dir))
+    output = tmp_path / "previous.zip"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--work-dir", str(work_dir), "export", "--output", str(output)],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "About to export the previous session for this working directory:" in result.output
+    assert f"Work dir: {work_dir}" in result.output
+    assert f"Session ID: {session.id}" in result.output
+    assert "Title: previous export target" in result.output
+    assert f"Last user message: {_format_message_timestamp(last_ts)}" in result.output
+    assert "Export cancelled." in result.output
+    assert not output.exists()
+
+
+def test_export_previous_session_after_confirmation(
+    isolated_share_dir: Path, work_dir: KaosPath, tmp_path: Path
+) -> None:
+    session, last_ts = asyncio.run(_create_previous_session(work_dir))
+    output = tmp_path / "confirmed.zip"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--work-dir", str(work_dir), "export", "--output", str(output)],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f"Session ID: {session.id}" in result.output
+    assert f"Last user message: {_format_message_timestamp(last_ts)}" in result.output
+    assert str(output) in result.output
+    assert output.exists()
+
+    with zipfile.ZipFile(output) as zf:
+        assert set(zf.namelist()) == {"context.jsonl", "wire.jsonl"}
+
+
+def test_export_previous_session_can_skip_confirmation_with_yes(
+    isolated_share_dir: Path, work_dir: KaosPath, tmp_path: Path
+) -> None:
+    asyncio.run(_create_previous_session(work_dir))
+    output = tmp_path / "skip-confirm.zip"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--work-dir", str(work_dir), "export", "--yes", "--output", str(output)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "About to export the previous session" not in result.output
+    assert "Export this session?" not in result.output
+    assert output.exists()
+
+
+def test_export_explicit_session_id_skips_confirmation(
+    isolated_share_dir: Path, work_dir: KaosPath, tmp_path: Path
+) -> None:
+    session, _ = asyncio.run(_create_previous_session(work_dir))
+    output = tmp_path / "explicit.zip"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--work-dir", str(work_dir), "export", "--output", str(output), session.id],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "About to export the previous session" not in result.output
+    assert "Export this session?" not in result.output
+    assert output.exists()
+
+
+def test_export_explicit_session_id_accepts_options_after_argument(
+    isolated_share_dir: Path, work_dir: KaosPath, tmp_path: Path
+) -> None:
+    session, _ = asyncio.run(_create_previous_session(work_dir))
+    output = tmp_path / "explicit-after.zip"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--work-dir", str(work_dir), "export", session.id, "--output", str(output)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+
+
+def test_export_previous_session_errors_when_missing(
+    isolated_share_dir: Path, work_dir: KaosPath
+) -> None:
+    result = CliRunner().invoke(cli, ["--work-dir", str(work_dir), "export"])
+
+    assert result.exit_code == 1
+    assert "Error: no previous session found for the working directory." in result.output
+
+
+def test_export_help_is_leaf_command() -> None:
+    result = CliRunner().invoke(cli, ["export", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Usage: root export [OPTIONS] [SESSION_ID]" in result.output
+    assert "COMMAND [ARGS]..." not in result.output


### PR DESCRIPTION
## Summary
- make `kimi export` default to previewing the previous session for the current working directory and ask for confirmation before exporting
- add `--yes` to skip the confirmation prompt and show the session ID, title, and last user-message time in the preview
- fix `kimi export` CLI parsing so both `kimi export <session_id> --output ...` and `kimi export --output ... <session_id>` work
- add CLI tests and update the command/vis docs plus unreleased changelog entries

## Root Cause
`src/kimi_cli/cli/export.py` was registered as a callback-only Typer group instead of a leaf command. That made Click treat trailing options after `session_id` as possible subcommands, so `--output` could be parsed as a command rather than an option.

## Validation
- `uv run pytest tests/core/test_startup_imports.py -q tests/core/test_export_cli.py -q`
- `uv run ruff check src/kimi_cli/cli/export.py tests/core/test_export_cli.py`
- `uv run ty check src/kimi_cli/cli/export.py tests/core/test_export_cli.py`
- manual CLI smoke tests with isolated `KIMI_SHARE_DIR` covering:
  - `kimi export --yes --output ...`
  - interactive `kimi export` with `y` / `n`
  - explicit session ID with `--output` before and after the argument
  - empty workdir error path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
