### PR TITLE
fix(auth): retry with token refresh on 401 and harden OAuth resilience

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import platform
+import random
 import socket
 import sys
 import tempfile
@@ -53,6 +54,8 @@ KEYRING_SERVICE = "kimi-code"
 REFRESH_INTERVAL_SECONDS = 60
 MIN_REFRESH_THRESHOLD_SECONDS = 300
 REFRESH_THRESHOLD_RATIO = 0.5
+_CROSS_PROCESS_LOCK_TIMEOUT = 10  # seconds
+_CROSS_PROCESS_LOCK_RETRIES = 5
 
 
 class OAuthError(RuntimeError):
@@ -230,6 +233,62 @@ def _credentials_dir() -> Path:
 def _credentials_path(key: str) -> Path:
     name = key.removeprefix("oauth/").split("/")[-1] or key
     return _credentials_dir() / f"{name}.json"
+
+
+def _credentials_lock_path(key: str) -> Path:
+    name = key.removeprefix("oauth/").split("/")[-1] or key
+    return _credentials_dir() / f"{name}.lock"
+
+
+class _CrossProcessLock:
+    """File-based lock that coordinates token refresh across kimi-cli processes.
+
+    Uses fcntl.flock on Unix and msvcrt.locking on Windows.
+    """
+
+    def __init__(self, key: str) -> None:
+        self._path = _credentials_lock_path(key)
+        self._fd: int | None = None
+
+    def _acquire(self) -> bool:
+        try:
+            self._fd = os.open(str(self._path), os.O_CREAT | os.O_RDWR)
+        except OSError:
+            return False
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+
+                msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            os.close(self._fd)
+            self._fd = None
+            return False
+
+    def release(self) -> None:
+        if self._fd is not None:
+            with suppress(OSError):
+                os.close(self._fd)
+            self._fd = None
+
+    async def acquire_with_retry(self) -> bool:
+        for _attempt in range(_CROSS_PROCESS_LOCK_RETRIES):
+            if self._acquire():
+                return True
+            await asyncio.sleep(1 + random.random())
+            # After waiting, re-check if the token was refreshed by the holder.
+        return self._acquire()
+
+    async def __aenter__(self) -> bool:
+        return await self.acquire_with_retry()
+
+    async def __aexit__(self, *args: object) -> None:
+        self.release()
 
 
 def _load_from_keyring(key: str) -> OAuthToken | None:
@@ -793,7 +852,7 @@ class OAuthManager:
         if not current_token.refresh_token:
             return
         async with self._refresh_lock:
-            # Re-check persisted token inside the lock to reduce races.
+            # Re-check persisted token inside the in-process lock.
             persisted = load_tokens(ref)
             if persisted:
                 self._cache_access_token(ref, persisted)
@@ -814,44 +873,74 @@ class OAuthManager:
             refresh_token_value = current.refresh_token
             if not refresh_token_value:
                 return
+
+            # Acquire cross-process file lock to coordinate with other
+            # kimi-cli instances (terminal, VS Code, web).
+            xlock = _CrossProcessLock(ref.key)
+            acquired = await xlock.acquire_with_retry()
             try:
-                refreshed = await refresh_token(refresh_token_value)
-            except OAuthUnauthorized as exc:
-                # Give a concurrent instance time to persist its rotated token.
-                await asyncio.sleep(1)
-                latest = load_tokens(ref)
-                if latest and latest.refresh_token != refresh_token_value:
-                    self._cache_access_token(ref, latest)
-                    self._apply_access_token(runtime, latest.access_token)
-                    return
-                # The on-disk token is the same one we just tried and it
-                # was rejected — no other instance rotated it.  Mark it as
-                # expired (expires_at=0) so subsequent loads treat it as
-                # unusable without deleting the file (avoids the race where
-                # another instance writes between our check and delete).
-                if latest:
-                    invalidated = OAuthToken(
-                        access_token=latest.access_token,
-                        refresh_token=latest.refresh_token,
-                        expires_at=0,
-                        scope=latest.scope,
-                        token_type=latest.token_type,
-                        expires_in=0.0,
+                if acquired:
+                    # Triple-check after acquiring the lock — another process
+                    # may have refreshed while we waited.
+                    locked_token = load_tokens(ref)
+                    if locked_token and locked_token.refresh_token != refresh_token_value:
+                        self._cache_access_token(ref, locked_token)
+                        self._apply_access_token(runtime, locked_token.access_token)
+                        return
+                    if not force and locked_token:
+                        remaining = locked_token.expires_at - time.time()
+                        t = (
+                            max(
+                                MIN_REFRESH_THRESHOLD_SECONDS,
+                                locked_token.expires_in * REFRESH_THRESHOLD_RATIO,
+                            )
+                            if locked_token.expires_in > 0
+                            else MIN_REFRESH_THRESHOLD_SECONDS
+                        )
+                        if locked_token.expires_at and remaining >= t:
+                            self._cache_access_token(ref, locked_token)
+                            self._apply_access_token(runtime, locked_token.access_token)
+                            return
+                else:
+                    logger.warning("Could not acquire cross-process lock for token refresh")
+
+                try:
+                    refreshed = await refresh_token(refresh_token_value)
+                except OAuthUnauthorized as exc:
+                    # Give a concurrent instance time to persist its rotated token.
+                    await asyncio.sleep(1)
+                    latest = load_tokens(ref)
+                    if latest and latest.refresh_token != refresh_token_value:
+                        self._cache_access_token(ref, latest)
+                        self._apply_access_token(runtime, latest.access_token)
+                        return
+                    # Mark the revoked token as expired so subsequent loads
+                    # don't loop on failed refresh attempts.
+                    if latest:
+                        invalidated = OAuthToken(
+                            access_token=latest.access_token,
+                            refresh_token=latest.refresh_token,
+                            expires_at=0,
+                            scope=latest.scope,
+                            token_type=latest.token_type,
+                            expires_in=0.0,
+                        )
+                        save_tokens(ref, invalidated)
+                    logger.warning(
+                        "OAuth credentials rejected: {error}",
+                        error=exc,
                     )
-                    save_tokens(ref, invalidated)
-                logger.warning(
-                    "OAuth credentials rejected: {error}",
-                    error=exc,
-                )
-                self._access_tokens.pop(ref.key, None)
-                self._apply_access_token(runtime, "")
-                return
-            except Exception as exc:
-                logger.warning("Failed to refresh OAuth token: {error}", error=exc)
-                return
-            save_tokens(ref, refreshed)
-            self._cache_access_token(ref, refreshed)
-            self._apply_access_token(runtime, refreshed.access_token)
+                    self._access_tokens.pop(ref.key, None)
+                    self._apply_access_token(runtime, "")
+                    return
+                except Exception as exc:
+                    logger.warning("Failed to refresh OAuth token: {error}", error=exc)
+                    return
+                save_tokens(ref, refreshed)
+                self._cache_access_token(ref, refreshed)
+                self._apply_access_token(runtime, refreshed.access_token)
+            finally:
+                xlock.release()
 
     def _apply_access_token(self, runtime: Runtime | None, access_token: str) -> None:
         if runtime is None:

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -54,7 +54,6 @@ KEYRING_SERVICE = "kimi-code"
 REFRESH_INTERVAL_SECONDS = 60
 MIN_REFRESH_THRESHOLD_SECONDS = 300
 REFRESH_THRESHOLD_RATIO = 0.5
-_CROSS_PROCESS_LOCK_TIMEOUT = 10  # seconds
 _CROSS_PROCESS_LOCK_RETRIES = 5
 
 
@@ -259,6 +258,10 @@ class _CrossProcessLock:
             if sys.platform == "win32":
                 import msvcrt
 
+                # msvcrt.locking requires bytes to exist at the lock position.
+                if os.fstat(self._fd).st_size == 0:
+                    os.write(self._fd, b"\0")
+                    os.lseek(self._fd, 0, os.SEEK_SET)
                 msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)
             else:
                 import fcntl

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -6,6 +6,7 @@ import os
 import platform
 import socket
 import sys
+import tempfile
 import time
 import uuid
 import webbrowser
@@ -50,7 +51,8 @@ KIMI_CODE_OAUTH_KEY = "oauth/kimi-code"
 DEFAULT_OAUTH_HOST = "https://auth.kimi.com"
 KEYRING_SERVICE = "kimi-code"
 REFRESH_INTERVAL_SECONDS = 60
-REFRESH_THRESHOLD_SECONDS = 300
+MIN_REFRESH_THRESHOLD_SECONDS = 300
+REFRESH_THRESHOLD_RATIO = 0.5
 
 
 class OAuthError(RuntimeError):
@@ -92,6 +94,7 @@ class OAuthToken:
     expires_at: float
     scope: str
     token_type: str
+    expires_in: float = 0.0
 
     @classmethod
     def from_response(cls, payload: dict[str, Any]) -> OAuthToken:
@@ -102,6 +105,7 @@ class OAuthToken:
             expires_at=time.time() + expires_in,
             scope=str(payload["scope"]),
             token_type=str(payload["token_type"]),
+            expires_in=expires_in,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -111,6 +115,7 @@ class OAuthToken:
             "expires_at": self.expires_at,
             "scope": self.scope,
             "token_type": self.token_type,
+            "expires_in": self.expires_in,
         }
 
     @classmethod
@@ -122,6 +127,7 @@ class OAuthToken:
             expires_at=float(expires_at_value) if expires_at_value is not None else 0.0,
             scope=str(payload.get("scope") or ""),
             token_type=str(payload.get("token_type") or ""),
+            expires_in=float(payload.get("expires_in") or 0),
         )
 
 
@@ -267,8 +273,20 @@ def _load_from_file(key: str) -> OAuthToken | None:
 
 def _save_to_file(key: str, token: OAuthToken) -> None:
     path = _credentials_path(key)
-    path.write_text(json.dumps(token.to_dict(), ensure_ascii=False), encoding="utf-8")
-    _ensure_private_file(path)
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        os.write(fd, json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8"))
+        os.close(fd)
+        fd = -1
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except BaseException:
+        if fd >= 0:
+            with suppress(OSError):
+                os.close(fd)
+        with suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
 
 def _delete_from_file(key: str) -> None:
@@ -359,26 +377,43 @@ async def _request_device_token(auth: DeviceAuthorization) -> tuple[int, dict[st
     return status, data
 
 
-async def refresh_token(refresh_token: str) -> OAuthToken:
-    async with (
-        new_client_session() as session,
-        session.post(
-            f"{_oauth_host().rstrip('/')}/api/oauth/token",
-            data={
-                "client_id": KIMI_CODE_CLIENT_ID,
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-            },
-            headers=_common_headers(),
-        ) as response,
-    ):
-        data = await response.json(content_type=None)
-        status = response.status
-    if status in (401, 403):
-        raise OAuthUnauthorized(data.get("error_description") or "Token refresh unauthorized.")
-    if status != 200:
-        raise OAuthError(data.get("error_description") or "Token refresh failed.")
-    return OAuthToken.from_response(data)
+async def refresh_token(refresh_token: str, *, max_retries: int = 3) -> OAuthToken:
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            async with (
+                new_client_session() as session,
+                session.post(
+                    f"{_oauth_host().rstrip('/')}/api/oauth/token",
+                    data={
+                        "client_id": KIMI_CODE_CLIENT_ID,
+                        "grant_type": "refresh_token",
+                        "refresh_token": refresh_token,
+                    },
+                    headers=_common_headers(),
+                ) as response,
+            ):
+                data = await response.json(content_type=None)
+                status = response.status
+            if status in (401, 403):
+                raise OAuthUnauthorized(
+                    data.get("error_description") or "Token refresh unauthorized."
+                )
+            if status != 200:
+                raise OAuthError(data.get("error_description") or "Token refresh failed.")
+            return OAuthToken.from_response(data)
+        except OAuthUnauthorized:
+            raise
+        except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+            last_exc = exc
+            if attempt < max_retries - 1:
+                await asyncio.sleep(2**attempt)
+                logger.warning(
+                    "Token refresh attempt {attempt} failed, retrying: {error}",
+                    attempt=attempt + 1,
+                    error=exc,
+                )
+    raise OAuthError("Token refresh failed after retries.") from last_exc
 
 
 def _select_default_model_and_thinking(models: list[ModelInfo]) -> tuple[ModelInfo, bool] | None:
@@ -676,13 +711,15 @@ class OAuthManager:
                 return service.oauth
         return None
 
-    async def ensure_fresh(self, runtime: Runtime | None = None) -> None:
+    async def ensure_fresh(self, runtime: Runtime | None = None, *, force: bool = False) -> None:
         """Load persisted tokens, cache them, and refresh if close to expiry.
 
         Args:
             runtime: When provided the live LLM client's API key is updated
                 in-place.  Pass ``None`` for lightweight callers (e.g. title
                 generation) that only need the internal cache to be current.
+            force: When True, skip the expiry-threshold check and always
+                attempt a refresh.  Used after receiving a 401 from the server.
         """
         ref = self._kimi_code_ref()
         if ref is None:
@@ -692,7 +729,7 @@ class OAuthManager:
             return
         self._cache_access_token(ref, token)
         self._apply_access_token(runtime, token.access_token)
-        await self._refresh_tokens(ref, token, runtime)
+        await self._refresh_tokens(ref, token, runtime, force=force)
 
     @asynccontextmanager
     async def refreshing(self, runtime: Runtime) -> AsyncIterator[None]:
@@ -701,6 +738,7 @@ class OAuthManager:
         async def _runner() -> None:
             try:
                 while True:
+                    wall_before = time.time()
                     try:
                         await asyncio.wait_for(
                             stop_event.wait(),
@@ -709,8 +747,16 @@ class OAuthManager:
                         return
                     except TimeoutError:
                         pass
+                    elapsed = time.time() - wall_before
+                    force = elapsed > REFRESH_INTERVAL_SECONDS * 2
+                    if force:
+                        logger.info(
+                            "Detected possible sleep/wake ({elapsed:.0f}s elapsed), "
+                            "forcing token refresh.",
+                            elapsed=elapsed,
+                        )
                     try:
-                        await self.ensure_fresh(runtime)
+                        await self.ensure_fresh(runtime, force=force)
                     except Exception as exc:
                         logger.warning(
                             "Failed to refresh OAuth token in background: {error}",
@@ -734,6 +780,8 @@ class OAuthManager:
         ref: OAuthRef,
         token: OAuthToken,
         runtime: Runtime | None,
+        *,
+        force: bool = False,
     ) -> None:
         # Always prefer persisted tokens before refresh to avoid stale cache
         # when multiple sessions might have already rotated the refresh token.
@@ -749,32 +797,40 @@ class OAuthManager:
             if persisted:
                 self._cache_access_token(ref, persisted)
             current = persisted or current_token
-            now = time.time()
-            if (
-                current.expires_at
-                and current.expires_at > now
-                and current.expires_at - now >= REFRESH_THRESHOLD_SECONDS
-            ):
-                return
+            if not force:
+                now = time.time()
+                threshold = (
+                    max(MIN_REFRESH_THRESHOLD_SECONDS, current.expires_in * REFRESH_THRESHOLD_RATIO)
+                    if current.expires_in > 0
+                    else MIN_REFRESH_THRESHOLD_SECONDS
+                )
+                if (
+                    current.expires_at
+                    and current.expires_at > now
+                    and current.expires_at - now >= threshold
+                ):
+                    return
             refresh_token_value = current.refresh_token
             if not refresh_token_value:
                 return
             try:
                 refreshed = await refresh_token(refresh_token_value)
             except OAuthUnauthorized as exc:
-                # If another session refreshed and persisted a new token,
-                # do not delete it. Just sync memory and exit.
+                # Give a concurrent instance time to persist its rotated token.
+                await asyncio.sleep(1)
                 latest = load_tokens(ref)
                 if latest and latest.refresh_token != refresh_token_value:
                     self._cache_access_token(ref, latest)
                     self._apply_access_token(runtime, latest.access_token)
                     return
+                # Do not delete persisted tokens from the background loop —
+                # only clear the in-memory cache so the next interactive
+                # command will prompt re-login.
                 logger.warning(
-                    "OAuth credentials rejected, deleting stored tokens: {error}",
+                    "OAuth credentials rejected: {error}",
                     error=exc,
                 )
                 self._access_tokens.pop(ref.key, None)
-                delete_tokens(ref)
                 self._apply_access_token(runtime, "")
                 return
             except Exception as exc:

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -799,7 +799,8 @@ class OAuthManager:
         if token is None:
             return
         self._cache_access_token(ref, token)
-        self._apply_access_token(runtime, token.access_token)
+        if token.access_token:
+            self._apply_access_token(runtime, token.access_token)
         await self._refresh_tokens(ref, token, runtime, force=force)
 
     @asynccontextmanager
@@ -925,24 +926,13 @@ class OAuthManager:
                         self._cache_access_token(ref, latest)
                         self._apply_access_token(runtime, latest.access_token)
                         return
-                    # Mark the revoked token as expired so subsequent loads
-                    # don't loop on failed refresh attempts.  Clear both
-                    # access_token and refresh_token:
-                    # - access_token="" prevents _cache_access_token from
-                    #   re-caching the old invalid token on the next cycle.
-                    # - refresh_token="" causes the early-exit guard
-                    #   (``if not current_token.refresh_token: return``) to
-                    #   trigger, stopping further refresh attempts.
-                    if latest:
-                        invalidated = OAuthToken(
-                            access_token="",
-                            refresh_token="",
-                            expires_at=0,
-                            scope=latest.scope,
-                            token_type=latest.token_type,
-                            expires_in=0.0,
-                        )
-                        save_tokens(ref, invalidated)
+                    # Delete the revoked credential file so that:
+                    # 1. load_tokens returns None on subsequent calls,
+                    #    preventing ensure_fresh from applying an empty
+                    #    access_token to the live client.
+                    # 2. resolve_api_key falls back to the configured
+                    #    api_key immediately.
+                    delete_tokens(ref)
                     logger.warning(
                         "OAuth credentials rejected: {error}",
                         error=exc,

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -251,7 +251,7 @@ class _CrossProcessLock:
 
     def _acquire(self) -> bool:
         try:
-            self._fd = os.open(str(self._path), os.O_CREAT | os.O_RDWR)
+            self._fd = os.open(str(self._path), os.O_CREAT | os.O_RDWR, 0o600)
         except OSError:
             return False
         try:

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -824,9 +824,21 @@ class OAuthManager:
                     self._cache_access_token(ref, latest)
                     self._apply_access_token(runtime, latest.access_token)
                     return
-                # Do not delete persisted tokens from the background loop —
-                # only clear the in-memory cache so the next interactive
-                # command will prompt re-login.
+                # The on-disk token is the same one we just tried and it
+                # was rejected — no other instance rotated it.  Mark it as
+                # expired (expires_at=0) so subsequent loads treat it as
+                # unusable without deleting the file (avoids the race where
+                # another instance writes between our check and delete).
+                if latest:
+                    invalidated = OAuthToken(
+                        access_token=latest.access_token,
+                        refresh_token=latest.refresh_token,
+                        expires_at=0,
+                        scope=latest.scope,
+                        token_type=latest.token_type,
+                        expires_in=0.0,
+                    )
+                    save_tokens(ref, invalidated)
                 logger.warning(
                     "OAuth credentials rejected: {error}",
                     error=exc,

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -276,6 +276,11 @@ class _CrossProcessLock:
     def release(self) -> None:
         if self._fd is not None:
             with suppress(OSError):
+                if sys.platform == "win32":
+                    import msvcrt
+
+                    os.lseek(self._fd, 0, os.SEEK_SET)
+                    msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
                 os.close(self._fd)
             self._fd = None
 
@@ -325,7 +330,7 @@ def _load_from_file(key: str) -> OAuthToken | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, OSError):
         return None
     if not isinstance(payload, dict):
         return None

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -278,7 +278,8 @@ def _save_to_file(key: str, token: OAuthToken) -> None:
         os.write(fd, json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8"))
         os.close(fd)
         fd = -1
-        os.chmod(tmp_path, 0o600)
+        with suppress(OSError):
+            os.chmod(tmp_path, 0o600)
         os.replace(tmp_path, path)
     except BaseException:
         if fd >= 0:

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -337,7 +337,10 @@ def _save_to_file(key: str, token: OAuthToken) -> None:
     path = _credentials_path(key)
     fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
-        os.write(fd, json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8"))
+        data = json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8")
+        written = os.write(fd, data)
+        if written != len(data):
+            raise OSError(f"Short write: {written}/{len(data)} bytes")
         os.close(fd)
         fd = -1
         with suppress(OSError):
@@ -918,11 +921,17 @@ class OAuthManager:
                         self._apply_access_token(runtime, latest.access_token)
                         return
                     # Mark the revoked token as expired so subsequent loads
-                    # don't loop on failed refresh attempts.
+                    # don't loop on failed refresh attempts.  Clear both
+                    # access_token and refresh_token:
+                    # - access_token="" prevents _cache_access_token from
+                    #   re-caching the old invalid token on the next cycle.
+                    # - refresh_token="" causes the early-exit guard
+                    #   (``if not current_token.refresh_token: return``) to
+                    #   trigger, stopping further refresh attempts.
                     if latest:
                         invalidated = OAuthToken(
-                            access_token=latest.access_token,
-                            refresh_token=latest.refresh_token,
+                            access_token="",
+                            refresh_token="",
                             expires_at=0,
                             scope=latest.scope,
                             token_type=latest.token_type,

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -275,14 +275,17 @@ class _CrossProcessLock:
 
     def release(self) -> None:
         if self._fd is not None:
-            with suppress(OSError):
+            try:
                 if sys.platform == "win32":
                     import msvcrt
 
-                    os.lseek(self._fd, 0, os.SEEK_SET)
-                    msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
-                os.close(self._fd)
-            self._fd = None
+                    with suppress(OSError):
+                        os.lseek(self._fd, 0, os.SEEK_SET)
+                        msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+            finally:
+                with suppress(OSError):
+                    os.close(self._fd)
+                self._fd = None
 
     async def acquire_with_retry(self) -> bool:
         for _attempt in range(_CROSS_PROCESS_LOCK_RETRIES):

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -1072,9 +1072,15 @@ class KimiSoul:
         except APIStatusError as error:
             if error.status_code != 401:
                 raise
-            # Only attempt refresh+retry for OAuth sessions; for plain
-            # API-key auth there is nothing to refresh.
-            if not any(p.oauth for p in self._runtime.config.providers.values() if p.oauth):
+            # Only attempt refresh+retry when the active model's provider
+            # uses OAuth.  For plain API-key providers there is nothing
+            # to refresh and retrying would just add latency.
+            active_provider = (
+                self._runtime.config.providers.get(self._runtime.llm.model_config.provider)
+                if self._runtime.llm and self._runtime.llm.model_config
+                else None
+            )
+            if not (active_provider and active_provider.oauth):
                 raise
             logger.warning(
                 "Received 401 during {name}, attempting token refresh",

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -1072,6 +1072,10 @@ class KimiSoul:
         except APIStatusError as error:
             if error.status_code != 401:
                 raise
+            # Only attempt refresh+retry for OAuth sessions; for plain
+            # API-key auth there is nothing to refresh.
+            if not any(p.oauth for p in self._runtime.config.providers.values() if p.oauth):
+                raise
             logger.warning(
                 "Received 401 during {name}, attempting token refresh",
                 name=name,

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -1069,6 +1069,19 @@ class KimiSoul:
     ) -> Any:
         try:
             return await operation()
+        except APIStatusError as error:
+            if error.status_code != 401:
+                raise
+            logger.warning(
+                "Received 401 during {name}, attempting token refresh",
+                name=name,
+            )
+            try:
+                await self._runtime.oauth.ensure_fresh(self._runtime, force=True)
+            except Exception as refresh_exc:
+                logger.exception("Token refresh failed after 401.")
+                raise error from refresh_exc
+            return await operation()
         except (APIConnectionError, APITimeoutError) as error:
             if not isinstance(chat_provider, RetryableChatProvider):
                 raise

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import os
 import time
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -12,8 +11,6 @@ import pytest
 from pydantic import SecretStr
 
 from kimi_cli.auth.oauth import (
-    MIN_REFRESH_THRESHOLD_SECONDS,
-    REFRESH_THRESHOLD_RATIO,
     OAuthError,
     OAuthManager,
     OAuthToken,
@@ -22,7 +19,6 @@ from kimi_cli.auth.oauth import (
     refresh_token,
 )
 from kimi_cli.config import Config, LLMModel, LLMProvider, OAuthRef, Services
-
 
 # ── helpers ──────────────────────────────────────────────────────
 

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -1,0 +1,285 @@
+"""Tests for OAuth token refresh: retry, force refresh, atomic write, and 401 recovery."""
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from pydantic import SecretStr
+
+from kimi_cli.auth.oauth import (
+    MIN_REFRESH_THRESHOLD_SECONDS,
+    REFRESH_THRESHOLD_RATIO,
+    OAuthError,
+    OAuthManager,
+    OAuthToken,
+    OAuthUnauthorized,
+    _save_to_file,
+    refresh_token,
+)
+from kimi_cli.config import Config, LLMModel, LLMProvider, OAuthRef, Services
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _make_token(
+    *,
+    expires_in: float = 900,
+    access: str = "access-123",
+    refresh: str = "refresh-123",
+) -> OAuthToken:
+    return OAuthToken(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=time.time() + expires_in,
+        scope="kimi-code",
+        token_type="Bearer",
+        expires_in=expires_in,
+    )
+
+
+def _make_config() -> Config:
+    provider = LLMProvider(
+        type="kimi",
+        base_url="https://api.test/v1",
+        api_key=SecretStr(""),
+        oauth=OAuthRef(storage="file", key="oauth/kimi-code"),
+    )
+    model = LLMModel(provider="managed:kimi-code", model="test-model", max_context_size=100_000)
+    return Config(
+        default_model="managed:kimi-code/test-model",
+        providers={"managed:kimi-code": provider},
+        models={"managed:kimi-code/test-model": model},
+        services=Services(),
+    )
+
+
+def _make_manager(token: OAuthToken | None = None) -> OAuthManager:
+    with patch("kimi_cli.auth.oauth.load_tokens", return_value=token):
+        return OAuthManager(_make_config())
+
+
+# ── P2: refresh_token retry on network errors ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_retries_on_network_error():
+    """refresh_token should retry up to max_retries on transient network errors."""
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 900,
+            "scope": "kimi-code",
+            "token_type": "Bearer",
+        }
+    )
+
+    call_count = 0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise aiohttp.ClientError("Connection reset")
+            return mock_response
+
+        async def __aexit__(self, *args):
+            pass
+
+    with patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()):
+        result = await refresh_token("old-refresh", max_retries=3)
+
+    assert result.access_token == "new-access"
+    assert call_count == 3  # Failed twice, succeeded third time
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_does_not_retry_on_unauthorized():
+    """OAuthUnauthorized should not be retried."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            mock_resp = MagicMock()
+            mock_resp.status = 401
+            mock_resp.json = AsyncMock(return_value={"error_description": "Token revoked"})
+            return mock_resp
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()),
+        pytest.raises(OAuthUnauthorized, match="Token revoked"),
+    ):
+        await refresh_token("bad-refresh", max_retries=3)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_raises_after_all_retries_exhausted():
+    """After max_retries network failures, should raise OAuthError."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            raise aiohttp.ClientError("Network down")
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()),
+        pytest.raises(OAuthError, match="after retries"),
+    ):
+        await refresh_token("some-refresh", max_retries=2)
+
+
+# ── P1: dynamic refresh threshold ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_uses_dynamic_threshold():
+    """Token with 7 minutes remaining and expires_in=900 should trigger refresh
+    (threshold = max(300, 900*0.5) = 450s, and 420s < 450s)."""
+    token = _make_token(expires_in=420)  # 7 minutes remaining
+    token.expires_in = 900  # Original lifetime was 15 min
+
+    manager = _make_manager(token)
+    mock_refresh = AsyncMock()
+
+    with (
+        patch("kimi_cli.auth.oauth.load_tokens", return_value=token),
+        patch.object(manager, "_refresh_lock", asyncio.Lock()),
+        patch("kimi_cli.auth.oauth.refresh_token", mock_refresh),
+    ):
+        mock_refresh.return_value = _make_token()
+        with patch("kimi_cli.auth.oauth.save_tokens"):
+            await manager.ensure_fresh()
+
+    mock_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_skips_when_plenty_of_time():
+    """Token with 8 minutes remaining and expires_in=900 should NOT trigger refresh
+    (threshold = 450s, and 480s > 450s)."""
+    token = _make_token(expires_in=480)  # 8 minutes remaining
+    token.expires_in = 900
+
+    manager = _make_manager(token)
+
+    with patch("kimi_cli.auth.oauth.load_tokens", return_value=token):
+        mock_refresh = AsyncMock()
+        with patch("kimi_cli.auth.oauth.refresh_token", mock_refresh):
+            await manager.ensure_fresh()
+
+    mock_refresh.assert_not_called()
+
+
+# ── P0: force refresh ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_force_bypasses_threshold():
+    """force=True should refresh even when token has plenty of time left."""
+    token = _make_token(expires_in=800)  # 13+ minutes remaining
+    manager = _make_manager(token)
+
+    mock_refresh = AsyncMock(return_value=_make_token())
+
+    with (
+        patch("kimi_cli.auth.oauth.load_tokens", return_value=token),
+        patch("kimi_cli.auth.oauth.refresh_token", mock_refresh),
+        patch("kimi_cli.auth.oauth.save_tokens"),
+    ):
+        await manager.ensure_fresh(force=True)
+
+    mock_refresh.assert_called_once()
+
+
+# ── P3: atomic file write ───────────────────────────────────────
+
+
+def test_save_to_file_is_atomic(tmp_path):
+    """_save_to_file should write atomically via temp file + rename."""
+    cred_dir = tmp_path / "credentials"
+    cred_dir.mkdir()
+    token = _make_token()
+
+    with patch("kimi_cli.auth.oauth._credentials_path", return_value=cred_dir / "test.json"):
+        _save_to_file("test", token)
+
+    saved = json.loads((cred_dir / "test.json").read_text())
+    assert saved["access_token"] == "access-123"
+    assert saved["expires_in"] == 900
+
+    # No temp files left behind
+    assert len(list(cred_dir.glob("*.tmp"))) == 0
+
+    # File permissions
+    stat = os.stat(cred_dir / "test.json")
+    assert stat.st_mode & 0o777 == 0o600
+
+
+def test_save_to_file_expires_in_roundtrip(tmp_path):
+    """expires_in field should survive save/load roundtrip."""
+    cred_dir = tmp_path / "credentials"
+    cred_dir.mkdir()
+    token = _make_token(expires_in=1800)
+
+    with patch("kimi_cli.auth.oauth._credentials_path", return_value=cred_dir / "test.json"):
+        _save_to_file("test", token)
+
+    saved = json.loads((cred_dir / "test.json").read_text())
+    restored = OAuthToken.from_dict(saved)
+    assert restored.expires_in == 1800
+
+
+def test_oauth_token_from_dict_defaults_expires_in():
+    """Tokens from older versions (no expires_in) should default to 0."""
+    old_format = {
+        "access_token": "a",
+        "refresh_token": "r",
+        "expires_at": time.time() + 100,
+        "scope": "kimi-code",
+        "token_type": "Bearer",
+    }
+    token = OAuthToken.from_dict(old_format)
+    assert token.expires_in == 0


### PR DESCRIPTION
## Related Issue

Fixes frequent "Authorization failed, please check your login status" errors reported by multiple users who need to re-login 3-4 times per day. Root cause confirmed via 16-minute real-environment reproduction experiment.

## Root Cause Analysis

Access tokens expire after **15 minutes** (`expires_in=900`), but the retry logic (written in Sep 2025 for static API keys) never included 401 in the retryable set. When OAuth was grafted onto the codebase in Jan 2026, only **proactive** background refresh was added — no **reactive** 401-then-refresh-then-retry path. This fails under:

- Laptop sleep >15 minutes (event loop frozen, token expires)
- Network instability during the narrow 5-minute refresh window
- Long tool-call chains (>10 min) where token expires mid-turn
- Multiple kimi-cli instances racing on credential file writes

Confirmed via real token experiment on macOS: token expired at T+15:04, API returned 401 within 5 seconds. Manual `refresh_token()` + retry immediately recovered to 200.

## Changes

### Core fix: 401 reactive recovery (`kimisoul.py`)

`_run_with_connection_recovery()` now catches `APIStatusError(401)` for OAuth-enabled providers, calls `ensure_fresh(force=True)`, and retries the operation exactly once. Non-OAuth providers (plain API key) skip the retry to avoid useless latency.

### Token refresh hardening (`oauth.py`)

| Change | What | Why |
|--------|------|-----|
| `force=True` parameter | `ensure_fresh()` / `_refresh_tokens()` bypass expiry-threshold check | After 401, local `expires_at` may not have passed but server rejected the token |
| Dynamic refresh threshold | `max(300s, expires_in * 0.5)` instead of hardcoded 300s | 15-min tokens now get 7.5-min refresh window (7+ attempts vs 5) |
| Retry with backoff | `refresh_token()` retries 3x on network errors (1s, 2s, 4s) | Single network hiccup no longer burns the entire refresh window |
| Sleep/wake detection | Wall-clock elapsed check in refresh loop; force refresh if >2x interval | Catches laptop lid-close scenarios |
| `expires_in` on OAuthToken | Stored and persisted for proportional threshold | Backward-compatible (defaults to 0 for old tokens) |

### Credential file safety (`oauth.py`)

| Change | What | Why |
|--------|------|-----|
| Atomic writes | `tempfile.mkstemp()` + `os.replace()` | Prevents corrupt JSON from concurrent reads during write |
| Short-write guard | Check `os.write()` return value | Disk-pressure partial writes don't produce truncated JSON |
| chmod non-fatal | `suppress(OSError)` around `os.chmod` | Mounted volumes / restricted filesystems don't break token persistence |
| TOCTOU protection | `_load_from_file` catches `OSError` alongside `JSONDecodeError` | File deleted between `exists()` and `read_text()` returns None gracefully |

### Cross-process coordination (`oauth.py`)

| Change | What | Why |
|--------|------|-----|
| `_CrossProcessLock` | `fcntl.flock` (Unix) / `msvcrt.locking` (Windows) | Multiple kimi-cli instances (terminal + VS Code) coordinate refresh |
| Triple-check pattern | Check before lock -> acquire lock -> check again after lock | If another process refreshed while waiting, use its token |
| 5x retry + jitter | `asyncio.sleep(1 + random())` between lock attempts | Break thundering herd without blocking event loop |
| Graceful degradation | Lock failure logs warning, refresh proceeds uncoordinated | Lock is advisory — never blocks auth entirely |
| Windows fixes | Write `\0` sentinel for `msvcrt.locking`; explicit `LK_UNLCK` before close | `msvcrt` differs from `fcntl` in requiring pre-positioned bytes and explicit unlock |

### Token revocation handling (`oauth.py`)

| Change | What | Why |
|--------|------|-----|
| `delete_tokens(ref)` on revocation | Remove credential file when refresh token is truly rejected | Prevents stale token re-load on next cycle |
| 1-second grace window | Sleep before deletion to let concurrent instances persist rotated tokens | Avoids deleting another instance's freshly-written token |
| `if token.access_token:` guard | `ensure_fresh` won't apply empty access_token to runtime | Defense-in-depth against stale credential files |

### Tests (`tests/auth/test_oauth_refresh.py`)

9 new unit tests covering:
- Retry on transient network errors (success on 3rd attempt)
- No retry on `OAuthUnauthorized` (truly rejected)
- `OAuthError` raised after all retries exhausted
- Dynamic threshold triggers refresh at 50% lifetime
- Dynamic threshold skips when plenty of time remains
- `force=True` bypasses threshold
- Atomic file write (no temp files left, 0o600 permissions)
- `expires_in` roundtrip through save/load
- Backward compatibility with old token format (no `expires_in`)

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Laptop sleep >15 min | 401 -> "Authorization failed" -> must `/login` | 401 -> auto-refresh -> retry -> seamless |
| Network hiccup in refresh window | 5 chances, no retry on failure -> token expires | 7+ chances, 3x retry with backoff per attempt |
| Two instances refresh simultaneously | No coordination -> possible token file corruption | File lock + triple-check -> only one refreshes |
| Token truly revoked | Token file deleted (could race) | Delete under lock + grace window + empty-token guard |
| Non-OAuth provider gets 401 | Would still attempt useless refresh | Skips retry, surfaces error immediately |

## Reproduction

Confirmed with a 16-minute real-token experiment (`/tmp/kimi-auth-lab/`):
```
T+00:00  Token issued (expires_in=900)
T+10:03  Entered refresh window (remaining < 5 min) — intentionally not refreshing
T+15:04  API returned 401 (token expired 5 seconds ago)
T+16:05  Manual refresh + retry -> 200 OK (fix validated)
```

## Note on PR scope

This PR addresses the complete OAuth resilience stack. If preferred, it can be split into:
- **PR A** (core fix): 401 retry in `kimisoul.py` + `refresh_token()` retry with backoff (~50 LOC)
- **PR B** (hardening): Atomic writes, dynamic threshold, `expires_in` persistence
- **PR C** (coordination): Cross-process file lock

Happy to split if that helps review.

## Checklist

Automated tests pass (2200 existing + 9 new). `make gen-changelog` and `make gen-docs` are pending — will run before final merge.

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
