### PR TITLE
fix(context): cap list_directory to 500 entries (GH-1809)

### DIFF
--- a/src/kimi_cli/agents/default/system.md
+++ b/src/kimi_cli/agents/default/system.md
@@ -90,7 +90,7 @@ The directory listing of current working directory is:
 ${KIMI_WORK_DIR_LS}
 ```
 
-Use this as your basic understanding of the project structure.
+Use this as your basic understanding of the project structure. The tree only shows the first two levels; entries marked "... and N more" indicate additional contents — use Glob or Shell to explore further.
 {% if KIMI_ADDITIONAL_DIRS_INFO %}
 
 ## Additional Directories

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -55,6 +55,9 @@ async def next_available_rotation(path: Path) -> Path | None:
         next_num += 1
 
 
+_LIST_DIR_MAX_ENTRIES = 500
+
+
 async def list_directory(work_dir: KaosPath) -> str:
     """Return an ``ls``-like listing of *work_dir*.
 
@@ -63,11 +66,19 @@ async def list_directory(work_dir: KaosPath) -> str:
     It should therefore be robust against per-entry filesystem issues such as
     broken symlinks or permission errors: a single bad entry must not crash
     the whole CLI.
+
+    The listing is capped at :data:`_LIST_DIR_MAX_ENTRIES` entries to avoid
+    blowing up the system-prompt token budget when the working directory
+    contains thousands of files (see GH-1809).
     """
 
     entries: list[str] = []
+    total = 0
     # Iterate entries; tolerate per-entry stat failures (broken symlinks, permissions, etc.).
     async for entry in work_dir.iterdir():
+        total += 1
+        if len(entries) >= _LIST_DIR_MAX_ENTRIES:
+            continue
         try:
             st = await entry.stat()
         except OSError:
@@ -85,6 +96,10 @@ async def list_directory(work_dir: KaosPath) -> str:
         mode += "w" if st.st_mode & 0o002 else "-"
         mode += "x" if st.st_mode & 0o001 else "-"
         entries.append(f"{mode} {st.st_size:>10} {entry.name}")
+
+    remaining = total - len(entries)
+    if remaining > 0:
+        entries.append(f"... and {remaining} more entries (use Glob or Shell to explore)")
     return "\n".join(entries)
 
 

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -55,7 +55,7 @@ async def next_available_rotation(path: Path) -> Path | None:
         next_num += 1
 
 
-_LIST_DIR_ROOT_WIDTH = 30
+_LIST_DIR_ROOT_WIDTH = 30  # worst-case ~330 lines ≈ 2.5k tokens
 _LIST_DIR_CHILD_WIDTH = 10
 
 
@@ -130,7 +130,7 @@ async def list_directory(work_dir: KaosPath) -> str:
     if remaining > 0:
         lines.append(f"└── ... and {remaining} more entries")
 
-    return "\n".join(lines)
+    return "\n".join(lines) if lines else "(empty directory)"
 
 
 def shorten_home(path: KaosPath) -> KaosPath:

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -59,29 +59,16 @@ _LIST_DIR_ROOT_WIDTH = 30
 _LIST_DIR_CHILD_WIDTH = 10
 
 
-def _format_mode(st_mode: int) -> str:
-    """Format *st_mode* into a 10-char permission string like ``drwxr-xr-x``."""
-    m = "d" if S_ISDIR(st_mode) else "-"
-    for shift in (6, 3, 0):
-        triple = (st_mode >> shift) & 0o7
-        m += "r" if triple & 4 else "-"
-        m += "w" if triple & 2 else "-"
-        m += "x" if triple & 1 else "-"
-    return m
-
-
 async def _collect_entries(
     dir_path: KaosPath, max_width: int
-) -> tuple[list[tuple[str, bool, str]], int]:
+) -> tuple[list[tuple[str, bool]], int]:
     """Collect up to *max_width* entries from *dir_path*.
 
-    Returns ``(entries, total_count)`` where each entry is
-    ``(name, is_dir, mode_str)``.  *mode_str* is a permission string like
-    ``-rw-r--r--`` or ``"?"`` on stat failure.
+    Returns ``(entries, total_count)`` where each entry is ``(name, is_dir)``.
     Entries beyond *max_width* are counted but not stat-ed.
     Results are sorted directories-first, then alphabetically.
     """
-    entries: list[tuple[str, bool, str]] = []
+    entries: list[tuple[str, bool]] = []
     total = 0
     async for entry in dir_path.iterdir():
         total += 1
@@ -90,11 +77,9 @@ async def _collect_entries(
         try:
             st = await entry.stat()
             is_dir = S_ISDIR(st.st_mode)
-            mode = _format_mode(st.st_mode)
         except OSError:
             is_dir = False
-            mode = "?"
-        entries.append((entry.name, is_dir, mode))
+        entries.append((entry.name, is_dir))
     entries.sort(key=lambda e: (not e[1], e[0]))
     return entries, total
 
@@ -117,12 +102,12 @@ async def list_directory(work_dir: KaosPath) -> str:
     entries, total = await _collect_entries(work_dir, _LIST_DIR_ROOT_WIDTH)
     remaining = total - len(entries)
 
-    for i, (name, is_dir, mode) in enumerate(entries):
+    for i, (name, is_dir) in enumerate(entries):
         is_last = (i == len(entries) - 1) and remaining == 0
         connector = "└── " if is_last else "├── "
 
         if is_dir:
-            lines.append(f"{connector}[{mode}] {name}/")
+            lines.append(f"{connector}{name}/")
             child_prefix = "    " if is_last else "│   "
             try:
                 child_entries, child_total = await _collect_entries(
@@ -132,15 +117,15 @@ async def list_directory(work_dir: KaosPath) -> str:
                 lines.append(f"{child_prefix}└── [not readable]")
                 continue
             child_remaining = child_total - len(child_entries)
-            for j, (child_name, child_is_dir, child_mode) in enumerate(child_entries):
+            for j, (child_name, child_is_dir) in enumerate(child_entries):
                 child_is_last = (j == len(child_entries) - 1) and child_remaining == 0
                 child_connector = "└── " if child_is_last else "├── "
                 suffix = "/" if child_is_dir else ""
-                lines.append(f"{child_prefix}{child_connector}[{child_mode}] {child_name}{suffix}")
+                lines.append(f"{child_prefix}{child_connector}{child_name}{suffix}")
             if child_remaining > 0:
                 lines.append(f"{child_prefix}└── ... and {child_remaining} more")
         else:
-            lines.append(f"{connector}[{mode}] {name}")
+            lines.append(f"{connector}{name}")
 
     if remaining > 0:
         lines.append(f"└── ... and {remaining} more entries")

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -65,23 +65,20 @@ async def _collect_entries(
     """Collect up to *max_width* entries from *dir_path*.
 
     Returns ``(entries, total_count)`` where each entry is ``(name, is_dir)``.
-    Entries beyond *max_width* are counted but not stat-ed.
-    Results are sorted directories-first, then alphabetically.
+    All entries are stat-ed, sorted directories-first then alphabetically,
+    and truncated to *max_width* so the returned subset is deterministic
+    regardless of filesystem enumeration order.
     """
-    entries: list[tuple[str, bool]] = []
-    total = 0
+    all_entries: list[tuple[str, bool]] = []
     async for entry in dir_path.iterdir():
-        total += 1
-        if len(entries) >= max_width:
-            continue
         try:
             st = await entry.stat()
             is_dir = S_ISDIR(st.st_mode)
         except OSError:
             is_dir = False
-        entries.append((entry.name, is_dir))
-    entries.sort(key=lambda e: (not e[1], e[0]))
-    return entries, total
+        all_entries.append((entry.name, is_dir))
+    all_entries.sort(key=lambda e: (not e[1], e[0]))
+    return all_entries[:max_width], len(all_entries)
 
 
 async def list_directory(work_dir: KaosPath) -> str:

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -59,16 +59,29 @@ _LIST_DIR_ROOT_WIDTH = 30
 _LIST_DIR_CHILD_WIDTH = 10
 
 
+def _format_mode(st_mode: int) -> str:
+    """Format *st_mode* into a 10-char permission string like ``drwxr-xr-x``."""
+    m = "d" if S_ISDIR(st_mode) else "-"
+    for shift in (6, 3, 0):
+        triple = (st_mode >> shift) & 0o7
+        m += "r" if triple & 4 else "-"
+        m += "w" if triple & 2 else "-"
+        m += "x" if triple & 1 else "-"
+    return m
+
+
 async def _collect_entries(
     dir_path: KaosPath, max_width: int
-) -> tuple[list[tuple[str, bool]], int]:
+) -> tuple[list[tuple[str, bool, str]], int]:
     """Collect up to *max_width* entries from *dir_path*.
 
-    Returns ``(entries, total_count)`` where each entry is ``(name, is_dir)``.
+    Returns ``(entries, total_count)`` where each entry is
+    ``(name, is_dir, mode_str)``.  *mode_str* is a permission string like
+    ``-rw-r--r--`` or ``"?"`` on stat failure.
     Entries beyond *max_width* are counted but not stat-ed.
     Results are sorted directories-first, then alphabetically.
     """
-    entries: list[tuple[str, bool]] = []
+    entries: list[tuple[str, bool, str]] = []
     total = 0
     async for entry in dir_path.iterdir():
         total += 1
@@ -77,9 +90,11 @@ async def _collect_entries(
         try:
             st = await entry.stat()
             is_dir = S_ISDIR(st.st_mode)
+            mode = _format_mode(st.st_mode)
         except OSError:
             is_dir = False
-        entries.append((entry.name, is_dir))
+            mode = "?"
+        entries.append((entry.name, is_dir, mode))
     entries.sort(key=lambda e: (not e[1], e[0]))
     return entries, total
 
@@ -102,12 +117,12 @@ async def list_directory(work_dir: KaosPath) -> str:
     entries, total = await _collect_entries(work_dir, _LIST_DIR_ROOT_WIDTH)
     remaining = total - len(entries)
 
-    for i, (name, is_dir) in enumerate(entries):
+    for i, (name, is_dir, mode) in enumerate(entries):
         is_last = (i == len(entries) - 1) and remaining == 0
         connector = "└── " if is_last else "├── "
 
         if is_dir:
-            lines.append(f"{connector}{name}/")
+            lines.append(f"{connector}[{mode}] {name}/")
             child_prefix = "    " if is_last else "│   "
             try:
                 child_entries, child_total = await _collect_entries(
@@ -117,15 +132,15 @@ async def list_directory(work_dir: KaosPath) -> str:
                 lines.append(f"{child_prefix}└── [not readable]")
                 continue
             child_remaining = child_total - len(child_entries)
-            for j, (child_name, child_is_dir) in enumerate(child_entries):
+            for j, (child_name, child_is_dir, child_mode) in enumerate(child_entries):
                 child_is_last = (j == len(child_entries) - 1) and child_remaining == 0
                 child_connector = "└── " if child_is_last else "├── "
                 suffix = "/" if child_is_dir else ""
-                lines.append(f"{child_prefix}{child_connector}{child_name}{suffix}")
+                lines.append(f"{child_prefix}{child_connector}[{child_mode}] {child_name}{suffix}")
             if child_remaining > 0:
                 lines.append(f"{child_prefix}└── ... and {child_remaining} more")
         else:
-            lines.append(f"{connector}{name}")
+            lines.append(f"{connector}[{mode}] {name}")
 
     if remaining > 0:
         lines.append(f"└── ... and {remaining} more entries")

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -55,52 +55,82 @@ async def next_available_rotation(path: Path) -> Path | None:
         next_num += 1
 
 
-_LIST_DIR_MAX_ENTRIES = 200
+_LIST_DIR_ROOT_WIDTH = 30
+_LIST_DIR_CHILD_WIDTH = 10
 
 
-async def list_directory(work_dir: KaosPath) -> str:
-    """Return an ``ls``-like listing of *work_dir*.
+async def _collect_entries(
+    dir_path: KaosPath, max_width: int
+) -> tuple[list[tuple[str, bool]], int]:
+    """Collect up to *max_width* entries from *dir_path*.
 
-    This helper is used mainly to provide context to the LLM (for example
-    ``KIMI_WORK_DIR_LS``) and to show top-level directory contents in tools.
-    It should therefore be robust against per-entry filesystem issues such as
-    broken symlinks or permission errors: a single bad entry must not crash
-    the whole CLI.
-
-    The listing is capped at :data:`_LIST_DIR_MAX_ENTRIES` entries to avoid
-    blowing up the system-prompt token budget when the working directory
-    contains thousands of files (see GH-1809).
+    Returns ``(entries, total_count)`` where each entry is ``(name, is_dir)``.
+    Entries beyond *max_width* are counted but not stat-ed.
+    Results are sorted directories-first, then alphabetically.
     """
-
-    entries: list[str] = []
+    entries: list[tuple[str, bool]] = []
     total = 0
-    # Iterate entries; tolerate per-entry stat failures (broken symlinks, permissions, etc.).
-    async for entry in work_dir.iterdir():
+    async for entry in dir_path.iterdir():
         total += 1
-        if len(entries) >= _LIST_DIR_MAX_ENTRIES:
+        if len(entries) >= max_width:
             continue
         try:
             st = await entry.stat()
+            is_dir = S_ISDIR(st.st_mode)
         except OSError:
-            # Broken symlink, permission error, etc. – keep listing other entries.
-            entries.append(f"?--------- {'?':>10} {entry.name} [stat failed]")
-            continue
-        mode = "d" if S_ISDIR(st.st_mode) else "-"
-        mode += "r" if st.st_mode & 0o400 else "-"
-        mode += "w" if st.st_mode & 0o200 else "-"
-        mode += "x" if st.st_mode & 0o100 else "-"
-        mode += "r" if st.st_mode & 0o040 else "-"
-        mode += "w" if st.st_mode & 0o020 else "-"
-        mode += "x" if st.st_mode & 0o010 else "-"
-        mode += "r" if st.st_mode & 0o004 else "-"
-        mode += "w" if st.st_mode & 0o002 else "-"
-        mode += "x" if st.st_mode & 0o001 else "-"
-        entries.append(f"{mode} {st.st_size:>10} {entry.name}")
+            is_dir = False
+        entries.append((entry.name, is_dir))
+    entries.sort(key=lambda e: (not e[1], e[0]))
+    return entries, total
 
+
+async def list_directory(work_dir: KaosPath) -> str:
+    """Return a compact tree listing of *work_dir* (up to 2 levels).
+
+    This helper is used mainly to provide context to the LLM (for example
+    ``KIMI_WORK_DIR_LS``) and to show top-level directory contents in tools.
+
+    Both depth and width are capped to keep the system-prompt token budget
+    bounded (see GH-1809):
+
+    * **Depth 0** (root): up to :data:`_LIST_DIR_ROOT_WIDTH` entries.
+    * **Depth 1** (children of root dirs): up to :data:`_LIST_DIR_CHILD_WIDTH`
+      entries per directory.
+    * Truncated levels show ``... and N more`` so the LLM knows more exists.
+    """
+    lines: list[str] = []
+    entries, total = await _collect_entries(work_dir, _LIST_DIR_ROOT_WIDTH)
     remaining = total - len(entries)
+
+    for i, (name, is_dir) in enumerate(entries):
+        is_last = (i == len(entries) - 1) and remaining == 0
+        connector = "└── " if is_last else "├── "
+
+        if is_dir:
+            lines.append(f"{connector}{name}/")
+            child_prefix = "    " if is_last else "│   "
+            try:
+                child_entries, child_total = await _collect_entries(
+                    work_dir / name, _LIST_DIR_CHILD_WIDTH
+                )
+            except OSError:
+                lines.append(f"{child_prefix}└── [not readable]")
+                continue
+            child_remaining = child_total - len(child_entries)
+            for j, (child_name, child_is_dir) in enumerate(child_entries):
+                child_is_last = (j == len(child_entries) - 1) and child_remaining == 0
+                child_connector = "└── " if child_is_last else "├── "
+                suffix = "/" if child_is_dir else ""
+                lines.append(f"{child_prefix}{child_connector}{child_name}{suffix}")
+            if child_remaining > 0:
+                lines.append(f"{child_prefix}└── ... and {child_remaining} more")
+        else:
+            lines.append(f"{connector}{name}")
+
     if remaining > 0:
-        entries.append(f"... and {remaining} more entries (use Glob or Shell to explore)")
-    return "\n".join(entries)
+        lines.append(f"└── ... and {remaining} more entries")
+
+    return "\n".join(lines)
 
 
 def shorten_home(path: KaosPath) -> KaosPath:

--- a/src/kimi_cli/utils/path.py
+++ b/src/kimi_cli/utils/path.py
@@ -55,7 +55,7 @@ async def next_available_rotation(path: Path) -> Path | None:
         next_num += 1
 
 
-_LIST_DIR_MAX_ENTRIES = 500
+_LIST_DIR_MAX_ENTRIES = 200
 
 
 async def list_directory(work_dir: KaosPath) -> str:

--- a/tests/core/test_default_agent.py
+++ b/tests/core/test_default_agent.py
@@ -106,7 +106,7 @@ The directory listing of current working directory is:
 Test ls content
 ```
 
-Use this as your basic understanding of the project structure.
+Use this as your basic understanding of the project structure. The tree only shows the first two levels; entries marked "... and N more" indicate additional contents — use Glob or Shell to explore further.
 
 # Project Information
 

--- a/tests/utils/test_list_directory.py
+++ b/tests/utils/test_list_directory.py
@@ -145,6 +145,6 @@ async def test_list_directory_tree_windows(temp_work_dir: KaosPath) -> None:
 ├── adir/
 │   └── inside.txt
 ├── emptydir/
-├── regular.txt\
+└── regular.txt\
 """
     )

--- a/tests/utils/test_list_directory.py
+++ b/tests/utils/test_list_directory.py
@@ -32,13 +32,13 @@ async def test_list_directory_tree_unix(temp_work_dir: KaosPath) -> None:
     out = await list_directory(temp_work_dir)
     assert out == snapshot(
         """\
-├── [drwxr-xr-x] adir/
-│   └── [-rw-r--r--] inside.txt
-├── [drwxr-xr-x] emptydir/
-├── [-rw-r--r--] largefile.bin
-├── [-rw-r--r--] link_to_regular
-├── [?] link_to_regular_missing
-└── [-rw-r--r--] regular.txt\
+├── adir/
+│   └── inside.txt
+├── emptydir/
+├── largefile.bin
+├── link_to_regular
+├── link_to_regular_missing
+└── regular.txt\
 """
     )
 
@@ -85,10 +85,10 @@ async def test_list_directory_dirs_before_files(temp_work_dir: KaosPath) -> None
     out = await list_directory(temp_work_dir)
     assert out == snapshot(
         """\
-├── [drwxr-xr-x] alpha/
-├── [drwxr-xr-x] omega/
-├── [-rw-r--r--] beta.txt
-└── [-rw-r--r--] zebra.txt\
+├── alpha/
+├── omega/
+├── beta.txt
+└── zebra.txt\
 """
     )
 

--- a/tests/utils/test_list_directory.py
+++ b/tests/utils/test_list_directory.py
@@ -9,7 +9,7 @@ import pytest
 from inline_snapshot import snapshot
 from kaos.path import KaosPath
 
-from kimi_cli.utils.path import list_directory
+from kimi_cli.utils.path import _LIST_DIR_MAX_ENTRIES, list_directory
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific symlink tests.")
@@ -45,6 +45,20 @@ drwxr-xr-x adir
 drwxr-xr-x emptydir\
 """
     )
+
+
+async def test_list_directory_truncates_large_dirs(temp_work_dir: KaosPath) -> None:
+    """GH-1809: listing is capped at _LIST_DIR_MAX_ENTRIES to prevent token-limit blowup."""
+    file_count = _LIST_DIR_MAX_ENTRIES + 100
+    for i in range(file_count):
+        (temp_work_dir / f"file_{i:05d}.txt").unsafe_to_local_path().touch()
+
+    out = await list_directory(temp_work_dir)
+    lines = out.splitlines()
+
+    # Should have exactly MAX_ENTRIES listed + 1 truncation footer
+    assert len(lines) == _LIST_DIR_MAX_ENTRIES + 1
+    assert lines[-1] == "... and 100 more entries (use Glob or Shell to explore)"
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific symlink tests.")

--- a/tests/utils/test_list_directory.py
+++ b/tests/utils/test_list_directory.py
@@ -72,7 +72,7 @@ async def test_list_directory_truncates_child_width(temp_work_dir: KaosPath) -> 
     # 1 (subdir/) + CHILD_WIDTH (children) + 1 (truncation)
     assert len(lines) == 1 + _LIST_DIR_CHILD_WIDTH + 1
     assert "subdir/" in lines[0]
-    assert lines[-1].strip() == f"└── ... and {overflow} more"
+    assert lines[-1] == f"    └── ... and {overflow} more"
 
 
 async def test_list_directory_dirs_before_files(temp_work_dir: KaosPath) -> None:
@@ -89,6 +89,45 @@ async def test_list_directory_dirs_before_files(temp_work_dir: KaosPath) -> None
 ├── omega/
 ├── beta.txt
 └── zebra.txt\
+"""
+    )
+
+
+async def test_list_directory_empty(temp_work_dir: KaosPath) -> None:
+    """Empty directory returns a placeholder string."""
+    out = await list_directory(temp_work_dir)
+    assert out == "(empty directory)"
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific permission tests.")
+async def test_list_directory_unreadable_subdir(temp_work_dir: KaosPath) -> None:
+    """Unreadable subdirectory shows [not readable] instead of crashing."""
+    await (temp_work_dir / "secret").mkdir()
+    await (temp_work_dir / "secret" / "file.txt").write_text("x")
+    os.chmod((temp_work_dir / "secret").unsafe_to_local_path(), 0o000)
+    try:
+        out = await list_directory(temp_work_dir)
+        assert out == snapshot(
+            """\
+└── secret/
+    └── [not readable]\
+"""
+        )
+    finally:
+        os.chmod((temp_work_dir / "secret").unsafe_to_local_path(), 0o755)
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific tests.")
+async def test_list_directory_last_entry_is_dir(temp_work_dir: KaosPath) -> None:
+    """When the last root entry is a dir, child prefix uses spaces not │."""
+    await (temp_work_dir / "only_dir").mkdir()
+    await (temp_work_dir / "only_dir" / "child.txt").write_text("c")
+
+    out = await list_directory(temp_work_dir)
+    assert out == snapshot(
+        """\
+└── only_dir/
+    └── child.txt\
 """
     )
 

--- a/tests/utils/test_list_directory.py
+++ b/tests/utils/test_list_directory.py
@@ -32,13 +32,13 @@ async def test_list_directory_tree_unix(temp_work_dir: KaosPath) -> None:
     out = await list_directory(temp_work_dir)
     assert out == snapshot(
         """\
-├── adir/
-│   └── inside.txt
-├── emptydir/
-├── largefile.bin
-├── link_to_regular
-├── link_to_regular_missing
-└── regular.txt\
+├── [drwxr-xr-x] adir/
+│   └── [-rw-r--r--] inside.txt
+├── [drwxr-xr-x] emptydir/
+├── [-rw-r--r--] largefile.bin
+├── [-rw-r--r--] link_to_regular
+├── [?] link_to_regular_missing
+└── [-rw-r--r--] regular.txt\
 """
     )
 
@@ -85,10 +85,10 @@ async def test_list_directory_dirs_before_files(temp_work_dir: KaosPath) -> None
     out = await list_directory(temp_work_dir)
     assert out == snapshot(
         """\
-├── alpha/
-├── omega/
-├── beta.txt
-└── zebra.txt\
+├── [drwxr-xr-x] alpha/
+├── [drwxr-xr-x] omega/
+├── [-rw-r--r--] beta.txt
+└── [-rw-r--r--] zebra.txt\
 """
     )
 

--- a/tests/utils/test_list_directory.py
+++ b/tests/utils/test_list_directory.py
@@ -9,12 +9,12 @@ import pytest
 from inline_snapshot import snapshot
 from kaos.path import KaosPath
 
-from kimi_cli.utils.path import _LIST_DIR_MAX_ENTRIES, list_directory
+from kimi_cli.utils.path import _LIST_DIR_CHILD_WIDTH, _LIST_DIR_ROOT_WIDTH, list_directory
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific symlink tests.")
-async def test_list_directory_unix(temp_work_dir: KaosPath) -> None:
-    # Create a regular file and a directory (use KaosPath async ops for style consistency)
+async def test_list_directory_tree_unix(temp_work_dir: KaosPath) -> None:
+    """Tree output with dirs-first sorting, children expanded, broken symlinks handled."""
     await (temp_work_dir / "regular.txt").write_text("hello")
     await (temp_work_dir / "adir").mkdir()
     await (temp_work_dir / "adir" / "inside.txt").write_text("world")
@@ -30,50 +30,82 @@ async def test_list_directory_unix(temp_work_dir: KaosPath) -> None:
     )
 
     out = await list_directory(temp_work_dir)
-    out_without_size = "\n".join(
-        sorted(
-            line.split(maxsplit=2)[0] + " " + line.split(maxsplit=2)[2] for line in out.splitlines()
-        )
-    )  # Remove size for snapshot stability
-    assert out_without_size == snapshot(
+    assert out == snapshot(
         """\
--rw-r--r-- largefile.bin
--rw-r--r-- link_to_regular
--rw-r--r-- regular.txt
-?--------- link_to_regular_missing [stat failed]
-drwxr-xr-x adir
-drwxr-xr-x emptydir\
+├── adir/
+│   └── inside.txt
+├── emptydir/
+├── largefile.bin
+├── link_to_regular
+├── link_to_regular_missing
+└── regular.txt\
 """
     )
 
 
-async def test_list_directory_truncates_large_dirs(temp_work_dir: KaosPath) -> None:
-    """GH-1809: listing is capped at _LIST_DIR_MAX_ENTRIES to prevent token-limit blowup."""
-    file_count = _LIST_DIR_MAX_ENTRIES + 100
+async def test_list_directory_truncates_root_width(temp_work_dir: KaosPath) -> None:
+    """GH-1809: root level is capped at _LIST_DIR_ROOT_WIDTH."""
+    overflow = 50
+    file_count = _LIST_DIR_ROOT_WIDTH + overflow
     for i in range(file_count):
-        (temp_work_dir / f"file_{i:05d}.txt").unsafe_to_local_path().touch()
+        (temp_work_dir / f"file_{i:04d}.txt").unsafe_to_local_path().touch()
 
     out = await list_directory(temp_work_dir)
     lines = out.splitlines()
 
-    # Should have exactly MAX_ENTRIES listed + 1 truncation footer
-    assert len(lines) == _LIST_DIR_MAX_ENTRIES + 1
-    assert lines[-1] == "... and 100 more entries (use Glob or Shell to explore)"
+    # ROOT_WIDTH entries + 1 truncation footer
+    assert len(lines) == _LIST_DIR_ROOT_WIDTH + 1
+    assert lines[-1] == f"└── ... and {overflow} more entries"
+
+
+async def test_list_directory_truncates_child_width(temp_work_dir: KaosPath) -> None:
+    """Children of a root directory are capped at _LIST_DIR_CHILD_WIDTH."""
+    await (temp_work_dir / "subdir").mkdir()
+    overflow = 5
+    child_count = _LIST_DIR_CHILD_WIDTH + overflow
+    for i in range(child_count):
+        (temp_work_dir / "subdir" / f"child_{i:03d}.txt").unsafe_to_local_path().touch()
+
+    out = await list_directory(temp_work_dir)
+    lines = out.splitlines()
+
+    # 1 (subdir/) + CHILD_WIDTH (children) + 1 (truncation)
+    assert len(lines) == 1 + _LIST_DIR_CHILD_WIDTH + 1
+    assert "subdir/" in lines[0]
+    assert lines[-1].strip() == f"└── ... and {overflow} more"
+
+
+async def test_list_directory_dirs_before_files(temp_work_dir: KaosPath) -> None:
+    """Directories are sorted before files, both groups alphabetical."""
+    await (temp_work_dir / "zebra.txt").write_text("z")
+    await (temp_work_dir / "alpha").mkdir()
+    await (temp_work_dir / "beta.txt").write_text("b")
+    await (temp_work_dir / "omega").mkdir()
+
+    out = await list_directory(temp_work_dir)
+    assert out == snapshot(
+        """\
+├── alpha/
+├── omega/
+├── beta.txt
+└── zebra.txt\
+"""
+    )
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific symlink tests.")
-async def test_list_directory_windows(temp_work_dir: KaosPath) -> None:
-    # Create a regular file and a directory (use KaosPath async ops for style consistency)
+async def test_list_directory_tree_windows(temp_work_dir: KaosPath) -> None:
     await (temp_work_dir / "regular.txt").write_text("hello")
     await (temp_work_dir / "adir").mkdir()
     await (temp_work_dir / "adir" / "inside.txt").write_text("world")
     await (temp_work_dir / "emptydir").mkdir()
-    await (temp_work_dir / "largefile.bin").write_bytes(b"x" * 10_000_000)
 
     out = await list_directory(temp_work_dir)
-    assert out == snapshot("""\
-drwxrwxrwx          0 adir
-drwxrwxrwx          0 emptydir
--rw-rw-rw-   10000000 largefile.bin
--rw-rw-rw-          5 regular.txt\
-""")
+    assert out == snapshot(
+        """\
+├── adir/
+│   └── inside.txt
+├── emptydir/
+├── regular.txt\
+"""
+    )


### PR DESCRIPTION
## Summary

- `list_directory()` 此前无条目上限，在包含数千文件的目录（如 node_modules）中启动 kimi 时，整个文件列表被注入系统提示词 `KIMI_WORK_DIR_LS`，轻松超过模型 262,144 token 上限
- 新增 `_LIST_DIR_MAX_ENTRIES = 500` 截断阈值，超出后追加 `... and N more entries (use Glob or Shell to explore)` 提示
- 与代码库已有的截断模式保持一致（glob `MAX_MATCHES=1000`、git_context `_MAX_DIRTY_FILES=20`、`ToolResultBuilder` `max_chars=50000`）

Closes #1809

## Test plan

- [x] 新增 `test_list_directory_truncates_large_dirs` 测试：创建 600 个文件，验证输出被截断为 500 行 + 1 行提示
- [x] 已有 `test_list_directory_unix` / `test_list_directory_windows` 测试不受影响（文件数远低于阈值）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- `list_directory()` previously had no upper limit for entries. When kimi is started in a directory containing thousands of files (such as node_modules), the entire file list is injected with the system prompt word `KIMI_WORK_DIR_LS`, easily exceeding the model's upper limit of 262,144 tokens.
- Added `_LIST_DIR_MAX_ENTRIES = 500` truncation threshold, append `... and N more entries (use Glob or Shell to explore)` prompt after exceeding
- Consistent with existing truncation patterns in the code base (glob `MAX_MATCHES=1000`, git_context `_MAX_DIRTY_FILES=20`, `ToolResultBuilder` `max_chars=50000`)

Closes #1809

## Test plan

- [x] Added `test_list_directory_truncates_large_dirs` test: create 600 files, verify output is truncated to 500 lines + 1 line prompt
- [x] Existing `test_list_directory_unix` / `test_list_directory_windows` tests are not affected (number of files is well below the threshold)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
