### PR TITLE
fix: handle non-UTF-8 filenames in git ls-files on Windows

### DIFF
--- a/src/kimi_cli/utils/file_filter.py
+++ b/src/kimi_cli/utils/file_filter.py
@@ -145,13 +145,15 @@ def git_index_mtime(root: Path) -> float | None:
         return None
 
 
-def _parse_ls_files_output(stdout: str, *, filter_ignored: bool = True) -> list[str]:
+def _parse_ls_files_output(stdout: str | None, *, filter_ignored: bool = True) -> list[str]:
     """Parse NUL-delimited ``git ls-files -z`` output into paths with synthesised dirs.
 
     When *filter_ignored* is *True*, paths whose segments match
     ``is_ignored()`` are excluded so that tracked ``node_modules/``,
     ``vendor/``, etc. do not pollute completion candidates.
     """
+    if not stdout:
+        return []
     paths: list[str] = []
     seen_dirs: set[str] = set()
     ignored_prefixes: set[str] = set()
@@ -193,9 +195,11 @@ def _git_deleted_files(root: Path, scope: str | None = None) -> set[str]:
             cwd=root,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_GIT_LS_FILES_TIMEOUT,
         )
-        if result.returncode == 0:
+        if result.returncode == 0 and result.stdout:
             return {e for e in result.stdout.split("\0") if e}
     except Exception:
         pass
@@ -236,6 +240,8 @@ def list_files_git(
             cwd=root,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_GIT_LS_FILES_TIMEOUT,
         )
         if result.returncode != 0:
@@ -265,6 +271,8 @@ def list_files_git(
                 cwd=root,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_GIT_LS_FILES_TIMEOUT,
             )
             if others.returncode == 0:


### PR DESCRIPTION
## Summary

On Chinese Windows systems, `subprocess.run(..., text=True)` uses the system default encoding (GBK), which crashes when `git ls-files` outputs UTF-8 filenames containing Chinese characters.

This PR:
- Adds `encoding="utf-8"` and `errors="replace"` to all three `subprocess.run` calls in `file_filter.py`
- Guards `_parse_ls_files_output` against `None` stdout to prevent the `AttributeError: 'NoneType' object has no attribute 'split'` cascade

Fixes #1866

## Changes

1 file changed, 10 insertions, 2 deletions — all in `src/kimi_cli/utils/file_filter.py`

## Test plan

- [x] Verified the three `subprocess.run` calls now specify `encoding="utf-8"`
- [ ] Needs testing on a Windows machine with Chinese-named files in a git repo
- [ ] `@` file completion should work without `UnicodeDecodeError`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
