### PR TITLE
fix: gracefully handle MCP connection failure instead of crashing worker

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -683,6 +683,8 @@ class KimiSoul:
                 wire_send(MCPLoadingBegin())
             try:
                 await self.wait_for_background_mcp_loading()
+            except Exception as e:
+                logger.warning("MCP loading failed, continuing without MCP tools: %s", e)
             finally:
                 if loading:
                     wire_send(StatusUpdate(mcp_status=self._mcp_status_snapshot()))


### PR DESCRIPTION
## Summary

Fixes #1766.

When an MCP server fails to connect (e.g. port conflict), `MCPRuntimeError` propagates uncaught through `_agent_loop()`, crashing the worker process. Messages stay stuck in "thinking" state indefinitely.

## Change

Catch exceptions from `wait_for_background_mcp_loading()` and log a warning, allowing the conversation to continue without MCP tools. The `finally` block still runs to properly clean up MCP loading state.

1 file changed, 2 lines added: `src/kimi_cli/soul/kimisoul.py`

## Test plan

- Start an MCP server, then open Web UI — MCP tools should work normally
- Start with a conflicting port — should log warning and continue without MCP tools
- Messages should not get stuck in "thinking" state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
