### PR TITLE
fix(background): keep cancelled task strong reference until runner cleans up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal; the cancelled task is now kept in the manager's live-tasks dict until its runner finishes cleaning up, preventing Python's GC from reaping the still-pending task
 - Shell: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking so highlight spans land correctly after tab expansion
 
 ## 1.33.0 (2026-04-13)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal; the cancelled task is now kept in the manager's live-tasks dict until its runner finishes cleaning up, preventing Python's GC from reaping the still-pending task
 - Shell: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking so highlight spans land correctly after tab expansion
 
 ## 1.33.0 (2026-04-13)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,7 @@
 
 ## 未发布
 
+- Core：修复 `TaskStop` 取消卡住的后台 agent 时 CLI 崩溃的问题——终端不再打印 `Unhandled exception in event loop / Exception None` 并冻结；已取消的 task 现在会保留在管理器的 live-tasks 字典中，直到 runner 完成清理，避免 Python GC 在 task 仍处 pending 时回收它
 - Shell：修复包含 tab 的行内 Diff 高亮偏移错位的问题——原始代码的 Diff 偏移量现在通过 expandtabs 列跟踪映射到渲染后的位置，确保 tab 展开后高亮区间落在正确位置
 
 ## 1.33.0 (2026-04-13)

--- a/src/kimi_cli/background/agent_runner.py
+++ b/src/kimi_cli/background/agent_runner.py
@@ -113,15 +113,23 @@ class BackgroundAgentRunner:
             self._manager._mark_task_failed(self._task_id, str(exc))
             output.error(str(exc))
         finally:
-            for task in list(self._approval_update_tasks):
-                task.cancel()
-            for task in list(self._approval_update_tasks):
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-            self._runtime.approval_runtime.unsubscribe(approval_subscription)
-            self._runtime.approval_runtime.cancel_by_source("background_agent", self._task_id)
-            reset_current_approval_source(token)
-            self._manager._live_agent_tasks.pop(self._task_id, None)
+            # Whatever happens in approval cleanup below, the dict pop must
+            # run — it is the *only* place that removes this task from
+            # _live_agent_tasks, and BackgroundTaskManager.kill() relies on
+            # that strong reference staying valid until cancellation has
+            # finished propagating. If we let an exception in the cleanup
+            # block skip the pop, the entry leaks forever.
+            try:
+                for task in list(self._approval_update_tasks):
+                    task.cancel()
+                for task in list(self._approval_update_tasks):
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                self._runtime.approval_runtime.unsubscribe(approval_subscription)
+                self._runtime.approval_runtime.cancel_by_source("background_agent", self._task_id)
+                reset_current_approval_source(token)
+            finally:
+                self._manager._live_agent_tasks.pop(self._task_id, None)
 
     async def _run_core(self, output: SubagentOutputWriter) -> None:
         assert self._runtime.subagent_store is not None

--- a/src/kimi_cli/background/manager.py
+++ b/src/kimi_cli/background/manager.py
@@ -348,7 +348,14 @@ class BackgroundTaskManager:
             self._mark_task_killed(task_id, reason)
             if self._runtime is not None and self._runtime.approval_runtime is not None:
                 self._runtime.approval_runtime.cancel_by_source("background_agent", task_id)
-            task = self._live_agent_tasks.pop(task_id, None)
+            # Keep the task in _live_agent_tasks until BackgroundAgentRunner's
+            # finally block removes it. asyncio holds tasks in a WeakSet, so if
+            # we drop the only strong reference here the still-pending task can
+            # be garbage-collected before cancellation propagates, which fires
+            # loop.call_exception_handler with no 'exception' field — surfacing
+            # as "Unhandled exception in event loop / Exception None" in the
+            # prompt_toolkit terminal.
+            task = self._live_agent_tasks.get(task_id)
             if task is not None:
                 task.cancel()
             return self._store.merged_view(task_id)

--- a/src/kimi_cli/background/manager.py
+++ b/src/kimi_cli/background/manager.py
@@ -250,6 +250,13 @@ class BackgroundTaskManager:
             ).run()
         )
         self._live_agent_tasks[task_id] = task
+        # Cleanup safety net for the case where the runner is cancelled before
+        # its first event-loop step. Python throws CancelledError into a
+        # FRAME_CREATED coroutine without executing any of the function body,
+        # so the runner's finally block never runs and cannot pop the entry
+        # itself. The done callback fires regardless of how the task ends, and
+        # is idempotent with the runner's own pop (both use pop(..., None)).
+        task.add_done_callback(lambda _t, tid=task_id: self._live_agent_tasks.pop(tid, None))
         return self._store.merged_view(task_id)
 
     def list_tasks(

--- a/src/kimi_cli/hooks/engine.py
+++ b/src/kimi_cli/hooks/engine.py
@@ -87,7 +87,40 @@ class HookEngine:
         self._on_wire_hook = on_wire_hook
         self._by_event: dict[str, list[HookDef]] = {}
         self._wire_by_event: dict[str, list[WireHookSubscription]] = {}
+        self._pending_fire_and_forget: set[asyncio.Task[Any]] = set()
         self._rebuild_index()
+
+    def fire_and_forget_trigger(
+        self,
+        event: HookEventType,
+        *,
+        matcher_value: str = "",
+        input_data: dict[str, Any],
+    ) -> asyncio.Task[list[HookResult]]:
+        """Trigger a hook in the background and keep a strong reference to the
+        task. asyncio holds tasks in a WeakSet, so naively writing
+        ``asyncio.create_task(engine.trigger(...))`` and discarding the local
+        variable lets Python's GC collect the still-pending task — which fires
+        ``loop.call_exception_handler`` with no exception field and surfaces as
+        ``Unhandled exception in event loop / Exception None`` in the
+        prompt_toolkit terminal. Use this helper any time the caller wants to
+        fire a hook without awaiting its completion.
+        """
+        task: asyncio.Task[list[HookResult]] = asyncio.create_task(
+            self.trigger(event, matcher_value=matcher_value, input_data=input_data)
+        )
+        self._pending_fire_and_forget.add(task)
+        task.add_done_callback(self._pending_fire_and_forget.discard)
+        task.add_done_callback(self._log_fire_and_forget_failure)
+        return task
+
+    @staticmethod
+    def _log_fire_and_forget_failure(task: asyncio.Task[Any]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.opt(exception=exc).warning("Fire-and-forget hook task failed")
 
     def _rebuild_index(self) -> None:
         self._by_event.clear()

--- a/src/kimi_cli/subagents/runner.py
+++ b/src/kimi_cli/subagents/runner.py
@@ -293,19 +293,21 @@ class ForegroundSubagentRunner:
             output_writer.stage("run_soul_finished")
 
             # --- SubagentStop hook ---
-            _hook_task = asyncio.create_task(
-                hook_engine.trigger(
-                    "SubagentStop",
-                    matcher_value=actual_type,
-                    input_data=hook_events.subagent_stop(
-                        session_id=self._runtime.session.id,
-                        cwd=str(Path.cwd()),
-                        agent_name=actual_type,
-                        response=(final_response or "")[:500],
-                    ),
-                )
+            # fire_and_forget_trigger keeps a strong reference to the task on
+            # the hook engine so it cannot be garbage-collected before it
+            # finishes. Without that, asyncio's WeakSet bookkeeping would let
+            # GC reap the still-pending task and trigger the broken
+            # "Exception None" loop-handler path.
+            hook_engine.fire_and_forget_trigger(
+                "SubagentStop",
+                matcher_value=actual_type,
+                input_data=hook_events.subagent_stop(
+                    session_id=self._runtime.session.id,
+                    cwd=str(Path.cwd()),
+                    agent_name=actual_type,
+                    response=(final_response or "")[:500],
+                ),
             )
-            _hook_task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
         except asyncio.CancelledError:
             self._store.update_instance(agent_id, status="killed")
             output_writer.stage("cancelled")

--- a/tests/core/test_background_agent_kill.py
+++ b/tests/core/test_background_agent_kill.py
@@ -132,6 +132,113 @@ async def test_kill_background_agent_during_soul_run(runtime, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Regression: kill() must not drop the only strong reference to the asyncio
+# task. asyncio holds tasks in a WeakSet, so dropping the strong reference
+# before cancellation has propagated lets Python's GC collect the still-pending
+# task — which fires loop.call_exception_handler with no 'exception' field.
+# prompt_toolkit then surfaces this as
+# "Unhandled exception in event loop: Exception None / Press ENTER to continue".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_keeps_strong_reference_until_runner_finishes(runtime, monkeypatch):
+    """kill() must keep the asyncio.Task in _live_agent_tasks until the runner's
+    finally block removes it, so the cancellation can propagate without the
+    task being garbage-collected mid-flight."""
+    import gc
+    import weakref
+
+    _register_coder(runtime)
+    agent_id = _create_bg_agent_instance(runtime, agent_id="agcrace1")
+
+    soul_started = asyncio.Event()
+
+    async def fake_load_agent(agent_file, rt, *, mcp_configs, start_mcp_loading=True):
+        return SoulAgent(
+            name=agent_file.stem,
+            system_prompt="gc race test",
+            toolset=EmptyToolset(),
+            runtime=rt,
+        )
+
+    async def fake_run_soul(
+        soul, user_input, ui_loop_fn, cancel_event, wire_file=None, runtime=None
+    ):
+        soul_started.set()
+        await asyncio.Future()  # Block forever; cancellation will unblock us.
+
+    monkeypatch.setattr("kimi_cli.subagents.builder.load_agent", fake_load_agent)
+    monkeypatch.setattr("kimi_cli.subagents.runner.run_soul", fake_run_soul)
+
+    runtime.background_tasks.bind_runtime(runtime)
+    view = runtime.background_tasks.create_agent_task(
+        agent_id=agent_id,
+        subagent_type="coder",
+        prompt="block forever",
+        description="gc race",
+        tool_call_id="tc-gc-race",
+        model_override=None,
+    )
+    task_id = view.spec.id
+
+    try:
+        await asyncio.wait_for(soul_started.wait(), timeout=10.0)
+    except TimeoutError:
+        pytest.fail("Background agent did not start run_soul within 10 seconds")
+
+    # Capture the live task object and a weakref before kill(). The id() is
+    # used to assert object identity after kill() — we want to be sure the
+    # *same* task object is still held, not just that some entry exists.
+    live_task_before = runtime.background_tasks._live_agent_tasks[task_id]
+    live_task_id_before = id(live_task_before)
+    task_ref = weakref.ref(live_task_before)
+    del live_task_before
+
+    # Trigger the kill. Under the bug, kill() pops the only strong reference
+    # to the task and returns immediately, leaving the task reachable only via
+    # asyncio's WeakSet. Once Python's GC runs, the still-pending task is
+    # collected and Task.__del__ fires the loop exception handler with no
+    # 'exception' field — exactly the "Exception None" symptom users see.
+    runtime.background_tasks.kill(task_id, reason="gc race")
+
+    # Primary invariant: immediately after kill() returns, _live_agent_tasks
+    # must still hold the *same* task object. Only the runner's finally block
+    # (which runs after cancellation has propagated) is allowed to remove it.
+    # This is the contract that prevents the GC race regardless of interpreter
+    # GC details.
+    assert task_id in runtime.background_tasks._live_agent_tasks, (
+        "kill() dropped the strong reference to the asyncio.Task before "
+        "cancellation propagated. asyncio holds only weak references to tasks; "
+        "the runner's finally block must be the one to clear _live_agent_tasks."
+    )
+    assert id(runtime.background_tasks._live_agent_tasks[task_id]) == live_task_id_before, (
+        "kill() replaced the asyncio.Task in _live_agent_tasks instead of "
+        "preserving the original strong reference."
+    )
+
+    # Secondary canary: with the strong reference still in the dict, the task
+    # must survive a forced collection cycle. This is implementation-detail
+    # sensitive (depends on CPython's GC behavior for cycles), so it is a
+    # best-effort additional check rather than the primary contract.
+    gc.collect()
+    assert task_ref() is not None, (
+        "Background agent asyncio.Task was garbage-collected after kill() "
+        "even though _live_agent_tasks should still hold it."
+    )
+
+    # Now let the cancellation actually propagate; the runner's finally block
+    # is responsible for removing the entry from _live_agent_tasks.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if task_id not in runtime.background_tasks._live_agent_tasks:
+            break
+        await asyncio.sleep(0.02)
+    else:
+        pytest.fail("Runner finally block did not clear _live_agent_tasks in time")
+
+
+# ---------------------------------------------------------------------------
 # Test 2: Kill cancels pending approval requests
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_background_agent_kill.py
+++ b/tests/core/test_background_agent_kill.py
@@ -239,6 +239,100 @@ async def test_kill_keeps_strong_reference_until_runner_finishes(runtime, monkey
 
 
 # ---------------------------------------------------------------------------
+# Regression: kill() must clean up _live_agent_tasks even when the runner
+# coroutine is cancelled before its first event-loop step. In that case
+# `coro.throw(CancelledError)` into a FRAME_CREATED coroutine completes it
+# without executing the function body — the runner's `finally` block never
+# runs, so it cannot be the only place that pops the dict entry. The cleanup
+# must come from a task done callback wired up at task creation time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_before_runner_starts_cleans_up_live_tasks(runtime, monkeypatch):
+    """If kill() is called in the same event-loop turn as create_agent_task(),
+    the runner coroutine is cancelled before it has a chance to take its first
+    step. Python throws CancelledError into the never-started coroutine, which
+    transitions to COMPLETED without executing any of the function body —
+    including the finally block. _live_agent_tasks must still be cleaned up
+    via a task done callback registered at creation time."""
+    _register_coder(runtime)
+    agent_id = _create_bg_agent_instance(runtime, agent_id="anvrstrt")
+
+    runner_body_started = asyncio.Event()
+
+    async def fake_load_agent(agent_file, rt, *, mcp_configs, start_mcp_loading=True):
+        # Reaching this proves the runner body executed — we want to assert
+        # the opposite, so flip the flag if we ever get here.
+        runner_body_started.set()
+        return SoulAgent(
+            name=agent_file.stem,
+            system_prompt="never started",
+            toolset=EmptyToolset(),
+            runtime=rt,
+        )
+
+    async def fake_run_soul(
+        soul, user_input, ui_loop_fn, cancel_event, wire_file=None, runtime=None
+    ):
+        await asyncio.Future()  # Would block forever if reached.
+
+    monkeypatch.setattr("kimi_cli.subagents.builder.load_agent", fake_load_agent)
+    monkeypatch.setattr("kimi_cli.subagents.runner.run_soul", fake_run_soul)
+
+    runtime.background_tasks.bind_runtime(runtime)
+
+    # Create the background agent task and IMMEDIATELY kill it without
+    # yielding to the event loop in between. The runner coroutine has been
+    # scheduled (loop.call_soon for its first __step) but has not yet executed.
+    view = runtime.background_tasks.create_agent_task(
+        agent_id=agent_id,
+        subagent_type="coder",
+        prompt="never starts",
+        description="never started",
+        tool_call_id="tc-never-start",
+        model_override=None,
+    )
+    task_id = view.spec.id
+
+    # Sanity: the task should be in the dict and the runner body should not
+    # have run yet (we have not yielded to the loop).
+    assert task_id in runtime.background_tasks._live_agent_tasks
+    assert not runner_body_started.is_set()
+
+    # Kill before the runner has had any chance to start its first step.
+    runtime.background_tasks.kill(task_id, reason="kill before start")
+
+    # Yield to the loop several times so asyncio can:
+    #   1. Process the runner task's scheduled __step (which sees must_cancel
+    #      and throws CancelledError into the FRAME_CREATED coroutine)
+    #   2. Mark the task DONE
+    #   3. Schedule and fire its done callbacks
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    # The runner body must NOT have executed — this is the precondition that
+    # makes this test exercise the never-started cancellation path. If this
+    # fails, the test setup is wrong and the assertion below would not be
+    # meaningful.
+    assert not runner_body_started.is_set(), (
+        "Runner coroutine started before kill() — test setup is wrong, "
+        "this scenario cannot exercise the never-started cancellation path"
+    )
+
+    # Despite the runner's finally block never running, the entry must have
+    # been cleaned up from _live_agent_tasks. Cleanup must come from a task
+    # done callback registered at creation time, because the finally block
+    # is no longer reachable on this path.
+    assert task_id not in runtime.background_tasks._live_agent_tasks, (
+        "_live_agent_tasks still holds the cancelled-before-start task — "
+        "the runner's finally block never ran on this path. create_agent_task "
+        "must register a task done callback so the dict entry is cleaned up "
+        "regardless of how the task terminates."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test 2: Kill cancels pending approval requests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

`BackgroundTaskManager.kill()` previously popped the asyncio Task from
`_live_agent_tasks` before its cancellation could propagate. Since asyncio
holds tasks in a `WeakSet`, dropping the only strong reference let Python's
GC reap the still-pending task and trip prompt_toolkit's exception handler
with an empty context — surfacing as `Unhandled exception in event loop /
Exception None / Press ENTER to continue` and freezing the terminal whenever
a user stopped a stuck background agent via `TaskStop`.

### Fix

- **`background/manager.py`**: `kill()` now keeps the task in
  `_live_agent_tasks` until `BackgroundAgentRunner`'s finally block removes
  it. A comment documents the invariant so future refactors don't reintroduce
  the GC race.
- **`background/agent_runner.py`**: the dict pop in the runner's `finally`
  is wrapped in an unconditional inner `try/finally`, so an exception in the
  approval-cleanup block (e.g. an awaited approval-update task raising) can
  no longer leak the entry.
- **`hooks/engine.py`**: new `HookEngine.fire_and_forget_trigger()` helper
  holds task references on the long-lived hook engine via an internal set
  with a `discard` done callback, fixing the same fire-and-forget GC race
  class.
- **`subagents/runner.py`**: the `SubagentStop` hook trigger uses the new
  helper instead of a bare `asyncio.create_task(...)` whose only strong
  reference was a local that vanished as soon as the runner returned.
- **`tests/core/test_background_agent_kill.py`**: new regression test
  asserts the strong-reference invariant directly (`task_id` still in
  `_live_agent_tasks` and identical task object after `kill()`) plus a
  `weakref + gc.collect()` canary. Confirmed the test fails on the
  pre-fix code and passes after the fix.

### Verification

- 149 targeted tests pass (`tests/core/test_background_agent_kill.py`,
  `tests/background/`, `tests/tools/test_agent_tool.py`,
  `tests/tools/test_background_tools.py`, `tests/hooks/`).
- `ruff check` / `ruff format --check` / `ty check` clean on all touched
  files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
