### PR TITLE
feat: supports list-sessions to list the existing sessions 

### DIFF
--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -152,6 +152,13 @@ def kimi(
             help="Continue the previous session for the working directory. Default: no.",
         ),
     ] = False,
+    list_sessions: Annotated[
+        bool,
+        typer.Option(
+            "--list-sessions",
+            help="List all sessions for the working directory and exit.",
+        ),
+    ] = False,
     config_string: Annotated[
         str | None,
         typer.Option(
@@ -433,6 +440,7 @@ def kimi(
         {
             "--continue": continue_,
             "--session": session_id is not None or _picker_mode,
+            "--list-sessions": list_sessions,
         },
         {
             "--config": config_string is not None,
@@ -524,6 +532,27 @@ def kimi(
         skills_dirs = [KaosPath.unsafe_from_local_path(p) for p in local_skills_dir]
 
     work_dir = KaosPath.unsafe_from_local_path(local_work_dir) if local_work_dir else KaosPath.cwd()
+
+    # Handle --list-sessions
+    if list_sessions:
+        from rich.console import Console
+
+        from kimi_cli.utils.datetime import format_relative_time
+
+        all_sessions = asyncio.run(Session.list(work_dir))
+        console = Console()
+
+        if not all_sessions:
+            console.print("[yellow]No sessions found for the working directory.[/yellow]")
+        else:
+            console.print(f"\n[bold]Sessions for {work_dir}:[/bold]\n")
+            for i, s in enumerate(all_sessions, 1):
+                time_str = format_relative_time(s.updated_at)
+                short_id = s.id[:8]
+                name = _strip_session_id_suffix(s.title, s.id)
+                console.print(f"{i}. [cyan]{name}[/cyan] ([dim]{short_id}[/dim]) - {time_str}")
+                console.print(f"   Resume: kimi -r {s.id}\n")
+        raise typer.Exit(0)
 
     # Tracks the most recently created/loaded session so that _reload_loop's
     # exception handler can clean it up even when _run() fails before returning.


### PR DESCRIPTION


<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

https://github.com/MoonshotAI/kimi-cli/issues/1814


## Description

<!-- Please describe your changes in detail. -->
Provide parameters `--list-sessions` for kimi-cli to list the existing sessions under the working directory

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
