### PR TITLE
fix(hooks): extract text from multimodal input for UserPromptSubmit prompt field

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -480,12 +480,11 @@ class KimiSoul:
             set_session_id(self._runtime.session.id)
 
             # --- UserPromptSubmit hook ---
-            if isinstance(user_input, str):
-                text_input_for_hook = user_input
-            else:
-                text_input_for_hook = "\n".join(
-                    part.text for part in user_input if hasattr(part, "text")
-                )
+            text_input_for_hook = (
+                user_input
+                if isinstance(user_input, str)
+                else Message(role="user", content=user_input).extract_text("\n")
+            )
             from kimi_cli.hooks import events
 
             hook_results = await self._hook_engine.trigger(

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -480,7 +480,12 @@ class KimiSoul:
             set_session_id(self._runtime.session.id)
 
             # --- UserPromptSubmit hook ---
-            text_input_for_hook = user_input if isinstance(user_input, str) else ""
+            if isinstance(user_input, str):
+                text_input_for_hook = user_input
+            else:
+                text_input_for_hook = "\n".join(
+                    part.text for part in user_input if hasattr(part, "text")
+                )
             from kimi_cli.hooks import events
 
             hook_results = await self._hook_engine.trigger(

--- a/tests/core/test_kimisoul_turn_balance.py
+++ b/tests/core/test_kimisoul_turn_balance.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from kosong.message import ImageURLPart
 from kosong.tooling.empty import EmptyToolset
 
 import kimi_cli.soul.kimisoul as kimisoul_module
@@ -113,3 +114,31 @@ async def test_run_does_not_duplicate_turn_end_for_blocked_prompt(
         TextPart(text="blocked by hook"),
         TurnEnd(),
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_extracts_text_parts_for_user_prompt_submit_hook(
+    runtime: Runtime,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    soul = _make_soul(runtime, tmp_path)
+    seen_prompt: str | None = None
+
+    async def fake_trigger(_event: str, **kwargs):
+        nonlocal seen_prompt
+        seen_prompt = kwargs["input_data"]["prompt"]
+        return [SimpleNamespace(action="block", reason="blocked by hook")]
+
+    monkeypatch.setattr(soul._hook_engine, "trigger", fake_trigger)
+    monkeypatch.setattr(kimisoul_module, "wire_send", lambda _msg: None)
+
+    await soul.run(
+        [
+            TextPart(text="Check this image"),
+            ImageURLPart(image_url=ImageURLPart.ImageURL(url="https://example.com/test.png")),
+            TextPart(text="And summarize it"),
+        ]
+    )
+
+    assert seen_prompt == "Check this image\nAnd summarize it"


### PR DESCRIPTION
## Related Issue

Resolve #1779

## Description

The `UserPromptSubmit` hook event was sending an empty string in the `prompt` field whenever the user submitted multimodal content such as text plus images or other media. The hook path now extracts only the textual `TextPart` content from multimodal input, preserving plain-string input behavior and ignoring non-text parts.

This branch also adds a focused regression test around `KimiSoul.run()` to verify that `UserPromptSubmit` receives newline-joined text from multimodal prompts.

## Validation

- `uv run pytest tests/core/test_kimisoul_turn_balance.py`
- `uv run pytest tests/hooks/test_integration.py -k user_prompt_submit_block`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
