### PR TITLE
fix: always stringify tool message content in Chat Completions provider

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -206,9 +206,11 @@ class OpenAILegacy:
                 reasoning_content += part.think
             else:
                 content.append(part)
-        # if tool message and `tool_result_conversion` is `extract_text`, patch all text parts into
-        # one so that we can make use of the serialization process of `Message` to output string
-        if message.role == "tool" and self._tool_message_conversion == "extract_text":
+        # OpenAI Chat Completions API requires tool message content to be a string,
+        # so always collapse multi-part tool results into one TextPart.
+        # Without this, multiple ContentParts serialize as a JSON array which
+        # triggers "invalid type: sequence, expected a string" (fixes #1762).
+        if message.role == "tool":
             message.content = [TextPart(text=message.extract_text(sep="\n"))]
         else:
             message.content = content

--- a/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
@@ -122,16 +122,7 @@ async def test_openai_legacy_message_conversion():
                         },
                         {
                             "role": "tool",
-                            "content": [
-                                {"type": "text", "text": "5"},
-                                {
-                                    "type": "image_url",
-                                    "image_url": {
-                                        "url": "https://example.com/image.png",
-                                        "id": None,
-                                    },
-                                },
-                            ],
+                            "content": "5",
                             "tool_call_id": "call_abc123",
                         },
                     ],
@@ -182,26 +173,14 @@ async def test_openai_legacy_message_conversion():
                         },
                         {
                             "role": "tool",
-                            "content": [
-                                {
-                                    "type": "text",
-                                    "text": "<system-reminder>This is a system reminder"
-                                    "</system-reminder>",
-                                },
-                                {"type": "text", "text": "5"},
-                            ],
+                            "content": "<system-reminder>This is a system reminder"
+                            "</system-reminder>\n5",
                             "tool_call_id": "call_add",
                         },
                         {
                             "role": "tool",
-                            "content": [
-                                {
-                                    "type": "text",
-                                    "text": "<system-reminder>This is a system reminder"
-                                    "</system-reminder>",
-                                },
-                                {"type": "text", "text": "20"},
-                            ],
+                            "content": "<system-reminder>This is a system reminder"
+                            "</system-reminder>\n20",
                             "tool_call_id": "call_mul",
                         },
                     ],


### PR DESCRIPTION
## Summary

Fixes #1762

The OpenAI Chat Completions API requires `content` to be a **string** for `role: "tool"` messages. When a tool result had multiple `ContentPart`s (e.g. a system-reminder TextPart + the actual output TextPart), `_convert_message` kept them as an array, causing:

```
400: Failed to deserialize the JSON body into the target type:
messages[3]: invalid type: sequence, expected a string
```

The fix: always collapse tool message content to a single `TextPart` via `extract_text()`, regardless of the `tool_message_conversion` setting. This matches the API spec and is consistent with how single-part tool results already worked.

## Changes

- `openai_legacy.py`: Remove the `tool_message_conversion == "extract_text"` condition for tool messages - they always need string content
- `test_openai_legacy.py`: Update snapshots to reflect string content for multi-part tool results

## Test plan

- [ ] `tool_call_with_image` snapshot: content is now `"5"` (string) instead of `[{text: "5"}, {image_url: ...}]` (array)
- [ ] `parallel_tool_calls` snapshot: content is now collapsed string instead of array of TextParts
- [ ] Existing tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
