### PR TITLE
Remind model do not use unsafe pattern

### DIFF
--- a/src/kimi_cli/tools/file/glob.py
+++ b/src/kimi_cli/tools/file/glob.py
@@ -16,7 +16,7 @@ MAX_MATCHES = 1000
 
 
 class Params(BaseModel):
-    pattern: str = Field(description=("Glob pattern to match files/directories."))
+    pattern: str = Field(description=("Glob pattern to match files/directories. NEVER start with '**'"))
     directory: str | None = Field(
         description=(
             "Absolute path to the directory to search in (defaults to working directory)."


### PR DESCRIPTION
A very simple pattern description: tell model never start  with `**` in glob pattern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
