### PR TITLE
fix(shell): guard against empty or non-text clipboard on Ctrl+V paste

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1463,8 +1463,16 @@ class CustomPromptSession:
             def _(event: KeyPressEvent) -> None:
                 if self._try_paste_media(event):
                     return
-                clipboard_data = event.app.clipboard.get_data()
+                try:
+                    clipboard_data = event.app.clipboard.get_data()
+                except TypeError:
+                    # pyperclip.paste() returns None when the clipboard is
+                    # empty or holds non-text data (e.g. a screenshot),
+                    # which causes a TypeError inside prompt_toolkit.
+                    return
                 if clipboard_data is None:  # type: ignore[reportUnnecessaryComparison]
+                    return
+                if not clipboard_data.text:
                     return
                 self._insert_pasted_text(event.current_buffer, clipboard_data.text)
                 event.app.invalidate()


### PR DESCRIPTION
## Related Issue

Resolve #1750
Resolve #1757

## Description

Pressing Ctrl+V crashes the CLI when the system clipboard is empty or holds non-text data (e.g. a screenshot copied from macOS). The root cause is `pyperclip.paste()` returning `None`, which prompt_toolkit's `PyperclipClipboard.get_data()` doesn't handle — it runs `"\n" in text` on the `None` value, raising a `TypeError`.

This patch wraps the `get_data()` call in a `try/except TypeError` so the paste is silently skipped instead of crashing. An additional guard on `clipboard_data.text` being falsy prevents downstream issues even if future prompt_toolkit versions change how they surface `None` clipboard content.

The fix also covers the scenario from #1757 where `_try_paste_media()` detects an image, warns about unsupported model, returns `False`, and the fallback text-paste path hits the same crash.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
