### PR TITLE
chore: ignore .local/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ static/
 .memo/
 .entire
 .claude
+.local/


### PR DESCRIPTION
## Related Issue

N/A — trivial repo hygiene, no behavior change.

## Description

Add `.local/` to `.gitignore` so tooling scratch (e.g. the pr-workflow runtime state at `.local/pr-workflow/current.json`) stays out of the working tree. No code or user-facing change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
