### PR TITLE
fix(slash): show completion menu for exact command matches

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -141,8 +141,6 @@ class SlashCommandCompleter(Completer):
         token = text[last_space + 1 :]
 
         typed = token[1:]
-        if typed and typed in self._command_lookup:
-            return
         mention_doc = Document(text=typed, cursor_position=len(typed))
         candidates = list(self._fuzzy.get_completions(mention_doc, complete_event))
 

--- a/tests/ui_and_conv/test_slash_completer.py
+++ b/tests/ui_and_conv/test_slash_completer.py
@@ -47,8 +47,8 @@ def _completions(completer: SlashCommandCompleter, text: str):
     return list(completer.get_completions(document, event))
 
 
-def test_exact_command_match_hides_completions():
-    """Exact matches should not show completions."""
+def test_exact_command_match_shows_completions():
+    """Exact matches should still show slash menu candidates."""
     completer = SlashCommandCompleter(
         [
             _make_command("mcp"),
@@ -59,11 +59,11 @@ def test_exact_command_match_hides_completions():
 
     texts = _completion_texts(completer, "/mcp")
 
-    assert not texts
+    assert "/mcp" in texts
 
 
-def test_exact_alias_match_hides_completions():
-    """Exact alias matches should not show completions."""
+def test_exact_alias_match_shows_completions():
+    """Exact alias matches should still show canonical command candidates."""
     completer = SlashCommandCompleter(
         [
             _make_command("help", aliases=["h"]),
@@ -73,7 +73,7 @@ def test_exact_alias_match_hides_completions():
 
     texts = _completion_texts(completer, "/h")
 
-    assert not texts
+    assert "/help" in texts
 
 
 def test_should_complete_only_for_root_slash_token():


### PR DESCRIPTION
## Summary
- remove exact-match early-return in `SlashCommandCompleter` so slash completion candidates are still shown when input exactly matches a command/alias
- keep canonical command rendering behavior unchanged
- update unit tests to verify exact command/alias inputs show completion candidates

## Tests
- `pytest tests/ui_and_conv/test_slash_completer.py tests/core/test_kimisoul_slash_commands.py -q`
  - `10 passed`

Fixes #1752
