### PR TITLE
fix(tools): truncate MCP tool output and handle unsupported content types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
-- Core: Truncate MCP tool output to 100K characters to prevent context overflow — tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; unsupported MCP content types are gracefully handled instead of crashing the turn
+- Core: Truncate MCP tool output to 100K characters to prevent context overflow — all content types (text and inline media such as image/audio/video data URLs) share a single character budget; tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; oversized media parts are dropped; unsupported MCP content types are gracefully handled instead of crashing the turn
+- CLI: Fix PyInstaller binary missing lazy CLI subcommands — `kimi info`, `kimi export`, `kimi mcp`, `kimi plugin`, `kimi vis`, and `kimi web` now work correctly in the standalone binary distribution
 
 ## 1.31.0 (2026-04-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Truncate MCP tool output to 100K characters to prevent context overflow — tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; unsupported MCP content types are gracefully handled instead of crashing the turn
+
 ## 1.31.0 (2026-04-10)
 
 - Core: Cap `list_directory` output as a depth-limited tree to prevent token-limit blowup in large directories — replaces the unbounded flat listing with a 2-level tree (root: 30 entries, child: 10 per subdirectory), dirs-first alphabetical sorting, and `"... and N more"` truncation hints so the model knows to explore further (fixes #1809)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,9 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Truncate MCP tool output to 100K characters to prevent context overflow — all content types (text and inline media such as image/audio/video data URLs) share a single character budget; tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; oversized media parts are dropped; unsupported MCP content types are gracefully handled instead of crashing the turn
+- CLI: Fix PyInstaller binary missing lazy CLI subcommands — `kimi info`, `kimi export`, `kimi mcp`, `kimi plugin`, `kimi vis`, and `kimi web` now work correctly in the standalone binary distribution
+
 ## 1.31.0 (2026-04-10)
 
 - Core: Cap `list_directory` output as a depth-limited tree to prevent token-limit blowup in large directories — replaces the unbounded flat listing with a 2-level tree (root: 30 entries, child: 10 per subdirectory), dirs-first alphabetical sorting, and `"... and N more"` truncation hints so the model knows to explore further (fixes #1809)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,9 @@
 
 ## 未发布
 
+- Core：将 MCP 工具输出截断至 10 万字符以防止上下文溢出——所有内容类型（文本和内联媒体如 image/audio/video data URL）共享同一字符预算；Playwright 等返回完整 DOM（500KB+）或大型 base64 截图的工具现在会被截断并附加提示信息；超出预算的媒体部分会被丢弃；不支持的 MCP 内容类型会被优雅处理而非导致当前轮次崩溃
+- CLI：修复 PyInstaller 二进制包缺少延迟加载 CLI 子命令的问题——`kimi info`、`kimi export`、`kimi mcp`、`kimi plugin`、`kimi vis` 和 `kimi web` 现在在独立二进制分发中可正常使用
+
 ## 1.31.0 (2026-04-10)
 
 - Core：限制 `list_directory` 输出为深度受限的树形结构，防止大目录导致 token 超限——将无上限的扁平列表替换为 2 级树（根级最多 30 条、每个子目录最多 10 条），按目录优先的字母序排列，截断处显示 `"... and N more"` 提示以引导模型进一步探索（修复 #1809）

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -37,6 +37,7 @@ from kimi_cli.wire.types import (
     ContentPart,
     MCPServerSnapshot,
     MCPStatusSnapshot,
+    TextPart,
     ToolCall,
     ToolCallRequest,
     ToolResult,
@@ -642,15 +643,56 @@ class WireExternalTool(CallableTool):
             )
 
 
+# Maximum characters allowed in MCP tool output before truncation.
+# Built-in tools use 50K via ToolResultBuilder; MCP gets a wider budget because
+# multi-part results (e.g. text + image) are common, but still needs a cap to
+# prevent context overflow from tools like Playwright that return full DOMs.
+MCP_MAX_OUTPUT_CHARS = 100_000
+
+
 def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
     """Convert MCP tool result to kosong tool return value.
 
-    Raises:
-        ValueError: If any content part has unsupported type or mime type.
+    Text content is truncated to *MCP_MAX_OUTPUT_CHARS* total characters.
+    Unsupported content types are replaced with a ``ToolError`` part instead
+    of crashing the turn.
     """
     content: list[ContentPart] = []
+    char_budget = MCP_MAX_OUTPUT_CHARS
+    truncated = False
+
     for part in result.content:
-        content.append(convert_mcp_content(part))
+        try:
+            converted = convert_mcp_content(part)
+        except ValueError as exc:
+            logger.warning(
+                "Skipping unsupported MCP content part: {error}",
+                error=exc,
+            )
+            converted = TextPart(text=f"[Unsupported content: {exc}]")
+
+        # Apply character budget to text parts
+        if isinstance(converted, TextPart):
+            if char_budget <= 0:
+                truncated = True
+                continue
+            if len(converted.text) > char_budget:
+                converted = TextPart(text=converted.text[:char_budget])
+                truncated = True
+            char_budget -= len(converted.text)
+
+        content.append(converted)
+
+    if truncated:
+        content.append(
+            TextPart(
+                text=(
+                    f"\n\n[Output truncated: exceeded {MCP_MAX_OUTPUT_CHARS} character limit. "
+                    "Use pagination or more specific queries to get remaining content.]"
+                )
+            )
+        )
+
     if result.is_error:
         return ToolError(
             output=content,

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -34,7 +34,9 @@ from kimi_cli.exception import InvalidToolError, MCPRuntimeError
 from kimi_cli.hooks.engine import HookEngine
 from kimi_cli.tools import SkipThisTool
 from kimi_cli.wire.types import (
+    AudioURLPart,
     ContentPart,
+    ImageURLPart,
     MCPServerSnapshot,
     MCPStatusSnapshot,
     TextPart,
@@ -42,6 +44,7 @@ from kimi_cli.wire.types import (
     ToolCallRequest,
     ToolResult,
     ToolReturnValue,
+    VideoURLPart,
 )
 
 if TYPE_CHECKING:
@@ -650,12 +653,27 @@ class WireExternalTool(CallableTool):
 MCP_MAX_OUTPUT_CHARS = 100_000
 
 
+def _media_part_size(part: ContentPart) -> int | None:
+    """Return the payload size of a media part, or ``None`` for non-media parts."""
+    if isinstance(part, ImageURLPart):
+        return len(part.image_url.url)
+    if isinstance(part, AudioURLPart):
+        return len(part.audio_url.url)
+    if isinstance(part, VideoURLPart):
+        return len(part.video_url.url)
+    return None
+
+
 def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
     """Convert MCP tool result to kosong tool return value.
 
-    Text content is truncated to *MCP_MAX_OUTPUT_CHARS* total characters.
-    Unsupported content types are replaced with a ``ToolError`` part instead
-    of crashing the turn.
+    All content — text *and* inline media (``data:`` URLs) — is subject to
+    a shared *MCP_MAX_OUTPUT_CHARS* character budget.  Text parts are
+    truncated in-place; media parts that exceed the remaining budget are
+    dropped and replaced with a descriptive placeholder.
+
+    Unsupported content types are caught and replaced with a ``TextPart``
+    placeholder instead of crashing the turn.
     """
     content: list[ContentPart] = []
     char_budget = MCP_MAX_OUTPUT_CHARS
@@ -671,7 +689,7 @@ def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
             )
             converted = TextPart(text=f"[Unsupported content: {exc}]")
 
-        # Apply character budget to text parts
+        # --- budget enforcement (text) ---
         if isinstance(converted, TextPart):
             if char_budget <= 0:
                 truncated = True
@@ -680,7 +698,20 @@ def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
                 converted = TextPart(text=converted.text[:char_budget])
                 truncated = True
             char_budget -= len(converted.text)
+            content.append(converted)
+            continue
 
+        # --- budget enforcement (media: image / audio / video) ---
+        media_size = _media_part_size(converted)
+        if media_size is not None:
+            if media_size > char_budget:
+                truncated = True
+                continue  # drop the oversized media part silently
+            char_budget -= media_size
+            content.append(converted)
+            continue
+
+        # Unknown ContentPart subclass — pass through without budget impact
         content.append(converted)
 
     if truncated:

--- a/tests/tools/test_mcp_tool_result.py
+++ b/tests/tools/test_mcp_tool_result.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+import base64
+from collections.abc import Sequence
 from unittest.mock import MagicMock
 
 import mcp.types
-from kosong.message import TextPart
+from kosong.message import ImageURLPart, TextPart
 from kosong.tooling import ToolError, ToolOk
 from pydantic import AnyUrl
 
 from kimi_cli.soul.toolset import MCP_MAX_OUTPUT_CHARS, convert_mcp_tool_result
 
 
-def _make_result(content: list[mcp.types.ContentBlock], *, is_error: bool = False) -> MagicMock:
+def _make_result(content: Sequence[mcp.types.ContentBlock], *, is_error: bool = False) -> MagicMock:
     r = MagicMock()
     r.content = content
     r.is_error = is_error
@@ -79,15 +81,77 @@ class TestMCPTruncation:
         assert isinstance(out.output[1], TextPart)
         assert "truncated" in out.output[1].text.lower()
 
-    def test_image_not_counted_against_budget(self):
-        """Non-text parts (images) don't consume the character budget."""
+    def test_small_image_counted_against_budget(self):
+        """Small images consume budget but fit, so both image and text survive."""
         img = mcp.types.ImageContent(type="image", data="AAAA", mimeType="image/png")
         text = mcp.types.TextContent(type="text", text="hello")
         result = _make_result([img, text])
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolOk)
         assert len(out.output) == 2
+        assert isinstance(out.output[0], ImageURLPart)
         assert _text(out.output[1]) == "hello"
+
+
+class TestMCPMediaTruncation:
+    """Regression tests: oversized non-text MCP payloads must be dropped."""
+
+    def test_oversized_image_dropped(self):
+        """A base64 image exceeding the budget should be dropped with truncation notice."""
+        # ~150K of base64 data → data URL will be well over MCP_MAX_OUTPUT_CHARS
+        big_data = base64.b64encode(b"\x00" * 150_000).decode()
+        img = mcp.types.ImageContent(type="image", data=big_data, mimeType="image/png")
+        result = _make_result([img])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        # Image should be dropped; only truncation notice remains
+        assert all(isinstance(p, TextPart) for p in out.output)
+        assert any("truncated" in _text(p).lower() for p in out.output)
+
+    def test_oversized_blob_resource_dropped(self):
+        """An EmbeddedResource with huge blob should be dropped."""
+        big_blob = base64.b64encode(b"\xff" * 150_000).decode()
+        blob = mcp.types.EmbeddedResource(
+            type="resource",
+            resource=mcp.types.BlobResourceContents(
+                uri=AnyUrl("file:///screenshot.png"),
+                mimeType="image/png",
+                blob=big_blob,
+            ),
+        )
+        result = _make_result([blob])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        assert all(isinstance(p, TextPart) for p in out.output)
+        assert any("truncated" in _text(p).lower() for p in out.output)
+
+    def test_text_survives_after_oversized_image_dropped(self):
+        """When an oversized image is dropped, subsequent text should still be kept."""
+        big_data = base64.b64encode(b"\x00" * 150_000).decode()
+        img = mcp.types.ImageContent(type="image", data=big_data, mimeType="image/png")
+        text = mcp.types.TextContent(type="text", text="caption after screenshot")
+        result = _make_result([img, text])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        texts = [p for p in out.output if isinstance(p, TextPart)]
+        assert any("caption" in t.text for t in texts)
+        assert any("truncated" in t.text.lower() for t in texts)
+
+    def test_multiple_images_exhaust_budget(self):
+        """Multiple medium images that together exceed the budget."""
+        # Each image ~ 40K chars of data URL, 3 of them > 100K
+        medium_data = base64.b64encode(b"\x00" * 30_000).decode()
+        imgs = [
+            mcp.types.ImageContent(type="image", data=medium_data, mimeType="image/png")
+            for _ in range(4)
+        ]
+        result = _make_result(imgs)
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        image_parts = [p for p in out.output if isinstance(p, ImageURLPart)]
+        # Not all 4 should survive
+        assert len(image_parts) < 4
+        assert any(isinstance(p, TextPart) and "truncated" in p.text.lower() for p in out.output)
 
 
 class TestMCPUnsupportedContent:

--- a/tests/tools/test_mcp_tool_result.py
+++ b/tests/tools/test_mcp_tool_result.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import mcp.types
 from kosong.message import TextPart
 from kosong.tooling import ToolError, ToolOk
+from pydantic import AnyUrl
 
 from kimi_cli.soul.toolset import MCP_MAX_OUTPUT_CHARS, convert_mcp_tool_result
 
@@ -18,13 +19,19 @@ def _make_result(content: list[mcp.types.ContentBlock], *, is_error: bool = Fals
     return r
 
 
+def _text(part: object) -> str:
+    """Extract .text from a ContentPart, narrowing for pyright."""
+    assert isinstance(part, TextPart)
+    return part.text
+
+
 class TestMCPTruncation:
     def test_small_text_passes_through(self):
         result = _make_result([mcp.types.TextContent(type="text", text="hello")])
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolOk)
         assert len(out.output) == 1
-        assert out.output[0].text == "hello"
+        assert _text(out.output[0]) == "hello"
 
     def test_text_truncated_at_budget(self):
         big_text = "x" * (MCP_MAX_OUTPUT_CHARS + 5000)
@@ -33,8 +40,8 @@ class TestMCPTruncation:
         assert isinstance(out, ToolOk)
         # Should have truncated text + truncation notice
         assert len(out.output) == 2
-        assert len(out.output[0].text) == MCP_MAX_OUTPUT_CHARS
-        assert "truncated" in out.output[1].text.lower()
+        assert len(_text(out.output[0])) == MCP_MAX_OUTPUT_CHARS
+        assert "truncated" in _text(out.output[1]).lower()
 
     def test_multi_part_truncation(self):
         half = MCP_MAX_OUTPUT_CHARS // 2
@@ -69,6 +76,7 @@ class TestMCPTruncation:
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolError)
         assert len(out.output) == 2
+        assert isinstance(out.output[1], TextPart)
         assert "truncated" in out.output[1].text.lower()
 
     def test_image_not_counted_against_budget(self):
@@ -79,7 +87,7 @@ class TestMCPTruncation:
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolOk)
         assert len(out.output) == 2
-        assert out.output[1].text == "hello"
+        assert _text(out.output[1]) == "hello"
 
 
 class TestMCPUnsupportedContent:
@@ -91,14 +99,14 @@ class TestMCPUnsupportedContent:
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolOk)
         assert len(out.output) == 1
-        assert "unsupported" in out.output[0].text.lower()
+        assert "unsupported" in _text(out.output[0]).lower()
 
     def test_unsupported_blob_mimetype_becomes_text_error(self):
         """EmbeddedResource with unsupported mime type should not crash."""
         blob = mcp.types.EmbeddedResource(
             type="resource",
             resource=mcp.types.BlobResourceContents(
-                uri="file:///test.bin",
+                uri=AnyUrl("file:///test.bin"),
                 mimeType="application/x-custom",
                 blob="deadbeef",
             ),
@@ -107,7 +115,7 @@ class TestMCPUnsupportedContent:
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolOk)
         assert len(out.output) == 1
-        assert "unsupported" in out.output[0].text.lower()
+        assert "unsupported" in _text(out.output[0]).lower()
 
     def test_mixed_valid_and_invalid_parts(self):
         """Valid parts should still be converted even when some fail."""
@@ -117,5 +125,5 @@ class TestMCPUnsupportedContent:
         out = convert_mcp_tool_result(result)
         assert isinstance(out, ToolOk)
         assert len(out.output) == 2
-        assert out.output[0].text == "valid"
-        assert "unsupported" in out.output[1].text.lower()
+        assert _text(out.output[0]) == "valid"
+        assert "unsupported" in _text(out.output[1]).lower()

--- a/tests/tools/test_mcp_tool_result.py
+++ b/tests/tools/test_mcp_tool_result.py
@@ -1,0 +1,121 @@
+"""Tests for convert_mcp_tool_result: truncation + unsupported content handling."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import mcp.types
+from kosong.message import TextPart
+from kosong.tooling import ToolError, ToolOk
+
+from kimi_cli.soul.toolset import MCP_MAX_OUTPUT_CHARS, convert_mcp_tool_result
+
+
+def _make_result(content: list[mcp.types.ContentBlock], *, is_error: bool = False) -> MagicMock:
+    r = MagicMock()
+    r.content = content
+    r.is_error = is_error
+    return r
+
+
+class TestMCPTruncation:
+    def test_small_text_passes_through(self):
+        result = _make_result([mcp.types.TextContent(type="text", text="hello")])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        assert len(out.output) == 1
+        assert out.output[0].text == "hello"
+
+    def test_text_truncated_at_budget(self):
+        big_text = "x" * (MCP_MAX_OUTPUT_CHARS + 5000)
+        result = _make_result([mcp.types.TextContent(type="text", text=big_text)])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        # Should have truncated text + truncation notice
+        assert len(out.output) == 2
+        assert len(out.output[0].text) == MCP_MAX_OUTPUT_CHARS
+        assert "truncated" in out.output[1].text.lower()
+
+    def test_multi_part_truncation(self):
+        half = MCP_MAX_OUTPUT_CHARS // 2
+        part1 = mcp.types.TextContent(type="text", text="a" * (half + 100))
+        part2 = mcp.types.TextContent(type="text", text="b" * (half + 100))
+        result = _make_result([part1, part2])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        # part1 passes, part2 gets truncated, plus truncation notice
+        total_text = sum(
+            len(p.text)
+            for p in out.output
+            if isinstance(p, TextPart) and "truncated" not in p.text.lower()
+        )
+        assert total_text <= MCP_MAX_OUTPUT_CHARS
+
+    def test_budget_exhausted_skips_remaining_text(self):
+        """When budget is fully consumed, subsequent text parts are skipped."""
+        full = mcp.types.TextContent(type="text", text="x" * MCP_MAX_OUTPUT_CHARS)
+        extra = mcp.types.TextContent(type="text", text="should be dropped")
+        result = _make_result([full, extra])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        # full text + truncation notice (extra is dropped)
+        texts = [p for p in out.output if isinstance(p, TextPart)]
+        assert len(texts) == 2
+        assert "truncated" in texts[-1].text.lower()
+
+    def test_error_result_preserves_truncation(self):
+        big_text = "e" * (MCP_MAX_OUTPUT_CHARS + 1000)
+        result = _make_result([mcp.types.TextContent(type="text", text=big_text)], is_error=True)
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolError)
+        assert len(out.output) == 2
+        assert "truncated" in out.output[1].text.lower()
+
+    def test_image_not_counted_against_budget(self):
+        """Non-text parts (images) don't consume the character budget."""
+        img = mcp.types.ImageContent(type="image", data="AAAA", mimeType="image/png")
+        text = mcp.types.TextContent(type="text", text="hello")
+        result = _make_result([img, text])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        assert len(out.output) == 2
+        assert out.output[1].text == "hello"
+
+
+class TestMCPUnsupportedContent:
+    def test_unsupported_content_type_becomes_text_error(self):
+        """Unknown content type should not crash, but produce an error placeholder."""
+        # Create a content block with an unknown type
+        unknown = MagicMock(spec=[])  # empty spec = no known attributes
+        result = _make_result([unknown])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        assert len(out.output) == 1
+        assert "unsupported" in out.output[0].text.lower()
+
+    def test_unsupported_blob_mimetype_becomes_text_error(self):
+        """EmbeddedResource with unsupported mime type should not crash."""
+        blob = mcp.types.EmbeddedResource(
+            type="resource",
+            resource=mcp.types.BlobResourceContents(
+                uri="file:///test.bin",
+                mimeType="application/x-custom",
+                blob="deadbeef",
+            ),
+        )
+        result = _make_result([blob])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        assert len(out.output) == 1
+        assert "unsupported" in out.output[0].text.lower()
+
+    def test_mixed_valid_and_invalid_parts(self):
+        """Valid parts should still be converted even when some fail."""
+        good = mcp.types.TextContent(type="text", text="valid")
+        bad = MagicMock(spec=[])
+        result = _make_result([good, bad])
+        out = convert_mcp_tool_result(result)
+        assert isinstance(out, ToolOk)
+        assert len(out.output) == 2
+        assert out.output[0].text == "valid"
+        assert "unsupported" in out.output[1].text.lower()


### PR DESCRIPTION
## Summary

- Add 100K character budget to `convert_mcp_tool_result()` — MCP tools like Playwright can return 500KB+ DOM or multi-MB base64, bypassing the 50K limit on built-in tools (`ToolResultBuilder`), causing context overflow (API 400) or wire pipe stalls
- Catch `ValueError` from `convert_mcp_content()` for unsupported content types/MIME — previously crashed the entire turn, now replaced with `[Unsupported content: ...]` placeholder
- All content types (text, image, audio, video) share the same budget — oversized media parts are dropped instead of passing through uncapped
- Truncation notice appended with pagination guidance when budget exceeded

```
MCP Server → CallToolResult
                │
                ▼
        convert_mcp_tool_result()
                │
     ┌──────────┼──────────┐
     ▼          ▼          ▼
  TextPart   MediaPart   Unknown
     │          │          │
     │          │       ValueError
     │          │      → placeholder
     │          │
  ┌──┴──┐   ┌──┴──┐
  │≤100K│   │≤rest│
  │keep  │   │keep │
  ├─────┤   ├─────┤
  │>100K│   │>rest│
  │trunc│   │drop │
  └──┬──┘   └──┬──┘
     └────┬────┘
          ▼
   over? → append "[Output truncated: ...]"
          ▼
     ToolOk / ToolError → Context → API
```

## Changes

| Path | What changed |
|------|-------------|
| `src/kimi_cli/soul/toolset.py:650` | `MCP_MAX_OUTPUT_CHARS = 100_000` constant |
| `src/kimi_cli/soul/toolset.py:656` | `_media_part_size()` helper for image/audio/video budget |
| `src/kimi_cli/soul/toolset.py:667-735` | Rewritten `convert_mcp_tool_result()` with unified char budget + ValueError catch |
| `tests/tools/test_mcp_tool_result.py` | 13 tests (text truncation × 6, media truncation × 4, unsupported content × 3) |

## Test plan

- [x] 13 unit tests via pytest (text truncation, media budget enforcement, unsupported content handling)
- [x] Integration test on **Linux** (Docker, Python 3.14.4) — 8/8 passed
- [x] Integration test on **Windows** (Python 3.14.2) — 8/8 passed
- [x] Regression: `tests/tools/` + `tests/core/` + `tests/hooks/` — 980 passed
- [x] `ruff check` + `ruff format --check` + `pyright` — 0 errors