### PR TITLE
fix(web): clear stale in-flight prompts on error to prevent session busy deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Web: Fix session recovery after stream errors — when a session process exits or hits a read-loop error, stale in-flight prompt IDs are now cleared before broadcasting the error, allowing the frontend to send new messages instead of getting "Session is busy"; the activity status indicator also surfaces the actual error message from the stream
+- Core: Fix Wire server prompt handler leaving sessions stuck busy on uncaught exceptions — SSL errors, connection errors, and other unexpected failures are now caught by a fallback handler and returned as `INTERNAL_ERROR`, allowing the session to recover instead of hanging indefinitely
+
 ## 1.34.0 (2026-04-14)
 
 - Core: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal; the cancelled task is now kept in the manager's live-tasks dict until its runner finishes cleaning up, preventing Python's GC from reaping the still-pending task

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,9 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Web: Fix session recovery after stream errors — when a session process exits or hits a read-loop error, stale in-flight prompt IDs are now cleared before broadcasting the error, allowing the frontend to send new messages instead of getting "Session is busy"; the activity status indicator also surfaces the actual error message from the stream
+- Core: Fix Wire server prompt handler leaving sessions stuck busy on uncaught exceptions — SSL errors, connection errors, and other unexpected failures are now caught by a fallback handler and returned as `INTERNAL_ERROR`, allowing the session to recover instead of hanging indefinitely
+
 ## 1.34.0 (2026-04-14)
 
 - Core: Fix CLI crash on `TaskStop` — stopping a stuck background agent no longer prints `Unhandled exception in event loop / Exception None` and freezes the terminal; the cancelled task is now kept in the manager's live-tasks dict until its runner finishes cleaning up, preventing Python's GC from reaping the still-pending task

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,9 @@
 
 ## 未发布
 
+- Web：修复会话流错误后的恢复问题——当会话进程退出或 read loop 发生异常时，现在在广播错误前先清除过期的 in-flight prompt ID，使前端能够发送新消息而非收到 "Session is busy"；活动状态指示器现在也会显示来自流的具体错误信息
+- Core：修复 Wire 服务端 prompt 处理未捕获异常导致会话永远卡在忙碌状态的问题——SSL 错误、连接错误及其他意外失败现在会被 fallback 处理器捕获并返回 INTERNAL_ERROR，避免异常逃逸导致会话无限挂起
+
 ## 1.34.0 (2026-04-14)
 
 - Core：修复 `TaskStop` 取消卡住的后台 agent 时 CLI 崩溃的问题——终端不再打印 `Unhandled exception in event loop / Exception None` 并冻结；已取消的 task 现在会保留在管理器的 live-tasks 字典中，直到 runner 完成清理，避免 Python GC 在 task 仍处 pending 时回收它

--- a/src/kimi_cli/web/api/sessions.py
+++ b/src/kimi_cli/web/api/sessions.py
@@ -995,19 +995,29 @@ async def session_stream(
                     except ValueError:
                         in_message = None
                     if isinstance(in_message, JSONRPCPromptMessage):
-                        await websocket.send_text(
-                            JSONRPCErrorResponse(
-                                id=in_message.id,
-                                error=JSONRPCErrorObject(
-                                    code=ErrorCodes.INVALID_STATE,
-                                    message=(
-                                        "Session is busy; wait for completion before sending "
-                                        "a new prompt."
+                        # If the session is in error state, the in-flight IDs
+                        # are stale from a failed prompt.  Clear them so the
+                        # user can recover by sending a new message.
+                        if session_process.status.state == "error":
+                            logger.info(
+                                "Clearing stale in-flight prompts for "
+                                f"session {session_id} (was in error state)"
+                            )
+                            session_process.clear_in_flight()
+                        else:
+                            await websocket.send_text(
+                                JSONRPCErrorResponse(
+                                    id=in_message.id,
+                                    error=JSONRPCErrorObject(
+                                        code=ErrorCodes.INVALID_STATE,
+                                        message=(
+                                            "Session is busy; wait for completion before sending "
+                                            "a new prompt."
+                                        ),
                                     ),
-                                ),
-                            ).model_dump_json()
-                        )
-                        continue
+                                ).model_dump_json()
+                            )
+                            continue
 
                 # Update last_session_id on first successful prompt
                 if not last_session_id_updated:

--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -116,6 +116,10 @@ class SessionProcess:
         """Whether the session is currently processing a prompt."""
         return len(self._in_flight_prompt_ids) > 0
 
+    def clear_in_flight(self) -> None:
+        """Clear stale in-flight prompt IDs (e.g. after an error)."""
+        self._in_flight_prompt_ids.clear()
+
     @property
     def status(self) -> SessionStatus:
         """Current runtime status snapshot."""
@@ -302,6 +306,10 @@ class SessionProcess:
                         stderr = await self._process.stderr.read()
                         if not stderr:
                             stderr = b"No stderr"
+                        # Clear in-flight IDs before broadcasting so that
+                        # is_busy is already False when the frontend reacts
+                        # to the error and sends a new prompt.
+                        self._in_flight_prompt_ids.clear()
                         await self._broadcast(
                             JSONRPCErrorResponse(
                                 id=str(uuid4()),
@@ -315,7 +323,6 @@ class SessionProcess:
                             f"Process exited with {self._process.returncode}: "
                             f"{stderr.decode('utf-8')}"
                         )
-                        self._in_flight_prompt_ids.clear()
                         await self._emit_status(
                             "error",
                             reason="process_exit",
@@ -355,6 +362,8 @@ class SessionProcess:
             raise
         except Exception as e:
             logger.warning(f"Unexpected error in read loop: {e.__class__.__name__} {e}")
+            self._in_flight_prompt_ids.clear()
+            await self._emit_status("error", reason="read_loop_error", detail=str(e))
 
     async def _handle_out_message(self, message: JSONRPCOutMessage) -> None:
         """Handle outbound message from worker."""

--- a/src/kimi_cli/wire/server.py
+++ b/src/kimi_cli/wire/server.py
@@ -690,6 +690,15 @@ class WireServer:
                 id=msg.id,
                 result={"status": Statuses.CANCELLED},
             )
+        except Exception as e:
+            logger.exception("Unexpected error in prompt handler")
+            return JSONRPCErrorResponse(
+                id=msg.id,
+                error=JSONRPCErrorObject(
+                    code=ErrorCodes.INTERNAL_ERROR,
+                    message=f"{type(e).__name__}: {e}",
+                ),
+            )
         finally:
             # Clean up any remaining pending requests from this turn.
             # After run_soul() returns, the soul and all subagents are done,

--- a/tests/core/test_auth_error_handling.py
+++ b/tests/core/test_auth_error_handling.py
@@ -191,6 +191,64 @@ class SuccessProvider:
         return self
 
 
+class SSLErrorProvider:
+    """A provider that raises ssl.SSLError (not in _handle_prompt's catch list)."""
+
+    name = "ssl-error"
+
+    @property
+    def model_name(self) -> str:
+        return "ssl-error"
+
+    @property
+    def thinking_effort(self) -> ThinkingEffort | None:
+        return None
+
+    async def generate(
+        self,
+        system_prompt: str,
+        tools: Sequence[Tool],
+        history: Sequence[Message],
+    ) -> None:
+        import ssl
+
+        raise ssl.SSLError(1, "[SSL] record layer failure (_ssl.c:2657)")
+
+    def on_retryable_error(self, error: BaseException) -> bool:
+        return False
+
+    def with_thinking(self, effort: ThinkingEffort) -> Self:
+        return self
+
+
+class ConnectionErrorProvider:
+    """A provider that raises ConnectionError."""
+
+    name = "conn-error"
+
+    @property
+    def model_name(self) -> str:
+        return "conn-error"
+
+    @property
+    def thinking_effort(self) -> ThinkingEffort | None:
+        return None
+
+    async def generate(
+        self,
+        system_prompt: str,
+        tools: Sequence[Tool],
+        history: Sequence[Message],
+    ) -> None:
+        raise ConnectionError("Connection reset by peer")
+
+    def on_retryable_error(self, error: BaseException) -> bool:
+        return False
+
+    def with_thinking(self, effort: ThinkingEffort) -> Self:
+        return self
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -457,3 +515,50 @@ async def test_acp_session_returns_internal_error_for_401_without_oauth() -> Non
         await session.prompt([acp.schema.TextContentBlock(type="text", text="hello")])
 
     assert exc_info.value.code != -32000  # NOT auth_required
+
+
+# ---------------------------------------------------------------------------
+# Tests: _handle_prompt fallback for uncaught exceptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wire_server_catches_ssl_error(
+    runtime: Runtime, tmp_path: Path
+) -> None:
+    """SSLError should be caught by the fallback except clause and return
+    INTERNAL_ERROR instead of escaping and leaving the session busy forever.
+    """
+    soul = _make_soul(runtime, SSLErrorProvider(), tmp_path)
+    server = WireServer(soul)
+
+    response = await server._handle_prompt(
+        JSONRPCPromptMessage(
+            id="1",
+            params=JSONRPCPromptMessage.Params(user_input="hello"),
+        )
+    )
+
+    assert isinstance(response, JSONRPCErrorResponse)
+    assert response.error.code == ErrorCodes.INTERNAL_ERROR
+    assert "SSLError" in response.error.message
+
+
+@pytest.mark.asyncio
+async def test_wire_server_catches_connection_error(
+    runtime: Runtime, tmp_path: Path
+) -> None:
+    """ConnectionError should be caught by the fallback except clause."""
+    soul = _make_soul(runtime, ConnectionErrorProvider(), tmp_path)
+    server = WireServer(soul)
+
+    response = await server._handle_prompt(
+        JSONRPCPromptMessage(
+            id="1",
+            params=JSONRPCPromptMessage.Params(user_input="hello"),
+        )
+    )
+
+    assert isinstance(response, JSONRPCErrorResponse)
+    assert response.error.code == ErrorCodes.INTERNAL_ERROR
+    assert "ConnectionError" in response.error.message

--- a/tests/core/test_auth_error_handling.py
+++ b/tests/core/test_auth_error_handling.py
@@ -523,9 +523,7 @@ async def test_acp_session_returns_internal_error_for_401_without_oauth() -> Non
 
 
 @pytest.mark.asyncio
-async def test_wire_server_catches_ssl_error(
-    runtime: Runtime, tmp_path: Path
-) -> None:
+async def test_wire_server_catches_ssl_error(runtime: Runtime, tmp_path: Path) -> None:
     """SSLError should be caught by the fallback except clause and return
     INTERNAL_ERROR instead of escaping and leaving the session busy forever.
     """
@@ -545,9 +543,7 @@ async def test_wire_server_catches_ssl_error(
 
 
 @pytest.mark.asyncio
-async def test_wire_server_catches_connection_error(
-    runtime: Runtime, tmp_path: Path
-) -> None:
+async def test_wire_server_catches_connection_error(runtime: Runtime, tmp_path: Path) -> None:
     """ConnectionError should be caught by the fallback except clause."""
     soul = _make_soul(runtime, ConnectionErrorProvider(), tmp_path)
     server = WireServer(soul)

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -16,7 +16,6 @@ import pytest
 from kimi_cli.web.models import SessionStatus
 from kimi_cli.web.runner.process import SessionProcess
 
-
 # ---------------------------------------------------------------------------
 # Tests: SessionProcess.clear_in_flight
 # ---------------------------------------------------------------------------

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -51,7 +51,7 @@ async def test_read_loop_clears_in_flight_on_exception() -> None:
 
     # Create a mock process whose stdout has one line then EOF
     mock_stdout = asyncio.StreamReader()
-    mock_stdout.feed_data(b'not-valid-json\n')
+    mock_stdout.feed_data(b"not-valid-json\n")
     mock_stdout.feed_eof()
 
     mock_stderr = asyncio.StreamReader()

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -1,0 +1,165 @@
+"""Tests for session error recovery in process.py and sessions.py.
+
+Verifies that _in_flight_prompt_ids is properly cleared on errors so
+that sessions don't get stuck in a permanent "busy" state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from kimi_cli.web.models import SessionStatus
+from kimi_cli.web.runner.process import SessionProcess
+
+
+# ---------------------------------------------------------------------------
+# Tests: SessionProcess.clear_in_flight
+# ---------------------------------------------------------------------------
+
+
+def test_clear_in_flight_resets_is_busy() -> None:
+    """clear_in_flight should empty _in_flight_prompt_ids so is_busy is False."""
+    sp = SessionProcess(uuid4())
+    sp._in_flight_prompt_ids.add("prompt-1")
+    sp._in_flight_prompt_ids.add("prompt-2")
+
+    assert sp.is_busy is True
+
+    sp.clear_in_flight()
+
+    assert sp.is_busy is False
+    assert len(sp._in_flight_prompt_ids) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: _read_loop clears in-flight on unexpected exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_loop_clears_in_flight_on_exception() -> None:
+    """When _read_loop encounters a non-EOF, non-CancelledError exception,
+    it should clear _in_flight_prompt_ids and emit an error status.
+    """
+    sp = SessionProcess(uuid4())
+    sp._in_flight_prompt_ids.add("prompt-in-flight")
+    assert sp.is_busy is True
+
+    # Create a mock process whose stdout has one line then EOF
+    mock_stdout = asyncio.StreamReader()
+    mock_stdout.feed_data(b'not-valid-json\n')
+    mock_stdout.feed_eof()
+
+    mock_stderr = asyncio.StreamReader()
+    mock_stderr.feed_data(b"mock stderr")
+    mock_stderr.feed_eof()
+
+    mock_process = MagicMock()
+    mock_process.stdout = mock_stdout
+    mock_process.stderr = mock_stderr
+    mock_process.returncode = None
+
+    sp._process = mock_process
+
+    # _broadcast raises on the first call (the stdout line),
+    # succeeds on subsequent calls (_emit_status broadcast).
+    call_count = 0
+
+    async def failing_then_ok_broadcast(msg: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("broadcast failed")
+
+    sp._broadcast = failing_then_ok_broadcast  # type: ignore[assignment]
+
+    await sp._read_loop()
+
+    assert sp.is_busy is False
+    assert sp.status.state == "error"
+    assert sp.status.reason == "read_loop_error"
+
+
+# ---------------------------------------------------------------------------
+# Tests: EOF path clears in-flight before broadcast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_loop_eof_clears_in_flight_before_broadcast() -> None:
+    """On worker process EOF, _in_flight_prompt_ids should be cleared
+    before _broadcast is called, so that is_busy is already False when
+    the frontend reacts to the error.
+    """
+    sp = SessionProcess(uuid4())
+    sp._in_flight_prompt_ids.add("prompt-in-flight")
+
+    # Track is_busy at the time broadcast is called
+    busy_at_broadcast: list[bool] = []
+
+    async def tracking_broadcast(msg: str) -> None:
+        busy_at_broadcast.append(sp.is_busy)
+
+    sp._broadcast = tracking_broadcast  # type: ignore[assignment]
+
+    # Create a mock process that immediately returns EOF
+    mock_stdout = asyncio.StreamReader()
+    mock_stdout.feed_eof()
+
+    mock_stderr = asyncio.StreamReader()
+    mock_stderr.feed_data(b"worker crashed")
+    mock_stderr.feed_eof()
+
+    mock_process = MagicMock()
+    mock_process.stdout = mock_stdout
+    mock_process.stderr = mock_stderr
+    mock_process.returncode = 1
+
+    sp._process = mock_process
+    sp._expecting_exit = False
+
+    await sp._read_loop()
+
+    # At the time broadcast was called, is_busy should already be False
+    assert busy_at_broadcast[0] is False
+    assert sp.status.state == "error"
+
+
+# ---------------------------------------------------------------------------
+# Tests: error state allows recovery with new prompt
+# ---------------------------------------------------------------------------
+
+
+def test_session_in_error_state_clears_stale_ids_on_new_prompt() -> None:
+    """When a session is in error state and is_busy is True (stale IDs),
+    clear_in_flight should be callable to recover the session.
+    This tests the building block used by the sessions.py WebSocket handler.
+    """
+    session_id = uuid4()
+    sp = SessionProcess(session_id)
+
+    # Simulate: session errored out but _in_flight_prompt_ids was not cleared
+    sp._in_flight_prompt_ids.add("stale-prompt")
+    sp._status = SessionStatus(
+        session_id=session_id,
+        state="error",
+        seq=1,
+        worker_id=None,
+        reason="process_exit",
+        detail=None,
+        updated_at=datetime.now(UTC),
+    )
+
+    assert sp.is_busy is True
+    assert sp.status.state == "error"
+
+    # The sessions.py handler checks this condition and calls clear_in_flight
+    if sp.status.state == "error" and sp.is_busy:
+        sp.clear_in_flight()
+
+    assert sp.is_busy is False

--- a/web/src/features/chat/chat-workspace-container.tsx
+++ b/web/src/features/chat/chat-workspace-container.tsx
@@ -125,6 +125,7 @@ export function ChatWorkspaceContainer({
     planMode,
     sendSetPlanMode,
     slashCommands,
+    error: streamError,
   } = sessionStream;
 
   const clearNewFiles = useToolEventsStore((state) => state.clearNewFiles);
@@ -386,6 +387,7 @@ export function ChatWorkspaceContainer({
       slashCommands={slashCommands}
       planMode={planMode}
       onPlanModeChange={handlePlanModeChange}
+      errorMessage={streamError?.message}
       onForkSession={onForkSession ? handleForkSession : undefined}
     />
   );

--- a/web/src/features/chat/chat.tsx
+++ b/web/src/features/chat/chat.tsx
@@ -169,7 +169,7 @@ export const ChatWorkspace = memo(function ChatWorkspaceComponent({
 
     prevActivityRef.current = newStatus;
     return newStatus;
-  }, [status, isAwaitingFirstResponse, isReplayingHistory, isUploadingFiles, messages]);
+  }, [status, isAwaitingFirstResponse, isReplayingHistory, isUploadingFiles, messages, errorMessage]);
 
   const maxTokens = maxContextSize ?? 64000;
   const usedTokens = Math.round(contextUsage * maxTokens);

--- a/web/src/features/chat/chat.tsx
+++ b/web/src/features/chat/chat.tsx
@@ -90,6 +90,8 @@ type ChatWorkspaceProps = {
   maxContextSize?: number;
   /** Fork session at a specific turn */
   onForkSession?: (turnIndex: number) => void;
+  /** Error message from the session stream */
+  errorMessage?: string;
 };
 
 type ToolApproval = NonNullable<LiveMessage["toolCall"]>["approval"];
@@ -121,6 +123,7 @@ export const ChatWorkspace = memo(function ChatWorkspaceComponent({
   planMode = false,
   onPlanModeChange,
   onForkSession,
+  errorMessage,
 }: ChatWorkspaceProps): ReactElement {
   const [blocksExpanded, setBlocksExpanded] = useState(false);
   const [isFilesPanelOpen, setIsFilesPanelOpen] = useState(false);
@@ -151,6 +154,7 @@ export const ChatWorkspace = memo(function ChatWorkspaceComponent({
       isReplayingHistory,
       isUploadingFiles,
       messages,
+      errorMessage,
     });
 
     // If status and description haven't changed, return cached reference

--- a/web/src/features/chat/components/activity-status-indicator.tsx
+++ b/web/src/features/chat/components/activity-status-indicator.tsx
@@ -37,6 +37,7 @@ type DeriveActivityStatusParams = {
   isReplayingHistory: boolean;
   isUploadingFiles: boolean;
   messages: LiveMessage[];
+  errorMessage?: string | null;
 };
 
 /**
@@ -48,6 +49,7 @@ export function deriveActivityStatus({
   isReplayingHistory,
   isUploadingFiles,
   messages,
+  errorMessage,
 }: DeriveActivityStatusParams): ActivityDetail {
   // Check for pending approval requests (search from end for efficiency)
   if (findPendingApproval(messages)) {
@@ -69,7 +71,7 @@ export function deriveActivityStatus({
   if (chatStatus === "error") {
     return {
       status: "error",
-      description: "An error occurred",
+      description: errorMessage || "An error occurred",
     };
   }
 


### PR DESCRIPTION
Clear stale in-flight prompts on error to prevent session busy deadlock

When a worker process crashes or an uncaught exception (e.g. SSLError, ConnectionError) escapes _handle_prompt, the prompt response is never sent back, leaving _in_flight_prompt_ids populated and is_busy stuck at True. Any subsequent message is rejected with "Session is busy", creating a permanent deadlock.

Fixes:
- process.py: move _in_flight_prompt_ids.clear() before _broadcast on EOF so is_busy is already False when the frontend reacts; add cleanup in the non-EOF exception path of _read_loop
- server.py: add fallback except Exception in _handle_prompt to ensure a response is always returned for unexpected errors
- sessions.py: when session status is "error" and is_busy is True, clear stale IDs and allow the new prompt through instead of rejecting
- Frontend: surface the actual error message in the activity status indicator instead of a generic "An error occurred"

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
