### PR TITLE
fix(file_filter): add explicit utf-8 encoding to subprocess calls (#1866) 

### DIFF
--- a/src/kimi_cli/utils/file_filter.py
+++ b/src/kimi_cli/utils/file_filter.py
@@ -133,6 +133,7 @@ def git_index_mtime(root: Path) -> float | None:
             capture_output=True,
             text=True,
             timeout=2,
+            encoding="utf-8",
         )
         if result.returncode != 0:
             return None
@@ -194,6 +195,7 @@ def _git_deleted_files(root: Path, scope: str | None = None) -> set[str]:
             capture_output=True,
             text=True,
             timeout=_GIT_LS_FILES_TIMEOUT,
+            encoding="utf-8",
         )
         if result.returncode == 0:
             return {e for e in result.stdout.split("\0") if e}
@@ -237,6 +239,7 @@ def list_files_git(
             capture_output=True,
             text=True,
             timeout=_GIT_LS_FILES_TIMEOUT,
+            encoding="utf-8",
         )
         if result.returncode != 0:
             return None
@@ -266,6 +269,7 @@ def list_files_git(
                 capture_output=True,
                 text=True,
                 timeout=_GIT_LS_FILES_TIMEOUT,
+                encoding="utf-8",
             )
             if others.returncode == 0:
                 tracked = set(paths)


### PR DESCRIPTION
…866)

Add encoding="utf-8" to all subprocess.run calls in file_filter.py to prevent encoding errors on systems where the default encoding is not UTF-8.

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
