### PR TITLE
chore: bump kimi-cli 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.34.0 (2026-04-14)
+
 - Core: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal; the cancelled task is now kept in the manager's live-tasks dict until its runner finishes cleaning up, preventing Python's GC from reaping the still-pending task
 - Shell: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking so highlight spans land correctly after tab expansion
 - Shell: Add `show_thinking_stream` config option to opt back into the legacy streaming reasoning preview — when set to `true`, the live area shows the classic `Thinking...` spinner above a 6-line scrolling preview of the raw reasoning text and the full reasoning markdown is committed to history when the block ends; defaults to `false` to keep the compact 1.32 indicator

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.33.0"
+version = "1.34.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.33.0"]
+dependencies = ["kimi-cli==1.34.0"]
 
 [project.scripts]
 kimi-code = "kimi_cli.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.33.0"
+version = "1.34.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.33.0"
+version = "1.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1300,7 +1300,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.33.0"
+version = "1.34.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },


### PR DESCRIPTION
## Summary

Bump `kimi-cli` and `kimi-code` to **1.34.0**.

### Changes since 1.33.0

- **Core**: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal (#1871)
- **Shell**: Fix inline diff highlights misaligned on lines containing tabs — raw-code diff offsets are now mapped to rendered positions via expandtabs column tracking (#1709)
- **Shell**: Add `show_thinking_stream` config option to opt back into the legacy streaming reasoning preview; defaults to `false` to keep the compact 1.32 indicator (#1872)

### Files touched

- `pyproject.toml` — 1.33.0 → 1.34.0
- `packages/kimi-code/pyproject.toml` — version + `kimi-cli==1.34.0` dep (lockstep)
- `CHANGELOG.md` — promote `Unreleased` to `1.34.0 (2026-04-14)`
- `uv.lock` — refreshed via `uv sync`

## Test plan

- [ ] CI green on bump branch
- [ ] Release workflow picks up tag after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
