### PR TITLE
fix(shell): skip session picker when no other sessions exist

### DIFF
--- a/src/kimi_cli/ui/shell/session_picker.py
+++ b/src/kimi_cli/ui/shell/session_picker.py
@@ -71,6 +71,15 @@ class SessionPickerApp:
     async def run(self) -> tuple[str, KaosPath] | None:
         """Run the picker and return ``(session_id, work_dir)``, or *None*."""
         await self._load_sessions()
+
+        # Skip the picker when no other sessions exist.
+        other_sessions = [s for s in self._sessions if s.id != self._current_session.id]
+        if not other_sessions:
+            from kimi_cli.ui.shell.console import console
+
+            console.print("[yellow]No other sessions to switch to.[/yellow]")
+            return None
+
         self._sync_radio_list()
         result = await self._app.run_async()
         if result is None:


### PR DESCRIPTION
## Related Issue

Resolve #1794

## Description

When `/sessions` (or `/resume`) is invoked and only the current session exists, the picker previously showed a single-item list with just the current session marked "(current)". Selecting it only displayed "You are already in this session." — confusing UX for no benefit.

This change adds an early return in `SessionPickerApp.run()` that checks whether any non-current sessions exist after loading. If not, it prints an informative message and returns `None` without launching the full-screen picker.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
