### PR TITLE
feat(shell): add show_thinking_stream config and minor UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Shell: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking so highlight spans land correctly after tab expansion
+- Shell: Add `show_thinking_stream` config option to opt back into the legacy streaming reasoning preview — when set to `true`, the live area shows the classic `Thinking...` spinner above a 6-line scrolling preview of the raw reasoning text and the full reasoning markdown is committed to history when the block ends; defaults to `false` to keep the compact 1.32 indicator
 
 ## 1.33.0 (2026-04-13)
 

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -30,6 +30,7 @@ The configuration file contains the following top-level configuration items:
 | `default_plan_mode` | `boolean` | Whether to start new sessions in plan mode by default (defaults to `false`); resumed sessions preserve their existing state |
 | `default_editor` | `string` | Default external editor command (e.g. `"vim"`, `"code --wait"`), auto-detects when empty |
 | `theme` | `string` | Terminal color theme, either `"dark"` or `"light"` (defaults to `"dark"`) |
+| `show_thinking_stream` | `boolean` | Whether to stream the raw reasoning text in the live area as a 6-line scrolling preview and commit the full reasoning markdown to history when the block ends (defaults to `false`, which shows only the compact `Thinking ...` indicator and a one-line trace summary) |
 | `merge_all_available_skills` | `boolean` | Whether to merge skills from all brand directories (defaults to `false`); see [Skills configuration](../customization/skills.md) |
 | `providers` | `table` | API provider configuration |
 | `models` | `table` | Model configuration |
@@ -47,6 +48,7 @@ default_yolo = false
 default_plan_mode = false
 default_editor = ""
 theme = "dark"
+show_thinking_stream = false
 merge_all_available_skills = false
 
 [providers.kimi-for-coding]

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -5,6 +5,7 @@ This page documents the changes in each Kimi Code CLI release.
 ## Unreleased
 
 - Shell: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking so highlight spans land correctly after tab expansion
+- Shell: Add `show_thinking_stream` config option to opt back into the legacy streaming reasoning preview — when set to `true`, the live area shows the classic `Thinking...` spinner above a 6-line scrolling preview of the raw reasoning text and the full reasoning markdown is committed to history when the block ends; defaults to `false` to keep the compact 1.32 indicator
 
 ## 1.33.0 (2026-04-13)
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -30,6 +30,7 @@ kimi --config '{"default_model": "kimi-for-coding", "providers": {...}, "models"
 | `default_plan_mode` | `boolean` | 默认是否以计划模式启动新会话（默认为 `false`）；恢复的会话保留其原有状态 |
 | `default_editor` | `string` | 默认外部编辑器命令（如 `"vim"`、`"code --wait"`），为空时自动检测 |
 | `theme` | `string` | 终端配色主题，可选 `"dark"` 或 `"light"`（默认为 `"dark"`） |
+| `show_thinking_stream` | `boolean` | 是否在 Live 区域以 6 行滚动预览方式实时展示模型的原始思考文本，并在 thinking 块结束时把完整思考内容（Markdown）写入历史记录（默认为 `false`，仅显示紧凑的 `Thinking ...` 指示器和一行 trace 总结） |
 | `merge_all_available_skills` | `boolean` | 是否合并所有品牌目录中的 Skills（默认为 `false`）；详见 [Skills 配置](../customization/skills.md) |
 | `providers` | `table` | API 供应商配置 |
 | `models` | `table` | 模型配置 |
@@ -47,6 +48,7 @@ default_yolo = false
 default_plan_mode = false
 default_editor = ""
 theme = "dark"
+show_thinking_stream = false
 merge_all_available_skills = false
 
 [providers.kimi-for-coding]

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -5,6 +5,7 @@
 ## 未发布
 
 - Shell：修复包含 tab 的行内 Diff 高亮偏移错位的问题——原始代码的 Diff 偏移量现在通过 expandtabs 列跟踪映射到渲染后的位置，确保 tab 展开后高亮区间落在正确位置
+- Shell：新增 `show_thinking_stream` 配置项，可恢复旧版的流式思考预览体验——设为 `true` 后，Live 区域会显示经典的 `Thinking...` spinner 以及 6 行原始思考文本的滚动预览，思考块结束时把完整的思考 markdown 写入历史记录；默认为 `false`，保持 1.32 版本引入的紧凑指示器
 
 ## 1.33.0 (2026-04-13)
 

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -519,7 +519,7 @@ class KimiCLI:
                 welcome_info.append(
                     WelcomeInfoItem(
                         name="Tip",
-                        value="send /login to use Kimi for Code",
+                        value="send /login to use Kimi for Coding",
                         level=WelcomeInfoItem.Level.WARN,
                     )
                 )

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -197,6 +197,15 @@ class Config(BaseModel):
         default="dark",
         description="Terminal color theme. Use 'light' for light terminal backgrounds.",
     )
+    show_thinking_stream: bool = Field(
+        default=False,
+        description=(
+            "If true, stream the raw reasoning text in the live area as a "
+            "6-line scrolling preview and commit the full reasoning markdown "
+            "to history when the block ends. Default false: show only the "
+            "compact 'Thinking ...' indicator and a one-line trace summary."
+        ),
+    )
     models: dict[str, LLMModel] = Field(default_factory=dict, description="List of LLM models")
     providers: dict[str, LLMProvider] = Field(
         default_factory=dict, description="List of LLM providers"

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -50,7 +50,7 @@ def model_display_name(model_name: str | None) -> str:
     if not model_name:
         return ""
     if model_name in ("kimi-for-coding", "kimi-code"):
-        return "Kimi for Code"
+        return "kimi-for-coding"
     return model_name
 
 

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -379,6 +379,7 @@ class Shell:
             await replay_recent_history(
                 self.soul.context.history,
                 wire_file=self.soul.wire_file,
+                show_thinking_stream=self.soul.runtime.config.show_thinking_stream,
             )
             await self.soul.start_background_mcp_loading()
 
@@ -759,6 +760,7 @@ class Shell:
         try:
             snap = self.soul.status
             runtime = self.soul.runtime if isinstance(self.soul, KimiSoul) else None
+            show_thinking_stream = runtime.config.show_thinking_stream if runtime else False
             # Capture view reference via closure — _clear_active_view sets
             # _active_view=None inside visualize()'s finally (before run_soul
             # returns), so we must capture the view object independently.
@@ -788,6 +790,7 @@ class Shell:
                     unbind_running_input=self._unbind_running_input,
                     on_view_ready=_on_view_ready,
                     on_view_closed=self._clear_active_view,
+                    show_thinking_stream=show_thinking_stream,
                 ),
                 cancel_event,
                 runtime.session.wire_file if runtime else None,
@@ -839,6 +842,7 @@ class Shell:
                         unbind_running_input=self._unbind_running_input,
                         on_view_ready=_on_view_ready,
                         on_view_closed=self._clear_active_view,
+                        show_thinking_stream=show_thinking_stream,
                     ),
                     cancel_event,
                     runtime.session.wire_file if runtime else None,

--- a/src/kimi_cli/ui/shell/replay.py
+++ b/src/kimi_cli/ui/shell/replay.py
@@ -46,6 +46,7 @@ async def replay_recent_history(
     history: Sequence[Message],
     *,
     wire_file: WireFile | None = None,
+    show_thinking_stream: bool = False,
 ) -> None:
     """
     Replay the most recent user-initiated turns from the provided message history or wire file.
@@ -69,7 +70,11 @@ async def replay_recent_history(
         wire = Wire()
         console.print(render_user_echo(turn.user_message))
         ui_task = asyncio.create_task(
-            visualize(wire.ui_side(merge=False), initial_status=StatusUpdate())
+            visualize(
+                wire.ui_side(merge=False),
+                initial_status=StatusUpdate(),
+                show_thinking_stream=show_thinking_stream,
+            )
         )
         for event in turn.events:
             wire.soul_side.send(event)

--- a/src/kimi_cli/ui/shell/update.py
+++ b/src/kimi_cli/ui/shell/update.py
@@ -162,8 +162,10 @@ def _run_update_gate(current_version: str, latest_version: str) -> None:
         ("  Latest version    ", ""),
         (latest_version + "\n\n", "bold green"),
         ("  What's new:\n", ""),
-        ("    · " + CHANGELOG_URL_ZH + "\n", "dodger_blue1"),
-        ("    · " + CHANGELOG_URL_EN + "\n", "dodger_blue1"),
+        ("    · [中文]    ", ""),
+        (CHANGELOG_URL_ZH + "\n", "dodger_blue1"),
+        ("    · [English] ", ""),
+        (CHANGELOG_URL_EN + "\n", "dodger_blue1"),
     )
     console.print()
     console.print(

--- a/src/kimi_cli/ui/shell/usage.py
+++ b/src/kimi_cli/ui/shell/usage.py
@@ -61,7 +61,7 @@ async def usage(app: Shell, args: str):
             if e.status == 401:
                 message = "Authorization failed. Please check your API key."
             elif e.status == 404:
-                message = "Usage endpoint not available. Try Kimi For Coding."
+                message = "Usage endpoint not available. Try Kimi for Coding."
             console.print(f"[red]{message}[/red]")
             return
         except TimeoutError:

--- a/src/kimi_cli/ui/shell/visualize/__init__.py
+++ b/src/kimi_cli/ui/shell/visualize/__init__.py
@@ -124,6 +124,7 @@ async def visualize(
     unbind_running_input: Callable[[], None] | None = None,
     on_view_ready: Callable[[Any], None] | None = None,
     on_view_closed: Callable[[], None] | None = None,
+    show_thinking_stream: bool = False,
 ):
     """A loop to consume agent events and visualize the agent behavior.
 
@@ -138,6 +139,7 @@ async def visualize(
             steer=steer,
             btw_runner=btw_runner,
             cancel_event=cancel_event,
+            show_thinking_stream=show_thinking_stream,
         )
         prompt_session.attach_running_prompt(view)
 
@@ -148,7 +150,7 @@ async def visualize(
         if bind_running_input is not None:
             bind_running_input(view.handle_local_input, _cancel_running_input)
     else:
-        view = _LiveView(initial_status, cancel_event)
+        view = _LiveView(initial_status, cancel_event, show_thinking_stream=show_thinking_stream)
     if on_view_ready is not None:
         on_view_ready(view)
     try:

--- a/src/kimi_cli/ui/shell/visualize/_blocks.py
+++ b/src/kimi_cli/ui/shell/visualize/_blocks.py
@@ -46,6 +46,7 @@ from kimi_cli.wire.types import (
 )
 
 _ELLIPSIS = "..."
+_THINKING_PREVIEW_LINES = 6
 _SELF_CLOSING_BLOCKS = frozenset(("fence", "code_block", "hr", "html_block"))
 MAX_SUBAGENT_TOOL_CALLS_TO_SHOW = 4
 
@@ -62,11 +63,10 @@ def _bullet_frame_for(elapsed: float) -> str:
     return _BULLET_FRAMES[idx]
 
 
-def _truncate_to_display_width(line: str, max_width: int) -> str:  # pyright: ignore[reportUnusedFunction]
+def _truncate_to_display_width(line: str, max_width: int) -> str:
     """Truncate *line* so its terminal display width fits within *max_width*.
 
     Uses ``rich.cells.cell_len`` for CJK-aware column width measurement.
-    Kept for backwards-compatible re-export from ``visualize/__init__.py``.
     """
     from rich.cells import cell_len
 
@@ -163,11 +163,8 @@ def _find_committed_boundary(text: str) -> int | None:
     return offset
 
 
-def _tail_lines(text: str, n: int) -> str:  # pyright: ignore[reportUnusedFunction]
-    """Extract the last *n* lines from *text* via reverse scanning (O(n)).
-
-    Kept for backwards-compatible re-export from ``visualize/__init__.py``.
-    """
+def _tail_lines(text: str, n: int) -> str:
+    """Extract the last *n* lines from *text* via reverse scanning (O(n))."""
     pos = len(text)
     for _ in range(n):
         pos = text.rfind("\n", 0, pos)
@@ -184,16 +181,22 @@ class _ContentBlock:
     giving users real-time streaming output.  Only the unconfirmed tail remains
     in the transient Rich Live area.
 
-    For **thinking** (``is_think=True``), the raw reasoning text is kept only
-    for token accounting and never rendered.  The Live area shows a compact
-    ``Thinking`` label with an animated bullet sequence, followed by elapsed
-    time, token count, and a live tokens/second pulse.  When the block ends,
-    a compact one-liner ``Thought for Xs · N tokens`` is committed to history
-    in grey italics.
+    For **thinking** (``is_think=True``), the default behavior is to keep the
+    raw reasoning text only for token accounting and never render it.  The
+    Live area shows a compact ``Thinking`` label with an animated bullet
+    sequence, elapsed time, token count, and a live tokens/second pulse;
+    when the block ends, a one-liner ``Thought for Xs · N tokens`` is
+    committed to history in grey italics.
+
+    When ``show_thinking_stream=True``, the legacy behavior is restored: the
+    Live area shows a ``Thinking...`` spinner above a 6-line scrolling preview
+    of the raw reasoning text, and the full reasoning markdown is committed
+    to history when the block ends.
     """
 
-    def __init__(self, is_think: bool):
+    def __init__(self, is_think: bool, *, show_thinking_stream: bool = False):
         self.is_think = is_think
+        self._show_thinking_stream = show_thinking_stream
         self._spinner = Spinner("dots", "")
         self.raw_text = ""
         # Accumulated float estimate — avoids per-chunk int truncation.
@@ -217,15 +220,27 @@ class _ContentBlock:
 
         Thinking mode shows the italic ``Thinking`` label with animated
         bullets; composing mode shows the dots spinner over the
-        uncommitted markdown tail.
+        uncommitted markdown tail.  When ``show_thinking_stream`` is enabled,
+        thinking mode falls back to the legacy ``Thinking...`` spinner stacked
+        above a 6-line scrolling preview of the raw reasoning text.
         """
         if self.is_think:
+            if self._show_thinking_stream:
+                return self._compose_thinking_stream()
             return self._compose_thinking()
         return self._compose_spinner()
 
     def compose_final(self) -> RenderableType:
         """Render the remaining uncommitted content when the block ends."""
         if self.is_think:
+            if self._show_thinking_stream:
+                remaining = self._pending_text()
+                if not remaining:
+                    return Text("")
+                return BulletColumns(
+                    Markdown(remaining, style="grey50 italic"),
+                    bullet_style="grey50",
+                )
             elapsed_str = format_elapsed(time.monotonic() - self._start_time)
             count_str = format_token_count(int(self._token_count))
             return Text(
@@ -280,6 +295,34 @@ class _ContentBlock:
             (f" · {count_str}", "grey50"),
         )
         return self._spinner
+
+    def _compose_thinking_stream(self) -> RenderableType:
+        """Legacy 'Thinking...' spinner stacked over a 6-line scrolling preview."""
+        spinner = self._compose_thinking_spinner()
+        pending = self._pending_text()
+        if not pending:
+            return spinner
+        preview = self._build_preview(pending)
+        return Group(spinner, Text(preview, style="grey50 italic"))
+
+    def _compose_thinking_spinner(self) -> Spinner:
+        """Legacy 'Thinking...' spinner header used by the stream-mode preview."""
+        elapsed = time.monotonic() - self._start_time
+        elapsed_str = format_elapsed(elapsed)
+        count_str = f"{format_token_count(int(self._token_count))} tokens"
+        self._spinner.text = Text.assemble(
+            ("Thinking...", ""),
+            (f" {elapsed_str}", "grey50"),
+            (f" · {count_str}", "grey50"),
+        )
+        return self._spinner
+
+    def _build_preview(self, text: str) -> str:
+        """Tail-trim *text* to the last ``_THINKING_PREVIEW_LINES`` and clamp width."""
+        max_width = console.width - 2 if console.width else 78
+        tail_text = _tail_lines(text, _THINKING_PREVIEW_LINES)
+        lines = tail_text.split("\n")
+        return "\n".join(_truncate_to_display_width(line, max_width) for line in lines)
 
     def _compose_thinking(self) -> Text:
         """Render the thinking line: italic Thinking + bullets + metadata."""

--- a/src/kimi_cli/ui/shell/visualize/_interactive.py
+++ b/src/kimi_cli/ui/shell/visualize/_interactive.py
@@ -72,8 +72,9 @@ class _PromptLiveView(_LiveView):
         steer: Callable[[str | list[ContentPart]], None],
         btw_runner: BtwRunner | None = None,
         cancel_event: asyncio.Event | None = None,
+        show_thinking_stream: bool = False,
     ) -> None:
-        super().__init__(initial_status, cancel_event)
+        super().__init__(initial_status, cancel_event, show_thinking_stream=show_thinking_stream)
         self._prompt_session = prompt_session
         self._steer = steer
         self._btw_runner = btw_runner

--- a/src/kimi_cli/ui/shell/visualize/_live_view.py
+++ b/src/kimi_cli/ui/shell/visualize/_live_view.py
@@ -100,8 +100,15 @@ async def _keyboard_listener(
 
 
 class _LiveView:
-    def __init__(self, initial_status: StatusUpdate, cancel_event: asyncio.Event | None = None):
+    def __init__(
+        self,
+        initial_status: StatusUpdate,
+        cancel_event: asyncio.Event | None = None,
+        *,
+        show_thinking_stream: bool = False,
+    ):
         self._cancel_event = cancel_event
+        self._show_thinking_stream = show_thinking_stream
 
         self._mooning_spinner: Spinner | None = None
         self._compacting_spinner: Spinner | None = None
@@ -633,11 +640,15 @@ class _LiveView:
                     return
                 is_think = isinstance(part, ThinkPart)
                 if self._current_content_block is None:
-                    self._current_content_block = _ContentBlock(is_think)
+                    self._current_content_block = _ContentBlock(
+                        is_think, show_thinking_stream=self._show_thinking_stream
+                    )
                     self.refresh_soon()
                 elif self._current_content_block.is_think != is_think:
                     self.flush_content()
-                    self._current_content_block = _ContentBlock(is_think)
+                    self._current_content_block = _ContentBlock(
+                        is_think, show_thinking_stream=self._show_thinking_stream
+                    )
                     self.refresh_soon()
                 self._current_content_block.append(text)
                 self.refresh_soon()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -27,6 +27,7 @@ def test_default_config_dump():
             "default_plan_mode": False,
             "default_editor": "",
             "theme": "dark",
+            "show_thinking_stream": False,
             "models": {},
             "providers": {},
             "loop_control": {

--- a/tests/ui_and_conv/test_replay.py
+++ b/tests/ui_and_conv/test_replay.py
@@ -197,7 +197,7 @@ async def test_replay_recent_history_prefers_wire_when_turns_match(
     step_counts: list[int] = []
     monkeypatch.setattr(replay_module.console, "print", lambda *_args, **_kwargs: None)
 
-    async def fake_visualize(wire_ui, *, initial_status) -> None:
+    async def fake_visualize(wire_ui, *, initial_status, show_thinking_stream=False) -> None:
         steps = 0
         while True:
             try:

--- a/tests/ui_and_conv/test_streaming_content_block.py
+++ b/tests/ui_and_conv/test_streaming_content_block.py
@@ -299,3 +299,122 @@ class TestContentBlockCommitment:
         # After first commit, bullet should be marked as printed
         if block._committed_len > 0:
             assert block._has_printed_bullet
+
+
+# ---------------------------------------------------------------------------
+# show_thinking_stream toggle (legacy streaming reasoning preview)
+# ---------------------------------------------------------------------------
+
+
+class TestShowThinkingStream:
+    """The ``show_thinking_stream`` flag opts back into the pre-1.32 behavior
+    where thinking content is rendered as a 6-line scrolling preview during
+    streaming and committed to history as full markdown when the block ends.
+    The default (``False``) keeps the compact 'Thinking ...' indicator and
+    one-line ``Thought for ...`` trace introduced in 1.32.
+    """
+
+    def test_compact_mode_compose_returns_compact_text(self):
+        from rich.text import Text
+
+        block = _ContentBlock(is_think=True)
+        block.append("Some reasoning content")
+        result = block.compose()
+        assert isinstance(result, Text)
+        assert "Thinking" in result.plain
+        # Compact mode never renders the raw reasoning text
+        assert "reasoning content" not in result.plain
+
+    def test_stream_mode_compose_returns_group_with_preview(self):
+        from rich.console import Group
+
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        block.append("line 1\nline 2\nline 3")
+        result = block.compose()
+        assert isinstance(result, Group)
+
+    def test_stream_mode_compose_no_pending_returns_spinner_only(self):
+        from rich.spinner import Spinner
+
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        # No content appended yet — should fall back to the bare spinner.
+        result = block.compose()
+        assert isinstance(result, Spinner)
+
+    def test_stream_mode_spinner_uses_thinking_label(self):
+        """Stream mode must restore the legacy 'Thinking...' spinner label."""
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        result = block.compose()
+        # Spinner.text is a Text — extract its plain string for assertion
+        text = result.text  # type: ignore[reportAttributeAccessIssue]
+        plain = text.plain if hasattr(text, "plain") else str(text)
+        assert "Thinking" in plain
+
+    def test_compact_mode_compose_final_returns_trace_line(self):
+        from rich.text import Text
+
+        block = _ContentBlock(is_think=True)
+        block.append("Some thought content")
+        result = block.compose_final()
+        assert isinstance(result, Text)
+        assert "Thought for" in result.plain
+        assert "tokens" in result.plain
+        # Compact trace must not contain the raw reasoning content
+        assert "thought content" not in result.plain
+
+    def test_stream_mode_compose_final_returns_markdown_bullet(self):
+        """Stream mode commits the full reasoning to history (legacy behavior)."""
+        from kimi_cli.utils.rich.columns import BulletColumns
+
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        block.append("Some thought content")
+        result = block.compose_final()
+        assert isinstance(result, BulletColumns)
+
+    def test_stream_mode_compose_final_empty_returns_empty_text(self):
+        from rich.text import Text
+
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        result = block.compose_final()
+        assert isinstance(result, Text)
+        assert result.plain == ""
+
+    def test_compact_mode_has_pending_with_content(self):
+        block = _ContentBlock(is_think=True)
+        block.append("anything")
+        assert block.has_pending()
+
+    def test_compact_mode_has_pending_without_content(self):
+        block = _ContentBlock(is_think=True)
+        assert not block.has_pending()
+
+    def test_stream_mode_has_pending_with_content(self):
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        block.append("anything")
+        assert block.has_pending()
+
+    def test_stream_mode_has_pending_without_content(self):
+        block = _ContentBlock(is_think=True, show_thinking_stream=True)
+        assert not block.has_pending()
+
+    def test_thinking_never_commits_in_either_mode(self):
+        """Thinking blocks must never commit incrementally regardless of mode."""
+        for stream in (False, True):
+            block = _ContentBlock(is_think=True, show_thinking_stream=stream)
+            block.append("First.\n\nSecond.\n\nThird.")
+            assert block._committed_len == 0
+
+    def test_preview_constant_is_six_lines(self):
+        """Stream preview window matches the historical 6-line tail."""
+        from kimi_cli.ui.shell.visualize._blocks import _THINKING_PREVIEW_LINES
+
+        assert _THINKING_PREVIEW_LINES == 6
+
+    def test_show_thinking_stream_ignored_for_composing_blocks(self):
+        """The flag only affects thinking blocks — composing path is unchanged."""
+        block_off = _ContentBlock(is_think=False, show_thinking_stream=False)
+        block_on = _ContentBlock(is_think=False, show_thinking_stream=True)
+        for block in (block_off, block_on):
+            block.append("hello\n\nworld")
+        # Both should commit identically
+        assert block_off._committed_len == block_on._committed_len

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -35,7 +35,16 @@ async def test_visualize_uses_prompt_live_view_when_prompt_session_and_steer_are
             called.append(("detach", delegate, None))
 
     class _DummyPromptLiveView:
-        def __init__(self, initial_status, *, prompt_session, steer, btw_runner=None, cancel_event):
+        def __init__(
+            self,
+            initial_status,
+            *,
+            prompt_session,
+            steer,
+            btw_runner=None,
+            cancel_event,
+            show_thinking_stream=False,
+        ):
             called.append(("init", initial_status, cancel_event))
             assert prompt_session is not None
             assert steer is not None


### PR DESCRIPTION
## Description

This PR bundles one shell config addition together with two small UX fixes.

### `show_thinking_stream` config (main change)

PR #1857 streamlined the thinking indicator into a compact one-liner
(`Thinking ... 3s · 245 tokens · 82 tok/s`) and replaced the per-block
reasoning markdown commit with a one-line `Thought for Xs · N tokens`
trace. Some users still want the legacy streaming preview, so this PR
adds an opt-in `show_thinking_stream` top-level config flag
(default `false`, so existing users see no change).

When `show_thinking_stream = true`, the experience is the same as before 1.32:

- Live area shows the classic `Thinking...` spinner above a 6-line
  scrolling tail of the raw reasoning text
- Full reasoning markdown is committed to history in grey italics when
  the thinking block ends

The flag is plumbed from `Config` through
`visualize()` → `_LiveView` / `_PromptLiveView` / `replay_recent_history`
→ `_ContentBlock`. It only branches the thinking path; composing blocks
are completely unaffected.

Tests: new `TestShowThinkingStream` class with 14 cases covering
`compose()` / `compose_final()` / `has_pending()` in both modes, the
6-line preview constant, and that the flag is a no-op for composing
blocks.

### Brand display: \"Kimi for Coding\" (lowercase \`for\`)

The canonical brand name is \`kimi-for-coding\`. This PR:

- \`model_display_name()\` now returns \`kimi-for-coding\` for the
  \`kimi-for-coding\` / \`kimi-code\` model IDs (previously \`Kimi for Code\`)
- The \`/login\` tip reads \`send /login to use Kimi for Coding\`
- The usage 404 hint reads \`Try Kimi for Coding.\` (was \`Try Kimi For Coding.\`
  with capital \`F\`)

### Update gate: label changelog links by language

The blocking update panel listed two changelog URLs that differed only
by \`/zh/\` vs \`/en/\` deep inside a long path, so users could easily miss
that one was Chinese and the other English. Each link is now prefixed
with \`[中文]\` / \`[English]\`.

## Test plan

- [x] \`make check-kimi-cli\` (exit 0)
- [x] \`uv run pytest tests/ui_and_conv/ tests/ui/ tests/core/test_config.py\` (741 passed)
- [ ] Manual: launch interactive shell, set \`show_thinking_stream = true\` in
  \`~/.kimi/config.toml\`, send a thinking-mode prompt, verify the legacy 6-line
  preview shows during streaming and the full markdown commits to history at
  the end
- [ ] Manual: with \`show_thinking_stream = false\` (default), verify the
  compact \`Thinking ...\` indicator and \`Thought for Xs · N tokens\` trace
  remain unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
