### PR TITLE
perf(notifications): O(1) dedupe lookup via in-memory index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Reduce idle CPU and typing latency for heavy background-task users — `NotificationManager.find_by_dedupe_key` now uses an in-memory `dedupe_key → notification_id` index (lazy-built, maintained by `publish()`), turning publish from an O(N) directory scan into an O(1) lookup; previously, sessions that spawned many `Agent(run_in_background=True)` or `Shell(run_in_background=True)` tool calls over a long session would see the main asyncio event loop saturate as each 1 Hz reconcile poll rescanned every notification, causing visible typing lag and streaming stutter while the process sat at ~100% CPU with the rest of the machine idle
 - Core: Truncate MCP tool output to 100K characters to prevent context overflow — all content types (text and inline media such as image/audio/video data URLs) share a single character budget; tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; oversized media parts are dropped; unsupported MCP content types are gracefully handled instead of crashing the turn
 - CLI: Fix PyInstaller binary missing lazy CLI subcommands — `kimi info`, `kimi export`, `kimi mcp`, `kimi plugin`, `kimi vis`, and `kimi web` now work correctly in the standalone binary distribution
 

--- a/src/kimi_cli/notifications/manager.py
+++ b/src/kimi_cli/notifications/manager.py
@@ -5,6 +5,8 @@ import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from kimi_cli.config import NotificationConfig
 from kimi_cli.utils.logging import logger
 
@@ -21,6 +23,13 @@ class NotificationManager:
     def __init__(self, root: Path, config: NotificationConfig) -> None:
         self._config = config
         self._store = NotificationStore(root)
+        # dedupe_key -> notification_id index for O(1) find_by_dedupe_key.
+        # None means "not yet built"; built lazily on first query by scanning
+        # the store once, then maintained incrementally by publish().
+        # Invariant: NotificationEvent.dedupe_key is set at create_notification
+        # time and never mutates (write_event is unused in the tree), so no
+        # invalidation is required for in-place updates.
+        self._dedupe_index: dict[str, str] | None = None
 
     @property
     def store(self) -> NotificationStore:
@@ -32,11 +41,34 @@ class NotificationManager:
     def _initial_delivery(self, event: NotificationEvent) -> NotificationDelivery:
         return NotificationDelivery(sinks={sink: NotificationSinkState() for sink in event.targets})
 
-    def find_by_dedupe_key(self, dedupe_key: str) -> NotificationView | None:
+    def _ensure_dedupe_index(self) -> dict[str, str]:
+        if self._dedupe_index is not None:
+            return self._dedupe_index
+        index: dict[str, str] = {}
         for view in self._store.list_views():
-            if view.event.dedupe_key == dedupe_key:
-                return view
-        return None
+            if view.event.dedupe_key:
+                index[view.event.dedupe_key] = view.event.id
+        self._dedupe_index = index
+        return index
+
+    def find_by_dedupe_key(self, dedupe_key: str) -> NotificationView | None:
+        index = self._ensure_dedupe_index()
+        notification_id = index.get(dedupe_key)
+        if notification_id is None:
+            return None
+        try:
+            return self._store.merged_view(notification_id)
+        except (FileNotFoundError, ValueError, ValidationError) as exc:
+            # Indexed file vanished or cannot be parsed. Drop the cache so the
+            # next lookup rebuilds from disk and surface the anomaly.
+            logger.warning(
+                "Stale dedupe index entry dropped: dedupe_key={key} id={nid} error={err}",
+                key=dedupe_key,
+                nid=notification_id,
+                err=exc,
+            )
+            self._dedupe_index = None
+            return None
 
     def publish(self, event: NotificationEvent) -> NotificationView:
         if event.dedupe_key:
@@ -45,6 +77,8 @@ class NotificationManager:
                 return existing
         delivery = self._initial_delivery(event)
         self._store.create_notification(event, delivery)
+        if event.dedupe_key and self._dedupe_index is not None:
+            self._dedupe_index[event.dedupe_key] = event.id
         return NotificationView(event=event, delivery=delivery)
 
     def recover(self) -> None:

--- a/tests/notifications/test_notification_manager.py
+++ b/tests/notifications/test_notification_manager.py
@@ -291,3 +291,109 @@ def test_recover_skips_notification_with_structurally_invalid_event(runtime) -> 
 
     views = manager.store.list_views()
     assert [view.event.id for view in views] == [event.event.id]
+
+
+def _make_dedupe_event(manager, source_id: str, dedupe_key: str) -> NotificationEvent:
+    return NotificationEvent(
+        id=manager.new_id(),
+        category="task",
+        type="task.completed",
+        source_kind="background_task",
+        source_id=source_id,
+        title=f"Task {source_id} completed",
+        body="done",
+        dedupe_key=dedupe_key,
+    )
+
+
+def test_find_by_dedupe_key_builds_index_lazily(runtime, monkeypatch) -> None:
+    manager = runtime.notifications
+    manager.publish(_make_dedupe_event(manager, "b0000001", "bg:b0000001:completed"))
+    manager.publish(_make_dedupe_event(manager, "b0000002", "bg:b0000002:completed"))
+
+    # Drop the index so the next lookup rebuilds from disk, then count how
+    # often the store is scanned.
+    manager._dedupe_index = None
+    calls: list[None] = []
+    original = manager._store.list_views
+
+    def counting_list_views() -> list:
+        calls.append(None)
+        return original()
+
+    monkeypatch.setattr(manager._store, "list_views", counting_list_views)
+
+    first = manager.find_by_dedupe_key("bg:b0000001:completed")
+    second = manager.find_by_dedupe_key("bg:b0000002:completed")
+
+    assert first is not None and first.event.source_id == "b0000001"
+    assert second is not None and second.event.source_id == "b0000002"
+    # The store should be scanned exactly once — on the first lookup.
+    assert len(calls) == 1
+
+
+def test_publish_updates_dedupe_index_without_rescan(runtime, monkeypatch) -> None:
+    manager = runtime.notifications
+    # Prime the index with an empty store.
+    manager._ensure_dedupe_index()
+
+    calls: list[None] = []
+    original = manager._store.list_views
+
+    def counting_list_views() -> list:
+        calls.append(None)
+        return original()
+
+    monkeypatch.setattr(manager._store, "list_views", counting_list_views)
+
+    manager.publish(_make_dedupe_event(manager, "b0000003", "bg:b0000003:completed"))
+    # Second publish with the same dedupe_key must return the existing view
+    # without scanning the store.
+    duplicate = _make_dedupe_event(manager, "b0000003", "bg:b0000003:completed")
+    duplicate = duplicate.model_copy(update={"id": manager.new_id()})
+    existing = manager.publish(duplicate)
+
+    assert existing.event.dedupe_key == "bg:b0000003:completed"
+    assert existing.event.source_id == "b0000003"
+    # publish() must not trigger a store rescan once the index is live.
+    assert calls == []
+
+
+def test_find_by_dedupe_key_recovers_from_stale_entry(runtime) -> None:
+    import shutil
+
+    manager = runtime.notifications
+    published = manager.publish(_make_dedupe_event(manager, "b0000004", "bg:b0000004:completed"))
+
+    # Force-delete the notification directory out from under the manager —
+    # simulating a missing-file race.
+    shutil.rmtree(manager.store.notification_dir(published.event.id))
+
+    # The indexed lookup must return None and invalidate the cache so a
+    # subsequent publish of the same dedupe_key can create a fresh entry.
+    first = manager.find_by_dedupe_key("bg:b0000004:completed")
+    assert first is None
+    assert manager._dedupe_index is None
+
+    recreated = manager.publish(_make_dedupe_event(manager, "b0000004", "bg:b0000004:completed"))
+    assert recreated.event.id != published.event.id
+    assert manager.find_by_dedupe_key("bg:b0000004:completed") is not None
+
+
+def test_publish_without_dedupe_key_does_not_touch_index(runtime) -> None:
+    manager = runtime.notifications
+    manager._ensure_dedupe_index()
+    snapshot = dict(manager._dedupe_index or {})
+
+    event = NotificationEvent(
+        id=manager.new_id(),
+        category="system",
+        type="system.info",
+        source_kind="test",
+        source_id="no-dedupe",
+        title="x",
+        body="y",
+    )
+    manager.publish(event)
+
+    assert manager._dedupe_index == snapshot


### PR DESCRIPTION
## What

`NotificationManager.find_by_dedupe_key` currently rescans the entire notification directory on every call. Because every terminal background-task notification is emitted with a `dedupe_key` (to keep `publish` idempotent per task), and because the reconcile loop polls the store at ~1 Hz, the O(N) scan becomes the inner loop of an O(M × N) pattern: `publish_terminal_notifications` walks M terminal tasks, each `publish()` then walks every one of N notifications.

Replace the scan with an in-memory `dedupe_key → notification_id` dict, lazy-built on first lookup and maintained incrementally by `publish()`. `find_by_dedupe_key` becomes O(1) on a hit; cache is dropped if the indexed file has gone missing or cannot be parsed so the next lookup rebuilds from disk.

## Why

Heavy background-task users (orchestrator prompts that spawn many `Agent(run_in_background=True)` or `Shell(run_in_background=True)` calls across a long session) observed simultaneous typing-echo lag and streaming stutter while the CLI process sat at ~100 % CPU with the rest of the machine idle.

Diagnosis was via coredump + live stress test. The pattern matches exactly what a blocked asyncio event loop looks like from the outside: typing input queues up, SSE chunks stall, and prompt_toolkit can't repaint, while any CPU-bound work (pydantic validation of N × 2 `model_validate_json` calls per second) saturates the single GIL-bound thread.

## Numbers

Stress test on Apple Silicon M-series / APFS SSD (best-case storage), local scripted-echo provider driving `Agent(run_in_background=True)` calls to accumulate real tasks and notifications. Prompt schedule and sampling identical across both runs.

|                                    | baseline (1.31.0) | patched | improvement |
| ---------------------------------- | -----------------:| -------:| -----------:|
| CPU median, full run               |             98.8 % |  35.8 % |       2.8 × |
| CPU mean, full run                 |             83.8 % |  33.9 % |       2.5 × |
| CPU at N ≈ 170 (paired sample)     |            100.0 % |  13.6 % |       7.4 × |
| py-spy dumps on the hot path       |            5 / 5   |   0 / 6 |           — |
| Typing echo median                 |            535 ms  |   22 ms |      24.3 × |
| Max N reached before queue drain   |              184   |    406  | — (event loop was previously self-limiting) |

py-spy consistently caught the baseline main thread in:

```
find_by_dedupe_key → list_views → merged_view → read_event / read_delivery → pathlib.read_text
    ⤴ publish → publish_terminal_notifications → reconcile → deliver_pending → poll_once → run_forever
```

Patched dumps caught the main thread in `asyncio.selectors.select` (idle, waiting for I/O) — the expected state.

## Scope & alternatives considered

- **In-memory dedupe index (this PR).** Minimum viable fix. ~40 LOC in `NotificationManager`, zero behavioral change, zero new knobs.
- **Caller-side batching in `publish_terminal_notifications`.** Would also eliminate the second `list_views` scan inside `BackgroundTaskManager.reconcile` (`recover()` + `publish_terminal_notifications()` both scan). Considered for inclusion but deferred: `recover()` can write runtime updates ("lost" status) that `publish_terminal_notifications` must see, so naive snapshot-once breaks `test_reconcile_recovers_and_publishes_lost_notification`. A follow-up PR can share a mutation-aware snapshot safely.
- **`asyncio.to_thread(reconcile)` at the caller.** Hides the O(N²) cost on a worker thread but doesn't fix it — a worker pegging a core at 100 % is still a regression, just less user-visible.
- **Make `NotificationStore` fully async (aiofiles).** Larger diff, changes the API shape of the store. Orthogonal to the algorithmic fix here.

## Correctness notes

- **Staleness from `write_event`:** `NotificationStore.write_event` has no callers in the tree today, so `dedupe_key` is immutable after `create_notification`. A code comment documents the invariant; if a future caller mutates `dedupe_key` in place it will need to invalidate the index.
- **Staleness from external file deletion:** covered by `test_find_by_dedupe_key_recovers_from_stale_entry`. `find_by_dedupe_key` catches `FileNotFoundError` / `ValueError` / `ValidationError` from `merged_view`, logs a warning, drops the cache, and returns `None`. Next publish with the same key legitimately creates a fresh notification.
- **Concurrent publish:** `publish()` has no `await` points, so two asyncio tasks cannot interleave a `find → create` race on the same dedupe_key within a single event loop. Same as pre-patch.
- **Cross-process writes:** notification stores are per-session (`session.context_file.parent / "notifications"`), not under a shared `KIMI_SHARE_DIR`. No cross-process coordination needed.

## Tests

Added to `tests/notifications/test_notification_manager.py`:

- `test_find_by_dedupe_key_builds_index_lazily` — two lookups touch `list_views` exactly once.
- `test_publish_updates_dedupe_index_without_rescan` — duplicate publish returns existing without rescan.
- `test_find_by_dedupe_key_recovers_from_stale_entry` — deleting the notification dir invalidates the cache and permits re-create.
- `test_publish_without_dedupe_key_does_not_touch_index` — non-dedupe fast path.

Full test suite (`pytest tests/ -q --ignore=tests/e2e`) passes: 2220 passed, 7 skipped.

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective.
- [x] I have updated `CHANGELOG.md`.
- [x] Ruff lint + format clean on touched files.
- [x] Pyright clean on touched files.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
