### PR TITLE
fix(web,mcp): gracefully degrade when MCP loading fails in Web UI worker

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -64,6 +64,7 @@ from kimi_cli.soul.dynamic_injections.yolo_mode import YoloModeInjectionProvider
 from kimi_cli.soul.message import check_message, system, system_reminder, tool_result_to_message
 from kimi_cli.soul.slash import registry as soul_slash_registry
 from kimi_cli.soul.toolset import KimiToolset
+from kimi_cli.exception import MCPRuntimeError
 from kimi_cli.tools.dmail import NAME as SendDMail_NAME
 from kimi_cli.tools.utils import ToolRejectedError
 from kimi_cli.utils.logging import logger
@@ -683,6 +684,8 @@ class KimiSoul:
                 wire_send(MCPLoadingBegin())
             try:
                 await self.wait_for_background_mcp_loading()
+            except MCPRuntimeError as e:
+                logger.warning("MCP loading failed, continuing without MCP tools: {}", e)
             finally:
                 if loading:
                     wire_send(StatusUpdate(mcp_status=self._mcp_status_snapshot()))

--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -355,6 +355,8 @@ class SessionProcess:
             raise
         except Exception as e:
             logger.warning(f"Unexpected error in read loop: {e.__class__.__name__} {e}")
+            self._in_flight_prompt_ids.clear()
+            await self._emit_status("error", reason="read_loop_error", detail=str(e))
 
     async def _handle_out_message(self, message: JSONRPCOutMessage) -> None:
         """Handle outbound message from worker."""


### PR DESCRIPTION
## Problem

When an MCP server fails to connect (e.g., due to a port conflict when switching from TUI to Web UI), the Web UI session worker crashes entirely. This causes messages to get stuck in the "thinking" state indefinitely, and the frontend becomes unresponsive.

This is described in detail in #1766.

## Root Cause

1. In `kimi_cli/soul/kimisoul.py`, `_agent_loop()` calls `wait_for_background_mcp_loading()` inside a `try/finally` block. The `finally` only ensures `MCPLoadingEnd` is sent, but does **not** catch `MCPRuntimeError`. The exception bubbles up and crashes the agent loop.

2. In `kimi_cli/web/runner/process.py`, `_read_loop()` catches unexpected exceptions but:
   - Does not clear `_in_flight_prompt_ids`
   - Does not emit `"error"` or `"idle"` status to WebSockets
   - The frontend has no way to know the worker died

## Changes

- **`src/kimi_cli/soul/kimisoul.py`**:
  - Import `MCPRuntimeError`
  - Catch `MCPRuntimeError` during `wait_for_background_mcp_loading()` and log a warning, allowing the conversation to continue without MCP tools.

- **`src/kimi_cli/web/runner/process.py`**:
  - On unexpected exceptions in `_read_loop()`, clear `_in_flight_prompt_ids` and emit an `"error"` status so the frontend can recover instead of leaving prompts stuck in "thinking".

## Testing

- Verified Python syntax with `py_compile`
- The fix directly addresses the two failure points identified in #1766

Fixes #1766

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
