### PR TITLE
fix(fetch): suppress duplicated extracted comment text

### DIFF
--- a/src/kimi_cli/tools/web/fetch.py
+++ b/src/kimi_cli/tools/web/fetch.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import override
 
@@ -5,6 +6,7 @@ import aiohttp
 import trafilatura
 from kosong.tooling import CallableTool2, ToolReturnValue
 from pydantic import BaseModel, Field
+from trafilatura.settings import Document
 
 from kimi_cli.config import Config
 from kimi_cli.constant import USER_AGENT
@@ -14,9 +16,50 @@ from kimi_cli.tools.utils import ToolResultBuilder, load_desc
 from kimi_cli.utils.aiohttp import new_client_session
 from kimi_cli.utils.logging import logger
 
+_METADATA_FIELDS = (
+    "title",
+    "author",
+    "url",
+    "hostname",
+    "description",
+    "sitename",
+    "date",
+    "categories",
+    "tags",
+    "fingerprint",
+    "id",
+    "license",
+)
+
 
 class Params(BaseModel):
     url: str = Field(description="The URL to fetch content from.")
+
+
+def _normalize_extracted_text(text: str) -> str:
+    return re.sub(r"[\W_]+", "", text.casefold())
+
+
+def _comments_duplicate_main_text(main_text: str, comments_text: str) -> bool:
+    if not main_text or not comments_text:
+        return False
+    return _normalize_extracted_text(main_text) == _normalize_extracted_text(comments_text)
+
+
+def _render_extracted_document(document: Document) -> str:
+    header_lines = ["---"]
+    for attr in _METADATA_FIELDS:
+        value = getattr(document, attr, None)
+        if value:
+            header_lines.append(f"{attr}: {value}")
+    header_lines.append("---")
+
+    parts = ["\n".join(header_lines)]
+    if main_text := getattr(document, "text", None):
+        parts.append(main_text)
+    if comments_text := getattr(document, "comments", None):
+        parts.append(comments_text)
+    return "\n".join(parts).strip()
 
 
 class FetchURL(CallableTool2[Params]):
@@ -85,16 +128,15 @@ class FetchURL(CallableTool2[Params]):
                 brief="Empty response body",
             )
 
-        extracted_text = trafilatura.extract(
+        document = trafilatura.bare_extraction(
             resp_text,
             include_comments=True,
             include_tables=True,
             include_formatting=False,
-            output_format="txt",
             with_metadata=True,
         )
 
-        if not extracted_text:
+        if not document or isinstance(document, dict):
             return builder.error(
                 (
                     "Failed to extract meaningful content from the page. "
@@ -104,7 +146,23 @@ class FetchURL(CallableTool2[Params]):
                 brief="No content extracted",
             )
 
-        builder.write(extracted_text)
+        main_text = document.text or ""
+        comments_text = document.comments or ""
+        if not (main_text or comments_text):
+            return builder.error(
+                (
+                    "Failed to extract meaningful content from the page. "
+                    "This may indicate the page content is not suitable for text extraction, "
+                    "or the page requires JavaScript to render its content."
+                ),
+                brief="No content extracted",
+            )
+
+        if _comments_duplicate_main_text(main_text, comments_text):
+            document.comments = None
+            document.commentsbody = None
+
+        builder.write(_render_extracted_document(document))
         return builder.ok("The returned content is the main text content extracted from the page.")
 
     async def _fetch_with_service(self, params: Params) -> ToolReturnValue:

--- a/tests/tools/test_fetch_url.py
+++ b/tests/tools/test_fetch_url.py
@@ -12,8 +12,9 @@ import pytest_asyncio
 from aiohttp import web
 from inline_snapshot import snapshot
 from kosong.tooling import ToolReturnValue
+from trafilatura.settings import Document
 
-from kimi_cli.tools.web.fetch import FetchURL, Params
+from kimi_cli.tools.web.fetch import FetchURL, Params, _comments_duplicate_main_text
 
 
 class MockServerFactory(Protocol):
@@ -197,6 +198,60 @@ This is a markdown document.
     assert not result.is_error
     assert result.output == snapshot(complex_markdown)
     assert result.message == "The returned content is the full content of the page."
+
+
+def test_fetch_url_detects_duplicate_comment_text() -> None:
+    main_text = (
+        "The default parameter value for `optimizer` should probably be `adamw` "
+        "instead of `adamW` according to how `get_optimizer` is written."
+    )
+    duplicate_comments_text = """\
+The default parameter value for
+optimizer
+should probably beadamw
+instead ofadamW
+according to howget_optimizer
+is written."""
+    distinct_comments_text = "hi, thanks for bringing up. We fixed it now"
+
+    assert _comments_duplicate_main_text(main_text, duplicate_comments_text)
+    assert not _comments_duplicate_main_text(main_text, distinct_comments_text)
+
+
+async def test_fetch_url_accepts_comment_only_extraction(
+    fetch_url_tool: FetchURL,
+    mock_http_server: MockServerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server_url = await mock_http_server("<html><body>placeholder</body></html>")
+
+    monkeypatch.setattr(
+        "kimi_cli.tools.web.fetch.trafilatura.bare_extraction",
+        lambda *args, **kwargs: Document(
+            title="Comment-only thread",
+            url=f"{server_url}/",
+            hostname="127.0.0.1",
+            text="",
+            comments="Only the comment thread contains useful content.",
+        ),
+    )
+
+    result = await fetch_url_tool(Params(url=f"{server_url}/"))
+
+    assert not result.is_error
+    assert (
+        result.message == "The returned content is the main text content extracted from the page."
+    )
+    assert result.output == snapshot(
+        f"""\
+---
+title: Comment-only thread
+url: {server_url}/
+hostname: 127.0.0.1
+---
+Only the comment thread contains useful content.\
+"""
+    )
 
 
 async def test_fetch_url_with_service(runtime) -> None:


### PR DESCRIPTION
## Summary

- switch the HTML extraction path in `FetchURL` to inspect Trafilatura's main text and comments separately
- suppress extracted comments when they normalize to the same content as the main body
- add a regression test for duplicated GitHub issue extraction output

## Root cause

`trafilatura` with `include_comments=True` can misclassify GitHub issue body content as comments and append a second malformed copy of the same text.

For pages like `https://github.com/MoonshotAI/Moonlight/issues/4`, this caused `FetchURL` to return the issue body twice:
- once as the normal extracted main content
- once again as a malformed "comment" block with missing spacing around inline code

## Testing

- `uv run pytest tests/tools/test_fetch_url.py -q`
- `uv run pytest tests/tools/test_tool_descriptions.py -q`
- `uv run pytest tests/tools/test_tool_schemas.py -q`

## Related issue

- Closes #1862

## Notes

- `make test` still reports an unrelated existing failure in `tests/e2e/test_shell_modal_e2e.py::test_approval_consecutive_across_turns`
- the `fetch_url` regression covered by this change passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
