### PR TITLE
fix(pyinstaller): include lazy CLI subcommands

### DIFF
--- a/src/kimi_cli/utils/pyinstaller.py
+++ b/src/kimi_cli/utils/pyinstaller.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-hiddenimports = collect_submodules("kimi_cli.tools") + ["setproctitle"]
+from kimi_cli.cli._lazy_group import LazySubcommandGroup
+
+lazy_cli_hiddenimports = [
+    module_name
+    for module_name, _attribute_name, _help_text in (LazySubcommandGroup.lazy_subcommands.values())
+]
+
+hiddenimports = collect_submodules("kimi_cli.tools") + lazy_cli_hiddenimports + ["setproctitle"]
 datas = (
     collect_data_files(
         "kimi_cli",

--- a/tests/utils/test_pyinstaller_utils.py
+++ b/tests/utils/test_pyinstaller_utils.py
@@ -146,6 +146,12 @@ def test_pyinstaller_hiddenimports():
 
     assert sorted(hiddenimports) == snapshot(
         [
+            "kimi_cli.cli.export",
+            "kimi_cli.cli.info",
+            "kimi_cli.cli.mcp",
+            "kimi_cli.cli.plugin",
+            "kimi_cli.cli.vis",
+            "kimi_cli.cli.web",
             "kimi_cli.tools",
             "kimi_cli.tools.agent",
             "kimi_cli.tools.ask_user",
@@ -175,3 +181,15 @@ def test_pyinstaller_hiddenimports():
             "setproctitle",
         ]
     )
+
+
+def test_pyinstaller_hiddenimports_include_lazy_cli_subcommands():
+    from kimi_cli.cli._lazy_group import LazySubcommandGroup
+    from kimi_cli.utils.pyinstaller import hiddenimports
+
+    expected_hiddenimports = {
+        module_name
+        for module_name, _attribute_name, _help_text in LazySubcommandGroup.lazy_subcommands.values()
+    }
+
+    assert expected_hiddenimports <= set(hiddenimports)


### PR DESCRIPTION
## Summary
- include lazy-loaded `kimi_cli.cli.*` subcommands in PyInstaller `hiddenimports`
- add a regression test that asserts all lazy CLI subcommands are packaged
- keep the hidden import list derived from `LazySubcommandGroup` so future subcommands do not regress silently

## Root cause
`kimi info --json` and the other lazy CLI subcommands are loaded via `import_module()` at runtime. PyInstaller only bundled `kimi_cli.tools.*`, so the onefile binary omitted `kimi_cli.cli.info` and failed with `ModuleNotFoundError`.

## Validation
- `uv run pytest tests/utils/test_pyinstaller_utils.py tests/core/test_startup_imports.py -q`
- `uv run ruff check src/kimi_cli/utils/pyinstaller.py tests/utils/test_pyinstaller_utils.py`
- `uv run pyinstaller --clean --noconfirm kimi.spec`
- `./dist/kimi info --json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
