### PR TITLE
fix(core): honor http_proxy env vars via aiohttp trust_env=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Fix login and other outbound HTTP requests ignoring `http_proxy` / `https_proxy` / `NO_PROXY` environment variables — `new_client_session()` now constructs `aiohttp.ClientSession` with `trust_env=True` so standard proxy env vars are honored; previously, users behind a local HTTP proxy whose DNS only resolves for traffic routed through the proxy would see `/login` fail with `Cannot connect to host auth.kimi.com:443 [nodename nor servname provided]` even though `curl -x $http_proxy` worked
 - Web: Fix session recovery after stream errors — when a session process exits or hits a read-loop error, stale in-flight prompt IDs are now cleared before broadcasting the error, allowing the frontend to send new messages instead of getting "Session is busy"; the activity status indicator also surfaces the actual error message from the stream
 - Core: Fix Wire server prompt handler leaving sessions stuck busy on uncaught exceptions — SSL errors, connection errors, and other unexpected failures are now caught by a fallback handler and returned as `INTERNAL_ERROR`, allowing the session to recover instead of hanging indefinitely
 

--- a/src/kimi_cli/utils/aiohttp.py
+++ b/src/kimi_cli/utils/aiohttp.py
@@ -21,4 +21,5 @@ def new_client_session(
     return aiohttp.ClientSession(
         connector=aiohttp.TCPConnector(ssl=_ssl_context),
         timeout=timeout or _DEFAULT_TIMEOUT,
+        trust_env=True,
     )

--- a/tests/utils/test_aiohttp_timeout.py
+++ b/tests/utils/test_aiohttp_timeout.py
@@ -27,6 +27,12 @@ async def test_custom_timeout_override():
         assert session.timeout.sock_read == 10
 
 
+async def test_session_trusts_proxy_env():
+    """new_client_session() should honor http_proxy / https_proxy env vars."""
+    async with new_client_session() as session:
+        assert session.trust_env is True
+
+
 async def test_slow_server_is_interrupted():
     """A server that accepts but never responds should be interrupted by timeout."""
     hang_forever = asyncio.Event()


### PR DESCRIPTION
## Summary

`new_client_session()` constructs `aiohttp.ClientSession` without `trust_env=True`, so the standard `http_proxy` / `https_proxy` / `NO_PROXY` environment variables are ignored and every outbound request goes direct.

On setups where direct network access isn't available — e.g. a local HTTP proxy whose DNS only resolves for traffic routed through it — `/login` fails with:

```
Login failed: Cannot connect to host auth.kimi.com:443
ssl:default [nodename nor servname provided, or not known]
```

`curl -x $http_proxy https://auth.kimi.com/` through the same proxy works fine, which confirms the issue is aiohttp-side, not a network / DNS / firewall problem.

## Fix

One-line change in `src/kimi_cli/utils/aiohttp.py`: pass `trust_env=True` to `aiohttp.ClientSession`. With this, aiohttp calls `urllib.request.getproxies()` on each request and honors the standard env vars (both lower- and upper-case on Unix). No new dependencies, no behavior change for users without proxy env vars set.

## Repro (before the fix)

1. Run a local HTTP proxy on `127.0.0.1:7890` whose DNS only answers for traffic routed through it.
2. `export http_proxy=http://127.0.0.1:7890 https_proxy=http://127.0.0.1:7890`.
3. `curl -I https://auth.kimi.com/` → succeeds (network path is fine).
4. `kimi` → `/login` → select any platform → DNS/connect failure as above.

After the fix, step 4 succeeds.

## Notes

- The brew-packaged `kimi-cli 1.24.0` formula shipped with `trust_env=True` already applied (as a local patch downstream), so this looks like a regression on `main`.
- Test plan: added `test_session_trusts_proxy_env` in `tests/utils/test_aiohttp_timeout.py` asserting `session.trust_env is True`. Existing timeout tests untouched.
- Changelog: added an `Unreleased` entry under Core.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
