### PR TITLE
fix(web): prevent Enter from sending message during IME composition on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Web: Fix Enter key sending message during IME composition on Safari — Safari fires `compositionend` before the Enter `keydown`, making both `isComposing` guards false; adds a 100 ms post-composition cooldown to block premature submission (WebKit bug #165004)
+
 - Core: Fix agent loop silently stopping when model response contains only thinking content — detect think-only responses (reasoning content with no text or tool calls) as an incomplete response error and retry automatically
 - Core: Fix crash on streaming mid-flight network disconnection — when the OpenAI SDK raises a base `APIError` (instead of `APIConnectionError`) during long-running streams, the error is now correctly classified as retryable, enabling automatic retry and connection recovery instead of an unrecoverable crash
 - Shell: Exclude empty current session from `/sessions` picker — completely empty sessions (no conversation history and no custom title) are no longer shown in the session list; sessions with a custom title are still displayed

--- a/web/src/components/ai-elements/prompt-input.tsx
+++ b/web/src/components/ai-elements/prompt-input.tsx
@@ -954,6 +954,11 @@ export const PromptInputTextarea = forwardRef<
     const controller = useOptionalPromptInputController();
     const attachments = usePromptInputAttachments();
     const [isComposing, setIsComposing] = useState(false);
+    // Track when compositionend last fired. Safari (WebKit bug #165004) fires
+    // compositionend *before* the Enter keydown, so both isComposing and
+    // nativeEvent.isComposing are false by the time we check. A short cooldown
+    // after compositionend prevents that Enter from triggering a send.
+    const compositionEndTimeRef = useRef(0);
 
     const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
       onKeyDown?.(e);
@@ -962,7 +967,11 @@ export const PromptInputTextarea = forwardRef<
       }
 
       if (e.key === "Enter") {
-        if (isComposing || e.nativeEvent.isComposing) {
+        if (
+          isComposing ||
+          e.nativeEvent.isComposing ||
+          Date.now() - compositionEndTimeRef.current < 100
+        ) {
           return;
         }
         if (e.shiftKey) {
@@ -1044,7 +1053,10 @@ export const PromptInputTextarea = forwardRef<
         autoComplete="off"
         name="message"
         onBlur={() => setIsComposing(false)}
-        onCompositionEnd={() => setIsComposing(false)}
+        onCompositionEnd={() => {
+          setIsComposing(false);
+          compositionEndTimeRef.current = Date.now();
+        }}
         onCompositionStart={() => setIsComposing(true)}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}

--- a/web/src/components/ai-elements/prompt-input.tsx
+++ b/web/src/components/ai-elements/prompt-input.tsx
@@ -970,7 +970,7 @@ export const PromptInputTextarea = forwardRef<
         if (
           isComposing ||
           e.nativeEvent.isComposing ||
-          Date.now() - compositionEndTimeRef.current < 100
+          e.timeStamp - compositionEndTimeRef.current < 100
         ) {
           return;
         }
@@ -1055,7 +1055,7 @@ export const PromptInputTextarea = forwardRef<
         onBlur={() => setIsComposing(false)}
         onCompositionEnd={() => {
           setIsComposing(false);
-          compositionEndTimeRef.current = Date.now();
+          compositionEndTimeRef.current = e.timeStamp;
         }}
         onCompositionStart={() => setIsComposing(true)}
         onKeyDown={handleKeyDown}

--- a/web/src/components/ai-elements/prompt-input.tsx
+++ b/web/src/components/ai-elements/prompt-input.tsx
@@ -1053,7 +1053,7 @@ export const PromptInputTextarea = forwardRef<
         autoComplete="off"
         name="message"
         onBlur={() => setIsComposing(false)}
-        onCompositionEnd={() => {
+        onCompositionEnd={(e) => {
           setIsComposing(false);
           compositionEndTimeRef.current = e.timeStamp;
         }}


### PR DESCRIPTION
## Related Issue

N/A (new issue — discovered during manual testing on Safari + macOS native Chinese IME)

## Description

### Bug

On Safari (macOS), pressing Enter to commit raw English letters from the IME candidate bar **sends the message immediately** instead of committing the text to the input field. Chrome and Firefox are not affected.

### Repro steps

1. Open Kimi Web in **Safari** on macOS
2. Keep the macOS native Chinese input method (Pinyin) active — do **not** switch to an English input source
3. In a mixed Chinese/English typing flow, type a short English word directly, e.g. `ok` or `hello` — the IME candidate bar appears with the raw letters
4. Press **Enter** to commit the raw English letters to the textarea (a common habit to avoid switching input sources for occasional English words)

**Expected:** The English letters (`ok` / `hello`) are committed to the textarea as-is; the user continues editing.
**Actual:** The message is sent immediately.

### Root cause

The existing guard in `PromptInputTextarea` checks two conditions before allowing Enter to submit:

```tsx
if (isComposing || e.nativeEvent.isComposing) {
  return;
}
```

This is a thoughtful design — `useState` may have stale values due to React's asynchronous batching, so `e.nativeEvent.isComposing` is added as a synchronous fallback. This works perfectly on Chrome and Firefox, where the W3C-specified event order is:

```
keydown (Enter, isComposing: true)  →  compositionend  →  keyup
```

However, Safari has a **long-standing event ordering bug** ([WebKit #165004](https://bugs.webkit.org/show_bug.cgi?id=165004), status: NEW, unfixed) that reverses the order:

```
compositionend  →  keydown (Enter, isComposing: false)  →  keyup
```

Because `compositionend` fires *before* the Enter `keydown`:
- `isComposing` (React state) → already set to `false` by the `onCompositionEnd` handler
- `e.nativeEvent.isComposing` → also `false` (the browser considers composition ended)

Both guards fail, and the Enter keystroke reaches `form?.requestSubmit()`.

### Fix

Record the timestamp of `compositionend` via a `useRef`. In the Enter keydown handler, treat any Enter arriving within 100 ms of `compositionend` as part of the composition — not a send action.

Uses `event.timeStamp` (monotonic, immune to main-thread blocking) instead of `Date.now()` for reliable timing — adopted from Copilot review feedback.

```tsx
const compositionEndTimeRef = useRef(0);

// In handleKeyDown:
if (
  isComposing ||
  e.nativeEvent.isComposing ||
  e.timeStamp - compositionEndTimeRef.current < 100  // Safari workaround
) {
  return;
}

// In onCompositionEnd:
onCompositionEnd={(e) => {
  setIsComposing(false);
  compositionEndTimeRef.current = e.timeStamp;
}}
```

This is the same approach used by [ProseMirror](https://github.com/ProseMirror/prosemirror-view) and [CodeMirror](https://github.com/codemirror/view) to handle this Safari quirk. The 100 ms window is far shorter than any realistic gap between finishing a composition and intentionally pressing Enter to send, so Chrome/Firefox behavior is completely unaffected.

**Scope:** 1 file changed, 3 lines of logic added. No behavioral change on Chrome/Firefox.

### Review feedback adopted

- **Copilot:** Switched from `Date.now()` to `event.timeStamp` for monotonic, main-thread-safe timing — thanks for catching this.
- **Codex:** Fixed missing `e` parameter in `onCompositionEnd` callback that would have caused a `ReferenceError` at runtime — good catch, especially since this file is excluded from `tsc` checking.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation. (N/A)