### PR TITLE
fix: graceful degradation when MCP server fails to connect

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -28,6 +28,7 @@ from kimi_cli.approval_runtime import (
     set_current_approval_source,
 )
 from kimi_cli.background import build_active_task_snapshot
+from kimi_cli.exception import MCPRuntimeError
 from kimi_cli.hooks.engine import HookEngine
 from kimi_cli.llm import ModelCapability
 from kimi_cli.notifications import (
@@ -864,6 +865,8 @@ class KimiSoul:
                                 failed_count=_failed,
                                 total_count=mcp_snap.total,
                             )
+            except MCPRuntimeError as exc:
+                logger.warning("MCP server loading failed, continuing without MCP tools: {}", exc)
             finally:
                 if loading:
                     wire_send(StatusUpdate(mcp_status=self._mcp_status_snapshot()))


### PR DESCRIPTION
## Summary
- When an MCP server fails to start (e.g. port conflict between TUI and Web UI sessions), `MCPRuntimeError` propagates uncaught through `_agent_loop()`, crashing the worker and leaving the frontend stuck in "thinking" forever
- **kimisoul.py**: catch `MCPRuntimeError` in `_agent_loop()` so the conversation continues without the failed MCP server's tools
- **process.py**: on unexpected `_read_loop` exceptions, clear in-flight prompt IDs and emit `"error"` status so the frontend can recover

## Test plan
- [ ] Start kimi-cli TUI with an MCP server using a fixed port
- [ ] Switch to Web UI via `/web`
- [ ] Send a message — previously crashes the worker, now degrades gracefully
- [ ] Verify the conversation proceeds normally without MCP tools

Fixes #1766
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
