### PR TITLE
fix(auth): retry with token refresh on 401 to prevent forced re-login

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -51,6 +51,7 @@ DEFAULT_OAUTH_HOST = "https://auth.kimi.com"
 KEYRING_SERVICE = "kimi-code"
 REFRESH_INTERVAL_SECONDS = 60
 REFRESH_THRESHOLD_SECONDS = 300
+_REFRESH_MAX_RETRIES = 3
 
 
 class OAuthError(RuntimeError):
@@ -359,26 +360,45 @@ async def _request_device_token(auth: DeviceAuthorization) -> tuple[int, dict[st
     return status, data
 
 
-async def refresh_token(refresh_token: str) -> OAuthToken:
-    async with (
-        new_client_session() as session,
-        session.post(
-            f"{_oauth_host().rstrip('/')}/api/oauth/token",
-            data={
-                "client_id": KIMI_CODE_CLIENT_ID,
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-            },
-            headers=_common_headers(),
-        ) as response,
-    ):
-        data = await response.json(content_type=None)
-        status = response.status
-    if status in (401, 403):
-        raise OAuthUnauthorized(data.get("error_description") or "Token refresh unauthorized.")
-    if status != 200:
-        raise OAuthError(data.get("error_description") or "Token refresh failed.")
-    return OAuthToken.from_response(data)
+async def refresh_token(
+    refresh_token: str, *, max_retries: int = _REFRESH_MAX_RETRIES
+) -> OAuthToken:
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            async with (
+                new_client_session() as session,
+                session.post(
+                    f"{_oauth_host().rstrip('/')}/api/oauth/token",
+                    data={
+                        "client_id": KIMI_CODE_CLIENT_ID,
+                        "grant_type": "refresh_token",
+                        "refresh_token": refresh_token,
+                    },
+                    headers=_common_headers(),
+                ) as response,
+            ):
+                data = await response.json(content_type=None)
+                status = response.status
+            if status in (401, 403):
+                raise OAuthUnauthorized(
+                    data.get("error_description") or "Token refresh unauthorized."
+                )
+            if status != 200:
+                raise OAuthError(data.get("error_description") or "Token refresh failed.")
+            return OAuthToken.from_response(data)
+        except OAuthUnauthorized:
+            raise
+        except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+            last_exc = exc
+            if attempt < max_retries - 1:
+                await asyncio.sleep(2**attempt)
+                logger.warning(
+                    "Token refresh attempt {attempt} failed, retrying: {error}",
+                    attempt=attempt + 1,
+                    error=exc,
+                )
+    raise OAuthError("Token refresh failed after retries.") from last_exc
 
 
 def _select_default_model_and_thinking(models: list[ModelInfo]) -> tuple[ModelInfo, bool] | None:
@@ -676,13 +696,15 @@ class OAuthManager:
                 return service.oauth
         return None
 
-    async def ensure_fresh(self, runtime: Runtime | None = None) -> None:
+    async def ensure_fresh(self, runtime: Runtime | None = None, *, force: bool = False) -> None:
         """Load persisted tokens, cache them, and refresh if close to expiry.
 
         Args:
             runtime: When provided the live LLM client's API key is updated
                 in-place.  Pass ``None`` for lightweight callers (e.g. title
                 generation) that only need the internal cache to be current.
+            force: When True, skip the expiry-threshold check and always
+                attempt a refresh.  Used after receiving a 401 from the server.
         """
         ref = self._kimi_code_ref()
         if ref is None:
@@ -691,8 +713,9 @@ class OAuthManager:
         if token is None:
             return
         self._cache_access_token(ref, token)
-        self._apply_access_token(runtime, token.access_token)
-        await self._refresh_tokens(ref, token, runtime)
+        if token.access_token:
+            self._apply_access_token(runtime, token.access_token)
+        await self._refresh_tokens(ref, token, runtime, force=force)
 
     @asynccontextmanager
     async def refreshing(self, runtime: Runtime) -> AsyncIterator[None]:
@@ -734,6 +757,8 @@ class OAuthManager:
         ref: OAuthRef,
         token: OAuthToken,
         runtime: Runtime | None,
+        *,
+        force: bool = False,
     ) -> None:
         # Always prefer persisted tokens before refresh to avoid stale cache
         # when multiple sessions might have already rotated the refresh token.
@@ -749,13 +774,14 @@ class OAuthManager:
             if persisted:
                 self._cache_access_token(ref, persisted)
             current = persisted or current_token
-            now = time.time()
-            if (
-                current.expires_at
-                and current.expires_at > now
-                and current.expires_at - now >= REFRESH_THRESHOLD_SECONDS
-            ):
-                return
+            if not force:
+                now = time.time()
+                if (
+                    current.expires_at
+                    and current.expires_at > now
+                    and current.expires_at - now >= REFRESH_THRESHOLD_SECONDS
+                ):
+                    return
             refresh_token_value = current.refresh_token
             if not refresh_token_value:
                 return

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -1069,6 +1069,29 @@ class KimiSoul:
     ) -> Any:
         try:
             return await operation()
+        except APIStatusError as error:
+            if error.status_code != 401:
+                raise
+            # Only attempt refresh+retry when the active model's provider
+            # uses OAuth.  For plain API-key providers there is nothing
+            # to refresh and retrying would just add latency.
+            active_provider = (
+                self._runtime.config.providers.get(self._runtime.llm.model_config.provider)
+                if self._runtime.llm and self._runtime.llm.model_config
+                else None
+            )
+            if not (active_provider and active_provider.oauth):
+                raise
+            logger.warning(
+                "Received 401 during {name}, attempting token refresh",
+                name=name,
+            )
+            try:
+                await self._runtime.oauth.ensure_fresh(self._runtime, force=True)
+            except Exception as refresh_exc:
+                logger.exception("Token refresh failed after 401.")
+                raise error from refresh_exc
+            return await operation()
         except (APIConnectionError, APITimeoutError) as error:
             if not isinstance(chat_provider, RetryableChatProvider):
                 raise

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -1,0 +1,183 @@
+"""Tests for OAuth token refresh: retry with backoff and force refresh."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from pydantic import SecretStr
+
+from kimi_cli.auth.oauth import (
+    OAuthError,
+    OAuthManager,
+    OAuthToken,
+    OAuthUnauthorized,
+    refresh_token,
+)
+from kimi_cli.config import Config, LLMModel, LLMProvider, OAuthRef, Services
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _make_token(
+    *,
+    expires_in: float = 900,
+    access: str = "access-123",
+    refresh: str = "refresh-123",
+) -> OAuthToken:
+    return OAuthToken(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=time.time() + expires_in,
+        scope="kimi-code",
+        token_type="Bearer",
+    )
+
+
+def _make_config() -> Config:
+    provider = LLMProvider(
+        type="kimi",
+        base_url="https://api.test/v1",
+        api_key=SecretStr(""),
+        oauth=OAuthRef(storage="file", key="oauth/kimi-code"),
+    )
+    model = LLMModel(provider="managed:kimi-code", model="test-model", max_context_size=100_000)
+    return Config(
+        default_model="managed:kimi-code/test-model",
+        providers={"managed:kimi-code": provider},
+        models={"managed:kimi-code/test-model": model},
+        services=Services(),
+    )
+
+
+def _make_manager(token: OAuthToken | None = None) -> OAuthManager:
+    with patch("kimi_cli.auth.oauth.load_tokens", return_value=token):
+        return OAuthManager(_make_config())
+
+
+# ── refresh_token retry on network errors ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_retries_on_network_error():
+    """refresh_token should retry up to max_retries on transient network errors."""
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 900,
+            "scope": "kimi-code",
+            "token_type": "Bearer",
+        }
+    )
+
+    call_count = 0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise aiohttp.ClientError("Connection reset")
+            return mock_response
+
+        async def __aexit__(self, *args):
+            pass
+
+    with patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()):
+        result = await refresh_token("old-refresh", max_retries=3)
+
+    assert result.access_token == "new-access"
+    assert call_count == 3  # Failed twice, succeeded third time
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_does_not_retry_on_unauthorized():
+    """OAuthUnauthorized should not be retried."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            mock_resp = MagicMock()
+            mock_resp.status = 401
+            mock_resp.json = AsyncMock(return_value={"error_description": "Token revoked"})
+            return mock_resp
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()),
+        pytest.raises(OAuthUnauthorized, match="Token revoked"),
+    ):
+        await refresh_token("bad-refresh", max_retries=3)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_raises_after_all_retries_exhausted():
+    """After max_retries network failures, should raise OAuthError."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            raise aiohttp.ClientError("Network down")
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()),
+        pytest.raises(OAuthError, match="after retries"),
+    ):
+        await refresh_token("some-refresh", max_retries=2)
+
+
+# ── force refresh ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_force_bypasses_threshold():
+    """force=True should refresh even when token has plenty of time left."""
+    token = _make_token(expires_in=800)  # 13+ minutes remaining
+    manager = _make_manager(token)
+
+    mock_refresh = AsyncMock(return_value=_make_token())
+
+    with (
+        patch("kimi_cli.auth.oauth.load_tokens", return_value=token),
+        patch("kimi_cli.auth.oauth.refresh_token", mock_refresh),
+        patch("kimi_cli.auth.oauth.save_tokens"),
+    ):
+        await manager.ensure_fresh(force=True)
+
+    mock_refresh.assert_called_once()


### PR DESCRIPTION
## Related Issue

Fixes frequent "Authorization failed" errors that force users to re-login 3-4 times per day. Confirmed via 16-minute real-token experiment: access tokens expire after 15 minutes, but the code had no reactive recovery path.

## Root Cause

The retry logic (`_is_retryable_error`, written Sep 2025 for static API keys) never included 401. When OAuth was added in Jan 2026, only proactive background refresh was implemented — no reactive 401→refresh→retry. This fails on laptop sleep >15 min, network hiccups, or long tool-call chains.

## Changes (minimal, ~260 LOC)

**`src/kimi_cli/auth/oauth.py`:**
- `ensure_fresh(force=True)` / `_refresh_tokens(force=True)` — bypass expiry-threshold check after 401 (server already rejected the token)
- `refresh_token()` retries 3x with exponential backoff (1s, 2s, 4s) on transient network errors; `OAuthUnauthorized` is never retried
- `ensure_fresh` guards `_apply_access_token` with `if token.access_token:` to prevent empty token overwrite

**`src/kimi_cli/soul/kimisoul.py`:**
- `_run_with_connection_recovery()` catches 401, checks active provider has OAuth, calls `ensure_fresh(force=True)`, retries once
- Non-OAuth providers skip retry (no useless latency)
- `raise error from refresh_exc` preserves both the 401 and refresh failure for diagnostics

**`tests/auth/test_oauth_refresh.py`** — 4 new tests:
- Retry succeeds on 3rd attempt after transient errors
- `OAuthUnauthorized` raises immediately (no retry)
- `OAuthError` after all retries exhausted
- `force=True` bypasses threshold check

## Follow-up PRs

This is intentionally minimal. Planned follow-ups:
- **Token lifecycle hardening**: dynamic refresh threshold, atomic credential writes, sleep/wake detection, revocation cleanup
- **Cross-process lock**: multi-instance coordination via fcntl/msvcrt

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
