### PR TITLE
fix: prevent Ctrl+V crash when clipboard contains non-text data

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -91,7 +91,7 @@ class _SafePyperclipClipboard(PyperclipClipboard):
             data = super().get_data()
         except TypeError as exc:
             logger.debug(
-                "Ignoring non-text clipboard payload in text paste handler: {error}",
+                "Ignoring non-text clipboard payload in clipboard get_data: {error}",
                 error=exc,
             )
             return ClipboardData()
@@ -1858,7 +1858,8 @@ class CustomPromptSession:
         Reads the clipboard once and handles all detected content:
         non-image files (videos, PDFs, etc.) are inserted as paths,
         image files are cached and inserted as placeholders.
-        Returns True if any media content was inserted.
+        Returns True if the paste event was handled (content inserted or
+        recognized but unsupported), False if no media was detected.
         """
         result = grab_media_from_clipboard()
         if result is None:

--- a/tests/ui_and_conv/test_prompt_clipboard.py
+++ b/tests/ui_and_conv/test_prompt_clipboard.py
@@ -185,7 +185,7 @@ def test_paste_single_image(monkeypatch) -> None:
     assert buffer.inserted[0].startswith("[image:")
 
 
-def test_paste_image_unsupported_model_consumes_paste(monkeypatch, capsys) -> None:
+def test_paste_image_unsupported_model_consumes_paste(monkeypatch) -> None:
     img = Image.new("RGB", (10, 10))
     monkeypatch.setattr(
         shell_prompt,


### PR DESCRIPTION
## Related Issue
                                                                                                                           
  Resolve #1757                                             
  Related to #1750

  ## Description

  Two-layer fix for `TypeError` crash when pressing Ctrl+V with non-text clipboard content (e.g. a screenshot on a model   
  that doesn't support image input, or any payload where `pyperclip.paste()` returns `None`).
                                                                                                                           
  ### Layer 1: `_SafePyperclipClipboard`                                                                                   
  
  Wraps `PyperclipClipboard.get_data()` to catch `TypeError` and treat `None`/non-string payloads as empty text            
  (`ClipboardData()`). This protects **all** clipboard access paths in prompt_toolkit — not just our explicit Ctrl+V 
  handler, but also built-in paste operations (Ctrl+Y, Vi `p`, etc.).                                                      
                                                            
  ### Layer 2: `_try_paste_media()` return value

  When images are detected in the clipboard but the current model does not support `image_in`, the paste event is now      
  **consumed** (`return True`) instead of returning `False` and falling through to the text paste path. The "Image input is
   not supported" warning is still printed.                                                                                
                                                            
  ### What's NOT changed

  - Models that support image input (e.g. `kimi-k2.5`) — behavior unchanged.                                               
  - `_try_paste_media()` still returns `False` when image caching fails — existing fallback semantics preserved.
                                                                                                                           
  ## Checklist                                              

  - [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.         
  - [x] I have linked the related issue, if any.
  - [x] I have added tests that prove my fix is effective or that my feature works.                                        
  - [ ] I have run `make gen-changelog` to update the changelog.
  - [ ] I have run `make gen-docs` to update the user documentation.                                                       
 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
