### PR TITLE
fix: extract text from ContentPart list for UserPromptSubmit hook prompt

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -480,7 +480,10 @@ class KimiSoul:
             set_session_id(self._runtime.session.id)
 
             # --- UserPromptSubmit hook ---
-            text_input_for_hook = user_input if isinstance(user_input, str) else ""
+            if isinstance(user_input, str):
+                text_input_for_hook = user_input
+            else:
+                text_input_for_hook = Message(role="user", content=user_input).extract_text(" ").strip()
             from kimi_cli.hooks import events
 
             hook_results = await self._hook_engine.trigger(


### PR DESCRIPTION
## Problem

The `UserPromptSubmit` hook event always sends an empty string for the `prompt` field when the user input comes from the shell UI.

**Root cause:** In `kimisoul.py`, `user_input` passed to `run()` is typed as `str | list[ContentPart]`. The shell UI always passes `list[ContentPart]`, but the hook code only extracted text for the `str` case:

```python
text_input_for_hook = user_input if isinstance(user_input, str) else ""
```

## Fix

Use `Message.extract_text()` to properly extract text from `list[ContentPart]`, consistent with how `text_input` is extracted just a few lines later in the same method:

```python
if isinstance(user_input, str):
    text_input_for_hook = user_input
else:
    text_input_for_hook = Message(role="user", content=user_input).extract_text(" ").strip()
```

## Testing

- All 34 existing hook tests pass
- Manually verified: hook now receives `{"prompt": "hello this is a test prompt for hook"}` instead of `{"prompt": ""}`

Fixes #1779
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
