### PR TITLE
feat: allow exiting shell by pressing Ctrl-C 3 times

### DIFF
--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -519,6 +519,7 @@ class Shell:
 
                     user_input = event.user_input
                     assert user_input is not None
+                    self._consecutive_interrupts = 0
                     bg_auto_failures = 0
                     deferred_bg_trigger = False
                     if not user_input:


### PR DESCRIPTION
## Summary
- Currently pressing Ctrl-C in idle shell only shows "press Ctrl-D or send 'exit' to quit" repeatedly, which can be frustrating
- This adds a counter so pressing Ctrl-C 3 times within 2 seconds exits the shell, matching common CLI user expectations
- The tip message now dynamically shows how many more presses are needed (e.g. "press Ctrl-C 2 more times to quit")

## Test plan
- [ ] Press Ctrl-C once → shows "press Ctrl-C 2 more times to quit, or press Ctrl-D, or send 'exit'"
- [ ] Press Ctrl-C twice quickly → shows "press Ctrl-C 1 more time to quit..."
- [ ] Press Ctrl-C three times quickly (within 2s) → prints "Bye!" and exits
- [ ] Press Ctrl-C once, wait >2s, press again → counter resets, shows "2 more times"
- [ ] Ctrl-D and `exit` command still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
