### PR TITLE
feat(ui): echo slash command inputs in shell UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Echo slash command inputs to the console in interactive shell mode — previously hidden commands like `/skill:coding` or `/help` are now displayed alongside regular user messages
+
 ## 1.34.0 (2026-04-14)
 
 - Core: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal; the cancelled task is now kept in the manager's live-tasks dict until its runner finishes cleaning up, preventing Python's GC from reaping the still-pending task

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -257,9 +257,7 @@ class Shell:
     def _should_echo_agent_input(user_input: UserInput) -> bool:
         if user_input.mode != PromptMode.AGENT:
             return False
-        if Shell._should_exit_input(user_input):
-            return False
-        return Shell._agent_slash_command_call(user_input) is None
+        return not Shell._should_exit_input(user_input)
 
     @staticmethod
     def _echo_agent_input(user_input: UserInput) -> None:

--- a/tests/ui_and_conv/test_shell_prompt_echo.py
+++ b/tests/ui_and_conv/test_shell_prompt_echo.py
@@ -108,10 +108,20 @@ def test_should_echo_agent_input_for_plain_agent_message() -> None:
     assert Shell._should_echo_agent_input(_make_user_input("hi")) is True
 
 
-def test_should_not_echo_agent_input_for_exit_or_slash_commands() -> None:
+def test_should_not_echo_agent_input_for_exit_commands() -> None:
     assert Shell._should_echo_agent_input(_make_user_input("exit")) is False
     assert Shell._should_echo_agent_input(_make_user_input("/exit")) is False
-    assert Shell._should_echo_agent_input(_make_user_input("/help")) is False
+    assert Shell._should_echo_agent_input(_make_user_input("/quit")) is False
+
+
+def test_should_echo_agent_input_for_slash_commands() -> None:
+    assert (
+        Shell._should_echo_agent_input(_make_user_input("/skill:coding 帮我写一个登录页")) is True
+    )
+    assert Shell._should_echo_agent_input(_make_user_input("/help something")) is True
+    assert Shell._should_echo_agent_input(_make_user_input("/theme dark")) is True
+    assert Shell._should_echo_agent_input(_make_user_input("/skill:coding")) is True
+    assert Shell._should_echo_agent_input(_make_user_input("/help")) is True
 
 
 def test_hidden_slash_in_placeholder_is_not_treated_as_local_command() -> None:
@@ -147,7 +157,7 @@ def test_visible_slash_command_keeps_expanded_placeholder_args() -> None:
         args="line1\nline2\nline3",
         raw_input="/echo line1\nline2\nline3",
     )
-    assert Shell._should_echo_agent_input(user_input) is False
+    assert Shell._should_echo_agent_input(user_input) is True
 
 
 def test_should_not_echo_non_agent_input() -> None:

--- a/tests/ui_and_conv/test_shell_run_placeholders.py
+++ b/tests/ui_and_conv/test_shell_run_placeholders.py
@@ -146,7 +146,7 @@ async def test_shell_run_dispatches_visible_slash_with_expanded_placeholder_args
     assert command_call.name == "fakecmd"
     assert command_call.args == "line1\nline2\nline3"
     assert command_call.raw_input == "/fakecmd line1\nline2\nline3"
-    assert printed == ["Bye!"]
+    assert printed == ["✨ /fakecmd [Pasted text #1 +3 lines]", "Bye!"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Echo slash command inputs to the console in interactive shell mode. Previously, any input starting with `/` was suppressed, so users could not see commands like `/skill:coding` or `/help` in their terminal history.

## Changes

- `Shell._should_echo_agent_input` now echoes all agent-mode inputs except `exit` and `quit` commands.
- Updated unit tests and integration tests to reflect the new behavior.
- Added changelog entry under `[Unreleased]`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
