### PR TITLE
feat(shell): compact thinking indicator with animated dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Only write entries that are worth mentioning to users.
 
 - Core: Truncate MCP tool output to 100K characters to prevent context overflow — all content types (text and inline media such as image/audio/video data URLs) share a single character budget; tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; oversized media parts are dropped; unsupported MCP content types are gracefully handled instead of crashing the turn
 - CLI: Fix PyInstaller binary missing lazy CLI subcommands — `kimi info`, `kimi export`, `kimi mcp`, `kimi plugin`, `kimi vis`, and `kimi web` now work correctly in the standalone binary distribution
+- Shell: Streamline the thinking indicator into a compact single-line layout — shows a `Thinking` label with animated dots, elapsed time, token count, and a live tokens/second pulse; finalises with a `Thought for Xs · N tokens` trace in history
 
 ## 1.31.0 (2026-04-10)
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -6,6 +6,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 - Core: Truncate MCP tool output to 100K characters to prevent context overflow — all content types (text and inline media such as image/audio/video data URLs) share a single character budget; tools like Playwright that return full DOMs (500KB+) or large base64 screenshots are now capped with a truncation notice; oversized media parts are dropped; unsupported MCP content types are gracefully handled instead of crashing the turn
 - CLI: Fix PyInstaller binary missing lazy CLI subcommands — `kimi info`, `kimi export`, `kimi mcp`, `kimi plugin`, `kimi vis`, and `kimi web` now work correctly in the standalone binary distribution
+- Shell: Streamline the thinking indicator into a compact single-line layout — shows a `Thinking` label with animated dots, elapsed time, token count, and a live tokens/second pulse; finalises with a `Thought for Xs · N tokens` trace in history
 
 ## 1.31.0 (2026-04-10)
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,6 +6,7 @@
 
 - Core：将 MCP 工具输出截断至 10 万字符以防止上下文溢出——所有内容类型（文本和内联媒体如 image/audio/video data URL）共享同一字符预算；Playwright 等返回完整 DOM（500KB+）或大型 base64 截图的工具现在会被截断并附加提示信息；超出预算的媒体部分会被丢弃；不支持的 MCP 内容类型会被优雅处理而非导致当前轮次崩溃
 - CLI：修复 PyInstaller 二进制包缺少延迟加载 CLI 子命令的问题——`kimi info`、`kimi export`、`kimi mcp`、`kimi plugin`、`kimi vis` 和 `kimi web` 现在在独立二进制分发中可正常使用
+- Shell：将思考指示器精简为紧凑的单行布局——显示 `Thinking` 标签、动画点、耗时、token 数和实时的 tokens/秒脉冲；结束后在历史中留下 `Thought for Xs · N tokens` 痕迹
 
 ## 1.31.0 (2026-04-10)
 

--- a/src/kimi_cli/ui/shell/visualize/_blocks.py
+++ b/src/kimi_cli/ui/shell/visualize/_blocks.py
@@ -46,16 +46,27 @@ from kimi_cli.wire.types import (
 )
 
 _ELLIPSIS = "..."
-_THINKING_PREVIEW_LINES = 6
-_PENDING_PREVIEW_LINES = 8
 _SELF_CLOSING_BLOCKS = frozenset(("fence", "code_block", "hr", "html_block"))
 MAX_SUBAGENT_TOOL_CALLS_TO_SHOW = 4
 
+# Animated bullet frames shown after the "Thinking" label. Dots grow in
+# from the left, reach three, then drain out from the left — a continuous
+# rightward flow that loops every ``_BULLET_FRAME_INTERVAL * len(frames)``.
+_BULLET_FRAMES = (".  ", ".. ", "...", " ..", "  .", "   ")
+_BULLET_FRAME_INTERVAL = 0.13  # seconds per frame
 
-def _truncate_to_display_width(line: str, max_width: int) -> str:
+
+def _bullet_frame_for(elapsed: float) -> str:
+    """Select the current bullet frame from wall-clock elapsed time."""
+    idx = int(elapsed / _BULLET_FRAME_INTERVAL) % len(_BULLET_FRAMES)
+    return _BULLET_FRAMES[idx]
+
+
+def _truncate_to_display_width(line: str, max_width: int) -> str:  # pyright: ignore[reportUnusedFunction]
     """Truncate *line* so its terminal display width fits within *max_width*.
 
     Uses ``rich.cells.cell_len`` for CJK-aware column width measurement.
+    Kept for backwards-compatible re-export from ``visualize/__init__.py``.
     """
     from rich.cells import cell_len
 
@@ -152,8 +163,11 @@ def _find_committed_boundary(text: str) -> int | None:
     return offset
 
 
-def _tail_lines(text: str, n: int) -> str:
-    """Extract the last *n* lines from *text* via reverse scanning (O(n))."""
+def _tail_lines(text: str, n: int) -> str:  # pyright: ignore[reportUnusedFunction]
+    """Extract the last *n* lines from *text* via reverse scanning (O(n)).
+
+    Kept for backwards-compatible re-export from ``visualize/__init__.py``.
+    """
     pos = len(text)
     for _ in range(n):
         pos = text.rfind("\n", 0, pos)
@@ -170,8 +184,12 @@ class _ContentBlock:
     giving users real-time streaming output.  Only the unconfirmed tail remains
     in the transient Rich Live area.
 
-    For **thinking** (``is_think=True``), content stays in the Live area as a
-    scrolling preview until the block is finalized.
+    For **thinking** (``is_think=True``), the raw reasoning text is kept only
+    for token accounting and never rendered.  The Live area shows a compact
+    ``Thinking`` label with an animated bullet sequence, followed by elapsed
+    time, token count, and a live tokens/second pulse.  When the block ends,
+    a compact one-liner ``Thought for Xs · N tokens`` is committed to history
+    in grey italics.
     """
 
     def __init__(self, is_think: bool):
@@ -195,35 +213,36 @@ class _ContentBlock:
             self._flush_committed()
 
     def compose(self) -> RenderableType:
-        """Render the transient Live area content."""
-        pending = self._pending_text()
+        """Render the transient Live area content.
 
-        # Thinking: always show spinner + preview.
+        Thinking mode shows the italic ``Thinking`` label with animated
+        bullets; composing mode shows the dots spinner over the
+        uncommitted markdown tail.
+        """
         if self.is_think:
-            spinner = self._compose_spinner()
-            if not pending:
-                return spinner
-            preview = self._build_preview(pending)
-            return Group(spinner, Text(preview, style="grey50 italic"))
-
-        # Composing: always show spinner with elapsed time and token count.
-        # Committed blocks are already printed permanently above.
+            return self._compose_thinking()
         return self._compose_spinner()
 
     def compose_final(self) -> RenderableType:
         """Render the remaining uncommitted content when the block ends."""
+        if self.is_think:
+            elapsed_str = format_elapsed(time.monotonic() - self._start_time)
+            count_str = format_token_count(int(self._token_count))
+            return Text(
+                f"Thought for {elapsed_str} · {count_str} tokens",
+                style="grey50 italic",
+            )
         remaining = self._pending_text()
         if not remaining:
             return Text("")
-        if self.is_think:
-            return BulletColumns(
-                Markdown(remaining, style="grey50 italic"),
-                bullet_style="grey50",
-            )
         return self._wrap_bullet(Markdown(remaining))
 
     def has_pending(self) -> bool:
         """Whether there is uncommitted content to flush."""
+        # Thinking blocks always commit a final trace line if any content
+        # was received, so gate on raw_text rather than uncommitted length.
+        if self.is_think:
+            return bool(self.raw_text)
         return bool(self._pending_text())
 
     # -- Private -------------------------------------------------------------
@@ -252,23 +271,39 @@ class _ContentBlock:
 
     def _compose_spinner(self) -> Spinner:
         elapsed = time.monotonic() - self._start_time
-        label = "Thinking..." if self.is_think else "Composing..."
         elapsed_str = format_elapsed(elapsed)
         count_str = f"{format_token_count(int(self._token_count))} tokens"
 
         self._spinner.text = Text.assemble(
-            (label, ""),
+            ("Composing...", ""),
             (f" {elapsed_str}", "grey50"),
             (f" · {count_str}", "grey50"),
         )
         return self._spinner
 
-    def _build_preview(self, text: str) -> str:
-        max_lines = _THINKING_PREVIEW_LINES if self.is_think else _PENDING_PREVIEW_LINES
-        max_width = console.width - 2 if console.width else 78
-        tail_text = _tail_lines(text, max_lines)
-        lines = tail_text.split("\n")
-        return "\n".join(_truncate_to_display_width(line, max_width) for line in lines)
+    def _compose_thinking(self) -> Text:
+        """Render the thinking line: italic Thinking + bullets + metadata."""
+        elapsed = time.monotonic() - self._start_time
+        elapsed_str = format_elapsed(elapsed)
+        tokens_int = int(self._token_count)
+        count_str = f"{format_token_count(tokens_int)} tokens"
+        frame = _bullet_frame_for(elapsed)
+
+        parts: list[tuple[str, str | Style]] = [
+            ("Thinking", "italic"),
+            (f" {frame}", "cyan"),
+            (f"  {elapsed_str}", "grey50"),
+            (f" · {count_str}", "grey50"),
+        ]
+
+        # Live tok/s pulse — a real heartbeat signal that confirms the model
+        # is still streaming even when the raw content is hidden.
+        if elapsed > 0.5 and tokens_int > 0:
+            rate = int(tokens_int / elapsed)
+            if rate > 0:
+                parts.append((f" · {rate} tok/s", "grey50"))
+
+        return Text.assemble(*parts)
 
 
 class _ToolCallBlock:


### PR DESCRIPTION
## Description

Streamline the thinking indicator into a compact single-line layout.

The previous multi-line preview is replaced with a `Thinking` label, an
animated dot sequence, elapsed time, token count, and a live tokens/second
pulse — keeping clear progress feedback in a much smaller footprint. When
the thinking block ends, a one-line `Thought for Xs · N tokens` trace is
committed to history.

Implementation lives entirely in `_ContentBlock`
(`src/kimi_cli/ui/shell/visualize/_blocks.py`) and only affects the
`is_think=True` branch — the composing path is unchanged. The animation
is driven by `time.monotonic()` and frame-index modulo, with no
per-frame state to maintain.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
