### PR TITLE
fix(auth): harden token lifecycle with dynamic threshold, atomic writes, and revocation cleanup

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -51,6 +51,7 @@ DEFAULT_OAUTH_HOST = "https://auth.kimi.com"
 KEYRING_SERVICE = "kimi-code"
 REFRESH_INTERVAL_SECONDS = 60
 REFRESH_THRESHOLD_SECONDS = 300
+_REFRESH_MAX_RETRIES = 3
 
 
 class OAuthError(RuntimeError):
@@ -359,26 +360,45 @@ async def _request_device_token(auth: DeviceAuthorization) -> tuple[int, dict[st
     return status, data
 
 
-async def refresh_token(refresh_token: str) -> OAuthToken:
-    async with (
-        new_client_session() as session,
-        session.post(
-            f"{_oauth_host().rstrip('/')}/api/oauth/token",
-            data={
-                "client_id": KIMI_CODE_CLIENT_ID,
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-            },
-            headers=_common_headers(),
-        ) as response,
-    ):
-        data = await response.json(content_type=None)
-        status = response.status
-    if status in (401, 403):
-        raise OAuthUnauthorized(data.get("error_description") or "Token refresh unauthorized.")
-    if status != 200:
-        raise OAuthError(data.get("error_description") or "Token refresh failed.")
-    return OAuthToken.from_response(data)
+async def refresh_token(
+    refresh_token: str, *, max_retries: int = _REFRESH_MAX_RETRIES
+) -> OAuthToken:
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            async with (
+                new_client_session() as session,
+                session.post(
+                    f"{_oauth_host().rstrip('/')}/api/oauth/token",
+                    data={
+                        "client_id": KIMI_CODE_CLIENT_ID,
+                        "grant_type": "refresh_token",
+                        "refresh_token": refresh_token,
+                    },
+                    headers=_common_headers(),
+                ) as response,
+            ):
+                data = await response.json(content_type=None)
+                status = response.status
+            if status in (401, 403):
+                raise OAuthUnauthorized(
+                    data.get("error_description") or "Token refresh unauthorized."
+                )
+            if status != 200:
+                raise OAuthError(data.get("error_description") or "Token refresh failed.")
+            return OAuthToken.from_response(data)
+        except OAuthUnauthorized:
+            raise
+        except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+            last_exc = exc
+            if attempt < max_retries - 1:
+                await asyncio.sleep(2**attempt)
+                logger.warning(
+                    "Token refresh attempt {attempt} failed, retrying: {error}",
+                    attempt=attempt + 1,
+                    error=exc,
+                )
+    raise OAuthError("Token refresh failed after retries.") from last_exc
 
 
 def _select_default_model_and_thinking(models: list[ModelInfo]) -> tuple[ModelInfo, bool] | None:
@@ -676,13 +696,15 @@ class OAuthManager:
                 return service.oauth
         return None
 
-    async def ensure_fresh(self, runtime: Runtime | None = None) -> None:
+    async def ensure_fresh(self, runtime: Runtime | None = None, *, force: bool = False) -> None:
         """Load persisted tokens, cache them, and refresh if close to expiry.
 
         Args:
             runtime: When provided the live LLM client's API key is updated
                 in-place.  Pass ``None`` for lightweight callers (e.g. title
                 generation) that only need the internal cache to be current.
+            force: When True, skip the expiry-threshold check and always
+                attempt a refresh.  Used after receiving a 401 from the server.
         """
         ref = self._kimi_code_ref()
         if ref is None:
@@ -691,8 +713,9 @@ class OAuthManager:
         if token is None:
             return
         self._cache_access_token(ref, token)
-        self._apply_access_token(runtime, token.access_token)
-        await self._refresh_tokens(ref, token, runtime)
+        if token.access_token:
+            self._apply_access_token(runtime, token.access_token)
+        await self._refresh_tokens(ref, token, runtime, force=force)
 
     @asynccontextmanager
     async def refreshing(self, runtime: Runtime) -> AsyncIterator[None]:
@@ -734,6 +757,8 @@ class OAuthManager:
         ref: OAuthRef,
         token: OAuthToken,
         runtime: Runtime | None,
+        *,
+        force: bool = False,
     ) -> None:
         # Always prefer persisted tokens before refresh to avoid stale cache
         # when multiple sessions might have already rotated the refresh token.
@@ -749,13 +774,14 @@ class OAuthManager:
             if persisted:
                 self._cache_access_token(ref, persisted)
             current = persisted or current_token
-            now = time.time()
-            if (
-                current.expires_at
-                and current.expires_at > now
-                and current.expires_at - now >= REFRESH_THRESHOLD_SECONDS
-            ):
-                return
+            if not force:
+                now = time.time()
+                if (
+                    current.expires_at
+                    and current.expires_at > now
+                    and current.expires_at - now >= REFRESH_THRESHOLD_SECONDS
+                ):
+                    return
             refresh_token_value = current.refresh_token
             if not refresh_token_value:
                 return

--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -4,8 +4,10 @@ import asyncio
 import json
 import os
 import platform
+import random
 import socket
 import sys
+import tempfile
 import time
 import uuid
 import webbrowser
@@ -50,8 +52,9 @@ KIMI_CODE_OAUTH_KEY = "oauth/kimi-code"
 DEFAULT_OAUTH_HOST = "https://auth.kimi.com"
 KEYRING_SERVICE = "kimi-code"
 REFRESH_INTERVAL_SECONDS = 60
-REFRESH_THRESHOLD_SECONDS = 300
-_REFRESH_MAX_RETRIES = 3
+MIN_REFRESH_THRESHOLD_SECONDS = 300
+REFRESH_THRESHOLD_RATIO = 0.5
+_CROSS_PROCESS_LOCK_RETRIES = 5
 
 
 class OAuthError(RuntimeError):
@@ -93,6 +96,7 @@ class OAuthToken:
     expires_at: float
     scope: str
     token_type: str
+    expires_in: float = 0.0
 
     @classmethod
     def from_response(cls, payload: dict[str, Any]) -> OAuthToken:
@@ -103,6 +107,7 @@ class OAuthToken:
             expires_at=time.time() + expires_in,
             scope=str(payload["scope"]),
             token_type=str(payload["token_type"]),
+            expires_in=expires_in,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -112,6 +117,7 @@ class OAuthToken:
             "expires_at": self.expires_at,
             "scope": self.scope,
             "token_type": self.token_type,
+            "expires_in": self.expires_in,
         }
 
     @classmethod
@@ -123,6 +129,7 @@ class OAuthToken:
             expires_at=float(expires_at_value) if expires_at_value is not None else 0.0,
             scope=str(payload.get("scope") or ""),
             token_type=str(payload.get("token_type") or ""),
+            expires_in=float(payload.get("expires_in") or 0),
         )
 
 
@@ -227,6 +234,74 @@ def _credentials_path(key: str) -> Path:
     return _credentials_dir() / f"{name}.json"
 
 
+def _credentials_lock_path(key: str) -> Path:
+    name = key.removeprefix("oauth/").split("/")[-1] or key
+    return _credentials_dir() / f"{name}.lock"
+
+
+class _CrossProcessLock:
+    """File-based lock that coordinates token refresh across kimi-cli processes.
+
+    Uses fcntl.flock on Unix and msvcrt.locking on Windows.
+    """
+
+    def __init__(self, key: str) -> None:
+        self._path = _credentials_lock_path(key)
+        self._fd: int | None = None
+
+    def _acquire(self) -> bool:
+        try:
+            self._fd = os.open(str(self._path), os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError:
+            return False
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+
+                # msvcrt.locking requires bytes to exist at the lock position.
+                if os.fstat(self._fd).st_size == 0:
+                    os.write(self._fd, b"\0")
+                    os.lseek(self._fd, 0, os.SEEK_SET)
+                msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            os.close(self._fd)
+            self._fd = None
+            return False
+
+    def release(self) -> None:
+        if self._fd is not None:
+            try:
+                if sys.platform == "win32":
+                    import msvcrt
+
+                    with suppress(OSError):
+                        os.lseek(self._fd, 0, os.SEEK_SET)
+                        msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+            finally:
+                with suppress(OSError):
+                    os.close(self._fd)
+                self._fd = None
+
+    async def acquire_with_retry(self) -> bool:
+        for _attempt in range(_CROSS_PROCESS_LOCK_RETRIES):
+            if self._acquire():
+                return True
+            await asyncio.sleep(1 + random.random())
+            # After waiting, re-check if the token was refreshed by the holder.
+        return self._acquire()
+
+    async def __aenter__(self) -> bool:
+        return await self.acquire_with_retry()
+
+    async def __aexit__(self, *args: object) -> None:
+        self.release()
+
+
 def _load_from_keyring(key: str) -> OAuthToken | None:
     try:
         raw = keyring.get_password(KEYRING_SERVICE, key)
@@ -258,7 +333,7 @@ def _load_from_file(key: str) -> OAuthToken | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, OSError):
         return None
     if not isinstance(payload, dict):
         return None
@@ -268,8 +343,24 @@ def _load_from_file(key: str) -> OAuthToken | None:
 
 def _save_to_file(key: str, token: OAuthToken) -> None:
     path = _credentials_path(key)
-    path.write_text(json.dumps(token.to_dict(), ensure_ascii=False), encoding="utf-8")
-    _ensure_private_file(path)
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        data = json.dumps(token.to_dict(), ensure_ascii=False).encode("utf-8")
+        written = os.write(fd, data)
+        if written != len(data):
+            raise OSError(f"Short write: {written}/{len(data)} bytes")
+        os.close(fd)
+        fd = -1
+        with suppress(OSError):
+            os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except BaseException:
+        if fd >= 0:
+            with suppress(OSError):
+                os.close(fd)
+        with suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
 
 def _delete_from_file(key: str) -> None:
@@ -360,9 +451,7 @@ async def _request_device_token(auth: DeviceAuthorization) -> tuple[int, dict[st
     return status, data
 
 
-async def refresh_token(
-    refresh_token: str, *, max_retries: int = _REFRESH_MAX_RETRIES
-) -> OAuthToken:
+async def refresh_token(refresh_token: str, *, max_retries: int = 3) -> OAuthToken:
     last_exc: Exception | None = None
     for attempt in range(max_retries):
         try:
@@ -724,6 +813,7 @@ class OAuthManager:
         async def _runner() -> None:
             try:
                 while True:
+                    wall_before = time.time()
                     try:
                         await asyncio.wait_for(
                             stop_event.wait(),
@@ -732,8 +822,16 @@ class OAuthManager:
                         return
                     except TimeoutError:
                         pass
+                    elapsed = time.time() - wall_before
+                    force = elapsed > REFRESH_INTERVAL_SECONDS * 2
+                    if force:
+                        logger.info(
+                            "Detected possible sleep/wake ({elapsed:.0f}s elapsed), "
+                            "forcing token refresh.",
+                            elapsed=elapsed,
+                        )
                     try:
-                        await self.ensure_fresh(runtime)
+                        await self.ensure_fresh(runtime, force=force)
                     except Exception as exc:
                         logger.warning(
                             "Failed to refresh OAuth token in background: {error}",
@@ -769,46 +867,90 @@ class OAuthManager:
         if not current_token.refresh_token:
             return
         async with self._refresh_lock:
-            # Re-check persisted token inside the lock to reduce races.
+            # Re-check persisted token inside the in-process lock.
             persisted = load_tokens(ref)
             if persisted:
                 self._cache_access_token(ref, persisted)
             current = persisted or current_token
             if not force:
                 now = time.time()
+                threshold = (
+                    max(MIN_REFRESH_THRESHOLD_SECONDS, current.expires_in * REFRESH_THRESHOLD_RATIO)
+                    if current.expires_in > 0
+                    else MIN_REFRESH_THRESHOLD_SECONDS
+                )
                 if (
                     current.expires_at
                     and current.expires_at > now
-                    and current.expires_at - now >= REFRESH_THRESHOLD_SECONDS
+                    and current.expires_at - now >= threshold
                 ):
                     return
             refresh_token_value = current.refresh_token
             if not refresh_token_value:
                 return
+
+            # Acquire cross-process file lock to coordinate with other
+            # kimi-cli instances (terminal, VS Code, web).
+            xlock = _CrossProcessLock(ref.key)
+            acquired = await xlock.acquire_with_retry()
             try:
-                refreshed = await refresh_token(refresh_token_value)
-            except OAuthUnauthorized as exc:
-                # If another session refreshed and persisted a new token,
-                # do not delete it. Just sync memory and exit.
-                latest = load_tokens(ref)
-                if latest and latest.refresh_token != refresh_token_value:
-                    self._cache_access_token(ref, latest)
-                    self._apply_access_token(runtime, latest.access_token)
+                if acquired:
+                    # Triple-check after acquiring the lock — another process
+                    # may have refreshed while we waited.
+                    locked_token = load_tokens(ref)
+                    if locked_token and locked_token.refresh_token != refresh_token_value:
+                        self._cache_access_token(ref, locked_token)
+                        self._apply_access_token(runtime, locked_token.access_token)
+                        return
+                    if not force and locked_token:
+                        remaining = locked_token.expires_at - time.time()
+                        t = (
+                            max(
+                                MIN_REFRESH_THRESHOLD_SECONDS,
+                                locked_token.expires_in * REFRESH_THRESHOLD_RATIO,
+                            )
+                            if locked_token.expires_in > 0
+                            else MIN_REFRESH_THRESHOLD_SECONDS
+                        )
+                        if locked_token.expires_at and remaining >= t:
+                            self._cache_access_token(ref, locked_token)
+                            self._apply_access_token(runtime, locked_token.access_token)
+                            return
+                else:
+                    logger.warning("Could not acquire cross-process lock for token refresh")
+
+                try:
+                    refreshed = await refresh_token(refresh_token_value)
+                except OAuthUnauthorized as exc:
+                    # Give a concurrent instance time to persist its rotated token.
+                    await asyncio.sleep(1)
+                    latest = load_tokens(ref)
+                    if latest and latest.refresh_token != refresh_token_value:
+                        self._cache_access_token(ref, latest)
+                        self._apply_access_token(runtime, latest.access_token)
+                        return
+                    # Delete the revoked credential file so that:
+                    # 1. load_tokens returns None on subsequent calls,
+                    #    preventing ensure_fresh from applying an empty
+                    #    access_token to the live client.
+                    # 2. resolve_api_key falls back to the configured
+                    #    api_key immediately.
+                    delete_tokens(ref)
+                    logger.warning(
+                        "OAuth credentials rejected: {error}",
+                        error=exc,
+                    )
+                    self._access_tokens.pop(ref.key, None)
+                    self._apply_access_token(runtime, "")
                     return
-                logger.warning(
-                    "OAuth credentials rejected, deleting stored tokens: {error}",
-                    error=exc,
-                )
-                self._access_tokens.pop(ref.key, None)
-                delete_tokens(ref)
-                self._apply_access_token(runtime, "")
-                return
-            except Exception as exc:
-                logger.warning("Failed to refresh OAuth token: {error}", error=exc)
-                return
-            save_tokens(ref, refreshed)
-            self._cache_access_token(ref, refreshed)
-            self._apply_access_token(runtime, refreshed.access_token)
+                except Exception as exc:
+                    logger.warning("Failed to refresh OAuth token: {error}", error=exc)
+                    return
+                save_tokens(ref, refreshed)
+                self._cache_access_token(ref, refreshed)
+                self._apply_access_token(runtime, refreshed.access_token)
+            finally:
+                xlock.release()
 
     def _apply_access_token(self, runtime: Runtime | None, access_token: str) -> None:
         if runtime is None:

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -1069,6 +1069,29 @@ class KimiSoul:
     ) -> Any:
         try:
             return await operation()
+        except APIStatusError as error:
+            if error.status_code != 401:
+                raise
+            # Only attempt refresh+retry when the active model's provider
+            # uses OAuth.  For plain API-key providers there is nothing
+            # to refresh and retrying would just add latency.
+            active_provider = (
+                self._runtime.config.providers.get(self._runtime.llm.model_config.provider)
+                if self._runtime.llm and self._runtime.llm.model_config
+                else None
+            )
+            if not (active_provider and active_provider.oauth):
+                raise
+            logger.warning(
+                "Received 401 during {name}, attempting token refresh",
+                name=name,
+            )
+            try:
+                await self._runtime.oauth.ensure_fresh(self._runtime, force=True)
+            except Exception as refresh_exc:
+                logger.exception("Token refresh failed after 401.")
+                raise error from refresh_exc
+            return await operation()
         except (APIConnectionError, APITimeoutError) as error:
             if not isinstance(chat_provider, RetryableChatProvider):
                 raise

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -1,5 +1,8 @@
-"""Tests for OAuth token refresh: retry with backoff and force refresh."""
+"""Tests for OAuth token refresh: retry, force refresh, atomic write, and 401 recovery."""
 
+import asyncio
+import json
+import os
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +15,7 @@ from kimi_cli.auth.oauth import (
     OAuthManager,
     OAuthToken,
     OAuthUnauthorized,
+    _save_to_file,
     refresh_token,
 )
 from kimi_cli.config import Config, LLMModel, LLMProvider, OAuthRef, Services
@@ -31,6 +35,7 @@ def _make_token(
         expires_at=time.time() + expires_in,
         scope="kimi-code",
         token_type="Bearer",
+        expires_in=expires_in,
     )
 
 
@@ -55,7 +60,7 @@ def _make_manager(token: OAuthToken | None = None) -> OAuthManager:
         return OAuthManager(_make_config())
 
 
-# ── refresh_token retry on network errors ──────────────────────
+# ── P2: refresh_token retry on network errors ────────────────────
 
 
 @pytest.mark.asyncio
@@ -162,7 +167,49 @@ async def test_refresh_token_raises_after_all_retries_exhausted():
         await refresh_token("some-refresh", max_retries=2)
 
 
-# ── force refresh ──────────────────────────────────────────────
+# ── P1: dynamic refresh threshold ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_uses_dynamic_threshold():
+    """Token with 7 minutes remaining and expires_in=900 should trigger refresh
+    (threshold = max(300, 900*0.5) = 450s, and 420s < 450s)."""
+    token = _make_token(expires_in=420)  # 7 minutes remaining
+    token.expires_in = 900  # Original lifetime was 15 min
+
+    manager = _make_manager(token)
+    mock_refresh = AsyncMock()
+
+    with (
+        patch("kimi_cli.auth.oauth.load_tokens", return_value=token),
+        patch.object(manager, "_refresh_lock", asyncio.Lock()),
+        patch("kimi_cli.auth.oauth.refresh_token", mock_refresh),
+    ):
+        mock_refresh.return_value = _make_token()
+        with patch("kimi_cli.auth.oauth.save_tokens"):
+            await manager.ensure_fresh()
+
+    mock_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_skips_when_plenty_of_time():
+    """Token with 8 minutes remaining and expires_in=900 should NOT trigger refresh
+    (threshold = 450s, and 480s > 450s)."""
+    token = _make_token(expires_in=480)  # 8 minutes remaining
+    token.expires_in = 900
+
+    manager = _make_manager(token)
+
+    with patch("kimi_cli.auth.oauth.load_tokens", return_value=token):
+        mock_refresh = AsyncMock()
+        with patch("kimi_cli.auth.oauth.refresh_token", mock_refresh):
+            await manager.ensure_fresh()
+
+    mock_refresh.assert_not_called()
+
+
+# ── P0: force refresh ───────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -181,3 +228,54 @@ async def test_ensure_fresh_force_bypasses_threshold():
         await manager.ensure_fresh(force=True)
 
     mock_refresh.assert_called_once()
+
+
+# ── P3: atomic file write ───────────────────────────────────────
+
+
+def test_save_to_file_is_atomic(tmp_path):
+    """_save_to_file should write atomically via temp file + rename."""
+    cred_dir = tmp_path / "credentials"
+    cred_dir.mkdir()
+    token = _make_token()
+
+    with patch("kimi_cli.auth.oauth._credentials_path", return_value=cred_dir / "test.json"):
+        _save_to_file("test", token)
+
+    saved = json.loads((cred_dir / "test.json").read_text())
+    assert saved["access_token"] == "access-123"
+    assert saved["expires_in"] == 900
+
+    # No temp files left behind
+    assert len(list(cred_dir.glob("*.tmp"))) == 0
+
+    # File permissions
+    stat = os.stat(cred_dir / "test.json")
+    assert stat.st_mode & 0o777 == 0o600
+
+
+def test_save_to_file_expires_in_roundtrip(tmp_path):
+    """expires_in field should survive save/load roundtrip."""
+    cred_dir = tmp_path / "credentials"
+    cred_dir.mkdir()
+    token = _make_token(expires_in=1800)
+
+    with patch("kimi_cli.auth.oauth._credentials_path", return_value=cred_dir / "test.json"):
+        _save_to_file("test", token)
+
+    saved = json.loads((cred_dir / "test.json").read_text())
+    restored = OAuthToken.from_dict(saved)
+    assert restored.expires_in == 1800
+
+
+def test_oauth_token_from_dict_defaults_expires_in():
+    """Tokens from older versions (no expires_in) should default to 0."""
+    old_format = {
+        "access_token": "a",
+        "refresh_token": "r",
+        "expires_at": time.time() + 100,
+        "scope": "kimi-code",
+        "token_type": "Bearer",
+    }
+    token = OAuthToken.from_dict(old_format)
+    assert token.expires_in == 0

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -1,0 +1,183 @@
+"""Tests for OAuth token refresh: retry with backoff and force refresh."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from pydantic import SecretStr
+
+from kimi_cli.auth.oauth import (
+    OAuthError,
+    OAuthManager,
+    OAuthToken,
+    OAuthUnauthorized,
+    refresh_token,
+)
+from kimi_cli.config import Config, LLMModel, LLMProvider, OAuthRef, Services
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _make_token(
+    *,
+    expires_in: float = 900,
+    access: str = "access-123",
+    refresh: str = "refresh-123",
+) -> OAuthToken:
+    return OAuthToken(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=time.time() + expires_in,
+        scope="kimi-code",
+        token_type="Bearer",
+    )
+
+
+def _make_config() -> Config:
+    provider = LLMProvider(
+        type="kimi",
+        base_url="https://api.test/v1",
+        api_key=SecretStr(""),
+        oauth=OAuthRef(storage="file", key="oauth/kimi-code"),
+    )
+    model = LLMModel(provider="managed:kimi-code", model="test-model", max_context_size=100_000)
+    return Config(
+        default_model="managed:kimi-code/test-model",
+        providers={"managed:kimi-code": provider},
+        models={"managed:kimi-code/test-model": model},
+        services=Services(),
+    )
+
+
+def _make_manager(token: OAuthToken | None = None) -> OAuthManager:
+    with patch("kimi_cli.auth.oauth.load_tokens", return_value=token):
+        return OAuthManager(_make_config())
+
+
+# ── refresh_token retry on network errors ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_retries_on_network_error():
+    """refresh_token should retry up to max_retries on transient network errors."""
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 900,
+            "scope": "kimi-code",
+            "token_type": "Bearer",
+        }
+    )
+
+    call_count = 0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise aiohttp.ClientError("Connection reset")
+            return mock_response
+
+        async def __aexit__(self, *args):
+            pass
+
+    with patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()):
+        result = await refresh_token("old-refresh", max_retries=3)
+
+    assert result.access_token == "new-access"
+    assert call_count == 3  # Failed twice, succeeded third time
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_does_not_retry_on_unauthorized():
+    """OAuthUnauthorized should not be retried."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            mock_resp = MagicMock()
+            mock_resp.status = 401
+            mock_resp.json = AsyncMock(return_value={"error_description": "Token revoked"})
+            return mock_resp
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()),
+        pytest.raises(OAuthUnauthorized, match="Token revoked"),
+    ):
+        await refresh_token("bad-refresh", max_retries=3)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_raises_after_all_retries_exhausted():
+    """After max_retries network failures, should raise OAuthError."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return FakeContext()
+
+    class FakeContext:
+        async def __aenter__(self):
+            raise aiohttp.ClientError("Network down")
+
+        async def __aexit__(self, *args):
+            pass
+
+    with (
+        patch("kimi_cli.auth.oauth.new_client_session", return_value=FakeSession()),
+        pytest.raises(OAuthError, match="after retries"),
+    ):
+        await refresh_token("some-refresh", max_retries=2)
+
+
+# ── force refresh ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_force_bypasses_threshold():
+    """force=True should refresh even when token has plenty of time left."""
+    token = _make_token(expires_in=800)  # 13+ minutes remaining
+    manager = _make_manager(token)
+
+    mock_refresh = AsyncMock(return_value=_make_token())
+
+    with (
+        patch("kimi_cli.auth.oauth.load_tokens", return_value=token),
+        patch("kimi_cli.auth.oauth.refresh_token", mock_refresh),
+        patch("kimi_cli.auth.oauth.save_tokens"),
+    ):
+        await manager.ensure_fresh(force=True)
+
+    mock_refresh.assert_called_once()


### PR DESCRIPTION
## Related Issue

Follow-up to #1819 (401 retry core fix). Hardens the OAuth token lifecycle against edge cases discovered during investigation.

## Description

Builds on the 401 retry fix (#1819) with additional resilience:

### Dynamic refresh threshold
- `max(300s, expires_in * 0.5)` instead of hardcoded 300s
- 15-minute tokens now get 7.5-minute refresh window (7+ attempts instead of 5)
- `expires_in` stored on `OAuthToken` for proportional calculation (backward-compatible, defaults to 0)

### Atomic credential writes
- `_save_to_file` uses `tempfile.mkstemp()` + `os.replace()` (POSIX atomic)
- Short-write guard: checks `os.write()` return value
- `chmod(0o600)` wrapped in `suppress(OSError)` for restricted filesystems
- `_load_from_file` catches `OSError` for TOCTOU protection

### Sleep/wake detection
- Background refresh loop compares wall-clock elapsed time
- Forces immediate refresh when `elapsed > 2x interval` (laptop lid close)

### Token revocation cleanup
- `delete_tokens(ref)` on truly revoked tokens (with 1s grace window for concurrent rotation)
- `if token.access_token:` guard prevents empty token from overwriting runtime key

### Cross-process coordination
- `_CrossProcessLock` using `fcntl.flock` (Unix) / `msvcrt.locking` (Windows)
- Triple-check pattern: check → acquire lock → check again
- 5x retry with jitter; graceful degradation on lock failure
- Lock file created with 0o600 permissions
- Windows: sentinel byte for msvcrt, explicit unlock before close, fd leak prevention

## Tests

5 additional tests (on top of #1819's 4):
- Dynamic threshold triggers/skips correctly
- Atomic write produces correct file with 0o600 permissions
- `expires_in` roundtrip through save/load
- Backward compatibility with old token format

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
