### PR TITLE
fix: normalize empty tool_call arguments to "{}" before serialization

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -199,6 +199,13 @@ class OpenAILegacy:
         # So we use `system` role here. OpenAIResponses will use `developer` role.
         # See https://cdn.openai.com/spec/model-spec-2024-05-08.html#definitions
         message = message.model_copy(deep=True)
+        # Normalize empty tool_call arguments to valid JSON so that
+        # OpenAI-compatible proxies can parse them into a dict
+        # (e.g. Anthropic's tool_use.input requires a dict).
+        if message.tool_calls:
+            for tc in message.tool_calls:
+                if not tc.function.arguments:
+                    tc.function.arguments = "{}"
         reasoning_content: str = ""
         content: list[ContentPart] = []
         for part in message.content:


### PR DESCRIPTION
## Summary

When a tool has no parameters (e.g. `list_files` with empty params model), the streaming response may leave `ToolCall.function.arguments` as `None` or `""`. On the next LLM call, `model_dump(exclude_none=True)` either drops the `arguments` field entirely or keeps the empty string. 

OpenAI-compatible proxies that forward to Anthropic then fail to convert it into the required `tool_use.input` dict, causing a **400 error**:

```
messages.N.content.M.tool_use.input: Input should be a valid dictionary
```

This patch normalizes `arguments` to `"{}"` in `_convert_message` before serialization, ensuring all proxies receive a parseable JSON object.

## Reproduction

1. Use `OpenAILegacy` provider with an OpenAI-compatible proxy that forwards to Anthropic (e.g. `openai-proxy.org`)
2. In a multi-turn conversation, trigger a tool call for a zero-parameter tool
3. The second LLM call (with tool call history) returns 400

## Changes

- `packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py`: Added normalization of empty `arguments` to `"{}"` in `_convert_message` after `model_copy`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
