### PR TITLE
feat(ui): show live and average tokens per second in shell UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Show live and average tokens per second in the shell UI — live TPS appears in the composing and thinking spinners after 0.5s, and a summary line with the average rate is printed at turn end
 - Shell: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking so highlight spans land correctly after tab expansion
 
 ## 1.33.0 (2026-04-13)

--- a/src/kimi_cli/ui/shell/visualize/_blocks.py
+++ b/src/kimi_cli/ui/shell/visualize/_blocks.py
@@ -246,7 +246,7 @@ class _ContentBlock:
         elapsed_str = format_elapsed(time.monotonic() - self._start_time)
         count_str = format_token_count(int(self._token_count))
         avg_tps = self._average_tps()
-        if not avg_tps and int(self._token_count) == 0:
+        if int(self._token_count) == 0:
             return None
         text = Text.assemble(
             ("Composed", ""),
@@ -258,13 +258,15 @@ class _ContentBlock:
         return text
 
     def _average_tps(self) -> int | None:
-        elapsed = time.monotonic() - self._start_time
-        tokens_int = int(self._token_count)
-        seconds = max(1, int(elapsed))
-        if tokens_int > 0:
-            rate = int(tokens_int / seconds)
-            return rate if rate > 0 else None
-        return None
+        return self._compute_tps(time.monotonic() - self._start_time, int(self._token_count))
+
+    @staticmethod
+    def _compute_tps(elapsed: float, tokens_int: int) -> int | None:
+        """Compute tokens per second; guard against early noisy samples."""
+        if elapsed <= 0.5 or tokens_int <= 0:
+            return None
+        rate = int(tokens_int / elapsed)
+        return rate if rate > 0 else None
 
     def has_pending(self) -> bool:
         """Whether there is uncommitted content to flush."""
@@ -303,20 +305,16 @@ class _ContentBlock:
         elapsed_str = format_elapsed(elapsed)
         count_str = f"{format_token_count(int(self._token_count))} tokens"
 
-        tps_str = ""
-        tokens_int = int(self._token_count)
-        seconds = max(1, int(elapsed))
-        if elapsed > 0.5 and tokens_int > 0:
-            rate = int(tokens_int / seconds)
-            if rate > 0:
-                tps_str = f" · {rate} tok/s"
-
-        self._spinner.text = Text.assemble(
+        parts: list[tuple[str, str | Style]] = [
             ("Composing...", ""),
             (f" {elapsed_str}", "grey50"),
             (f" · {count_str}", "grey50"),
-            (tps_str, "grey50"),
-        )
+        ]
+        tps = self._compute_tps(elapsed, int(self._token_count))
+        if tps:
+            parts.append((f" · {tps} tok/s", "grey50"))
+
+        self._spinner.text = Text.assemble(*parts)
         return self._spinner
 
     def _compose_thinking(self) -> Text:
@@ -335,11 +333,9 @@ class _ContentBlock:
         ]
 
         # Live tok/s pulse
-        seconds = max(1, int(elapsed))
-        if elapsed > 0.5 and tokens_int > 0:
-            rate = int(tokens_int / seconds)
-            if rate > 0:
-                parts.append((f" · {rate} tok/s", "grey50"))
+        tps = self._compute_tps(elapsed, tokens_int)
+        if tps:
+            parts.append((f" · {tps} tok/s", "grey50"))
 
         return Text.assemble(*parts)
 

--- a/src/kimi_cli/ui/shell/visualize/_blocks.py
+++ b/src/kimi_cli/ui/shell/visualize/_blocks.py
@@ -228,14 +228,43 @@ class _ContentBlock:
         if self.is_think:
             elapsed_str = format_elapsed(time.monotonic() - self._start_time)
             count_str = format_token_count(int(self._token_count))
+            avg_tps = self._average_tps()
+            tps_part = f" · {avg_tps} tok/s" if avg_tps else ""
             return Text(
-                f"Thought for {elapsed_str} · {count_str} tokens",
+                f"Thought for {elapsed_str} · {count_str} tokens{tps_part}",
                 style="grey50 italic",
             )
         remaining = self._pending_text()
         if not remaining:
             return Text("")
         return self._wrap_bullet(Markdown(remaining))
+
+    def compose_summary(self) -> Text | None:
+        """Return a summary line for the completed composing block."""
+        if self.is_think:
+            return None
+        elapsed_str = format_elapsed(time.monotonic() - self._start_time)
+        count_str = format_token_count(int(self._token_count))
+        avg_tps = self._average_tps()
+        if not avg_tps and int(self._token_count) == 0:
+            return None
+        text = Text.assemble(
+            ("Composed", ""),
+            (f" for {elapsed_str}", "grey50"),
+            (f" · {count_str} tokens", "grey50"),
+        )
+        if avg_tps:
+            text.append_text(Text(f" · {avg_tps} tok/s", style="grey50"))
+        return text
+
+    def _average_tps(self) -> int | None:
+        elapsed = time.monotonic() - self._start_time
+        tokens_int = int(self._token_count)
+        seconds = max(1, int(elapsed))
+        if tokens_int > 0:
+            rate = int(tokens_int / seconds)
+            return rate if rate > 0 else None
+        return None
 
     def has_pending(self) -> bool:
         """Whether there is uncommitted content to flush."""
@@ -274,10 +303,19 @@ class _ContentBlock:
         elapsed_str = format_elapsed(elapsed)
         count_str = f"{format_token_count(int(self._token_count))} tokens"
 
+        tps_str = ""
+        tokens_int = int(self._token_count)
+        seconds = max(1, int(elapsed))
+        if elapsed > 0.5 and tokens_int > 0:
+            rate = int(tokens_int / seconds)
+            if rate > 0:
+                tps_str = f" · {rate} tok/s"
+
         self._spinner.text = Text.assemble(
             ("Composing...", ""),
             (f" {elapsed_str}", "grey50"),
             (f" · {count_str}", "grey50"),
+            (tps_str, "grey50"),
         )
         return self._spinner
 
@@ -296,10 +334,10 @@ class _ContentBlock:
             (f" · {count_str}", "grey50"),
         ]
 
-        # Live tok/s pulse — a real heartbeat signal that confirms the model
-        # is still streaming even when the raw content is hidden.
+        # Live tok/s pulse
+        seconds = max(1, int(elapsed))
         if elapsed > 0.5 and tokens_int > 0:
-            rate = int(tokens_int / elapsed)
+            rate = int(tokens_int / seconds)
             if rate > 0:
                 parts.append((f" · {rate} tok/s", "grey50"))
 

--- a/src/kimi_cli/ui/shell/visualize/_interactive.py
+++ b/src/kimi_cli/ui/shell/visualize/_interactive.py
@@ -220,6 +220,7 @@ class _PromptLiveView(_LiveView):
                         self.dispatch_wire_message(msg)
                         self._flush_prompt_refresh()
                         continue
+                    self.flush_content(show_summary=True)
                     self.cleanup(is_interrupt=False)
                     self._flush_prompt_refresh()
                     break

--- a/src/kimi_cli/ui/shell/visualize/_live_view.py
+++ b/src/kimi_cli/ui/shell/visualize/_live_view.py
@@ -219,6 +219,7 @@ class _LiveView:
                                 live.update(self.compose(), refresh=True)
                                 self._need_recompose = False
                             continue
+                        self.flush_content(show_summary=True)
                         self.cleanup(is_interrupt=False)
                         live.update(self.compose(), refresh=True)
                         break
@@ -568,7 +569,7 @@ class _LiveView:
 
     def cleanup(self, is_interrupt: bool) -> None:
         """Cleanup the live view on step end or interruption."""
-        self.flush_content(show_summary=not is_interrupt)
+        self.flush_content()
 
         for block in self._tool_call_blocks.values():
             if not block.finished:

--- a/src/kimi_cli/ui/shell/visualize/_live_view.py
+++ b/src/kimi_cli/ui/shell/visualize/_live_view.py
@@ -375,7 +375,7 @@ class _LiveView:
 
         match msg:
             case TurnBegin():
-                self.flush_content()
+                self.flush_content(show_summary=True)
             case SteerInput(user_input=user_input):
                 self.cleanup(is_interrupt=False)
                 content: list[ContentPart]
@@ -568,7 +568,7 @@ class _LiveView:
 
     def cleanup(self, is_interrupt: bool) -> None:
         """Cleanup the live view on step end or interruption."""
-        self.flush_content()
+        self.flush_content(show_summary=not is_interrupt)
 
         for block in self._tool_call_blocks.values():
             if not block.finished:
@@ -597,11 +597,16 @@ class _LiveView:
             self._question_request_queue.popleft().resolve({})
         self._current_question_panel = None
 
-    def flush_content(self) -> None:
+    def flush_content(self, *, show_summary: bool = False) -> None:
         """Flush the current content block."""
         if self._current_content_block is not None:
-            if self._current_content_block.has_pending():
-                console.print(self._current_content_block.compose_final())
+            block = self._current_content_block
+            if block.has_pending():
+                console.print(block.compose_final())
+            if show_summary:
+                summary = block.compose_summary()
+                if summary is not None:
+                    console.print(summary)
             self._current_content_block = None
             self.refresh_soon()
 

--- a/tests/ui_and_conv/test_streaming_content_block.py
+++ b/tests/ui_and_conv/test_streaming_content_block.py
@@ -299,3 +299,74 @@ class TestContentBlockCommitment:
         # After first commit, bullet should be marked as printed
         if block._committed_len > 0:
             assert block._has_printed_bullet
+
+
+class TestContentBlockTps:
+    """Verify tokens-per-second computation and summary generation."""
+
+    def test_compute_tps_returns_none_early(self):
+        """TPS is suppressed until enough time has elapsed."""
+        block = _ContentBlock(is_think=True)
+        assert block._compute_tps(0.1, 10) is None
+        assert block._compute_tps(0.5, 10) is None
+        assert block._compute_tps(0.6, 0) is None
+
+    def test_compute_tps_after_threshold(self):
+        """TPS uses the real elapsed float and returns an int rate."""
+        block = _ContentBlock(is_think=False)
+        assert block._compute_tps(2.0, 100) == 50
+        assert block._compute_tps(1.9, 100) == 52
+        assert block._compute_tps(1.0, 10) == 10
+
+    def test_average_tps_via_elapsed(self, monkeypatch):
+        """_average_tps() reads the block's own timer."""
+        import time
+
+        block = _ContentBlock(is_think=False)
+        block._start_time = 1000.0
+        block._token_count = 100.0
+        monkeypatch.setattr(time, "monotonic", lambda: 1002.0)
+        assert block._average_tps() == 50
+
+    def test_compose_summary_returns_none_for_zero_tokens(self):
+        block = _ContentBlock(is_think=False)
+        assert block.compose_summary() is None
+
+    def test_compose_summary_includes_tps(self):
+        import time
+
+        block = _ContentBlock(is_think=False)
+        block._start_time = time.monotonic() - 2.0
+        block._token_count = 100.0
+        summary = block.compose_summary()
+        assert summary is not None
+        assert "Composed" in summary.plain
+        assert "tokens" in summary.plain
+        assert "tok/s" in summary.plain
+
+    def test_compose_summary_omits_tps_when_below_threshold(self, monkeypatch):
+        import time
+
+        block = _ContentBlock(is_think=False)
+        block._start_time = 1000.0
+        block._token_count = 10.0
+        monkeypatch.setattr(time, "monotonic", lambda: 1000.4)
+        summary = block.compose_summary()
+        assert summary is not None
+        assert "tokens" in summary.plain
+        assert "tok/s" not in summary.plain
+
+    def test_compose_final_thinking_includes_tps(self, monkeypatch):
+        import time
+
+        block = _ContentBlock(is_think=True)
+        block._start_time = 1000.0
+        block._token_count = 100.0
+        block.raw_text = "some thinking"
+        monkeypatch.setattr(time, "monotonic", lambda: 1002.0)
+        final = block.compose_final()
+        assert "tok/s" in str(final)
+
+    def test_compose_summary_for_thinking_block(self):
+        block = _ContentBlock(is_think=True)
+        assert block.compose_summary() is None

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -9,7 +9,7 @@ from prompt_toolkit.document import Document
 from rich.text import Text
 
 from kimi_cli.ui.shell.prompt import PromptMode, UserInput
-from kimi_cli.wire.types import ApprovalRequest, StatusUpdate, SteerInput, TextPart
+from kimi_cli.wire.types import ApprovalRequest, StatusUpdate, SteerInput, TextPart, TurnBegin
 
 shell_visualize = importlib.import_module("kimi_cli.ui.shell.visualize")
 # Sub-modules for monkeypatching internal names (Live, _keyboard_listener, console)
@@ -185,7 +185,9 @@ def test_live_view_flushes_current_output_before_printing_steer_input(monkeypatc
     view = _LiveView(StatusUpdate())
     order: list[object] = []
 
-    monkeypatch.setattr(view, "flush_content", lambda: order.append("flush_content"))
+    monkeypatch.setattr(
+        view, "flush_content", lambda *args, **kwargs: order.append("flush_content")
+    )
     monkeypatch.setattr(view, "flush_finished_tool_calls", lambda: order.append("flush_tools"))
     monkeypatch.setattr(
         shell_visualize.console,
@@ -197,6 +199,19 @@ def test_live_view_flushes_current_output_before_printing_steer_input(monkeypatc
 
     assert order[:2] == ["flush_content", "flush_tools"]
     assert order[-1] == ("print", "✨ A steer follow-up")
+
+
+def test_turn_begin_flushes_with_summary(monkeypatch) -> None:
+    view = _LiveView(StatusUpdate())
+    block = shell_visualize._ContentBlock(is_think=False)
+    block.append("hello\n\nworld")
+    view._current_content_block = block
+    called: list[bool] = []
+    monkeypatch.setattr(
+        view, "flush_content", lambda *, show_summary=False: called.append(show_summary)
+    )
+    view.dispatch_wire_message(TurnBegin(user_input=[TextPart(text="hi")]))
+    assert called == [True]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Show live tokens per second during streaming and display the average TPS at turn end in the shell UI.

- Live TPS is shown in the composing and thinking spinners after 0.5s.
- Average TPS is printed as a summary line when the turn completes.
- Summary is only shown at turn boundaries, never in the middle of content.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any. (Change is <100 lines)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
