### PR TITLE
docs(config): clarify quoted TOML keys for dotted model names

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -109,6 +109,10 @@ custom_headers = { "X-Custom-Header" = "value" }
 
 `models` defines available models. Each model uses a unique name as key.
 
+::: warning Note
+If a `providers` or `models` key contains `.`, you must use a quoted TOML key. Otherwise, TOML treats `.` as a path separator and parses the key as nested tables.
+:::
+
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `provider` | `string` | Yes | Provider name to use, must be defined in `providers` |
@@ -124,6 +128,16 @@ provider = "moonshot-cn"
 model = "kimi-k2-thinking-turbo"
 max_context_size = 262144
 capabilities = ["thinking", "image_in"]
+```
+
+If the model name contains `.`, use a quoted key:
+
+```toml
+[models."gpt-4.1"]
+provider = "openai"
+model = "gpt-4.1"
+max_context_size = 1047576
+capabilities = ["thinking"]
 ```
 
 ### `loop_control`

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -109,6 +109,10 @@ custom_headers = { "X-Custom-Header" = "value" }
 
 `models` 定义可用的模型。每个模型使用一个唯一的名称作为 key。
 
+::: warning 注意
+如果 `providers` 或 `models` 的 key 中包含 `.`，必须使用带引号的 TOML key。否则 TOML 会把 `.` 当作路径分隔符，将 key 解析为嵌套表。
+:::
+
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `provider` | `string` | 是 | 使用的供应商名称，必须在 `providers` 中定义 |
@@ -124,6 +128,16 @@ provider = "moonshot-cn"
 model = "kimi-k2-thinking-turbo"
 max_context_size = 262144
 capabilities = ["thinking", "image_in"]
+```
+
+如果模型名包含 `.`，需要使用带引号的 key：
+
+```toml
+[models."gpt-4.1"]
+provider = "openai"
+model = "gpt-4.1"
+max_context_size = 1047576
+capabilities = ["thinking"]
 ```
 
 ### `loop_control`


### PR DESCRIPTION
## Related Issue

Nil .ʕ◔ϖ◔ʔ

## Description

Clarify in the configuration docs that `providers` and `models` keys containing `.` must use quoted TOML keys.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

## Notes

- Docs-only change.
- No tests were added.
- No changelog update was needed.
- I ran prek run --all-files.

I ran into this while configuring a model with a dotted name.

```bash
Invalid configuration file /home/xxx/.kimi/config.toml: 3 validation errors for Config
models.xxx.provider
  Field required [type=missing, input_value={'xxx': {'provid...ilities': ['thinking']}}, input_type=Table]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
models.xxx.model
  Field required [type=missing, input_value={'xxx': {'provid...ilities': ['thinking']}}, input_type=Table]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
models.xxx.max_context_size
  Field required [type=missing, input_value={'xxx': {'provid...ilities': ['thinking']}}, input_type=Table]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
See logs: /home/xxx/.kimi/logs/kimi.log
Run with --debug for full traceback, or run kimi export to share diagnostics.
```

I have not confirmed this in an issue beforehand, so please feel free to treat this as an optional docs clarification if it is not aligned with current priorities.

Cheers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
