### PR TITLE
[codex] Fix OAuth wait cancellation in /login

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -11,7 +11,7 @@ import tempfile
 import time
 import uuid
 import webbrowser
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -153,6 +153,44 @@ class DeviceAuthorization:
     verification_uri_complete: str
     expires_in: int | None
     interval: int
+
+
+async def _await_or_cancel[T](awaitable: Awaitable[T], cancel_event: asyncio.Event | None) -> T:
+    if cancel_event is None:
+        return await awaitable
+    if cancel_event.is_set():
+        raise asyncio.CancelledError()
+
+    work_task = asyncio.create_task(awaitable)
+    cancel_task = asyncio.create_task(cancel_event.wait())
+    try:
+        done, _ = await asyncio.wait(
+            [work_task, cancel_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if cancel_task in done:
+            work_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await work_task
+            raise asyncio.CancelledError()
+        return await work_task
+    finally:
+        cancel_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await cancel_task
+
+
+async def _sleep_or_cancel(delay: float, cancel_event: asyncio.Event | None) -> None:
+    if cancel_event is None:
+        await asyncio.sleep(delay)
+        return
+    if cancel_event.is_set():
+        raise asyncio.CancelledError()
+    try:
+        await asyncio.wait_for(cancel_event.wait(), timeout=delay)
+    except TimeoutError:
+        return
+    raise asyncio.CancelledError()
 
 
 def _oauth_host() -> str:
@@ -581,7 +619,10 @@ def _apply_kimi_code_config(
 
 
 async def login_kimi_code(
-    config: Config, *, open_browser: bool = True
+    config: Config,
+    *,
+    open_browser: bool = True,
+    cancel_event: asyncio.Event | None = None,
 ) -> AsyncIterator[OAuthEvent]:
     if not config.is_from_default_location:
         yield OAuthEvent(
@@ -598,6 +639,8 @@ async def login_kimi_code(
     auth: DeviceAuthorization
     token: OAuthToken | None = None
     while True:
+        if cancel_event is not None and cancel_event.is_set():
+            raise asyncio.CancelledError()
         try:
             auth = await request_device_authorization()
         except Exception as exc:
@@ -626,7 +669,7 @@ async def login_kimi_code(
         printed_wait = False
         try:
             while True:
-                status, data = await _request_device_token(auth)
+                status, data = await _await_or_cancel(_request_device_token(auth), cancel_event)
                 if status == 200 and "access_token" in data:
                     token = OAuthToken.from_response(data)
                     break
@@ -644,7 +687,7 @@ async def login_kimi_code(
                         },
                     )
                     printed_wait = True
-                await asyncio.sleep(interval)
+                await _sleep_or_cancel(interval, cancel_event)
         except OAuthDeviceExpired:
             yield OAuthEvent("info", "Device code expired, restarting login...")
             continue

--- a/src/kimi_cli/ui/shell/oauth.py
+++ b/src/kimi_cli/ui/shell/oauth.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
+from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.key_binding import KeyPressEvent
+from rich.panel import Panel
 from rich.status import Status
+from rich.text import Text
 
 from kimi_cli.auth import KIMI_CODE_PLATFORM_ID
 from kimi_cli.auth.oauth import login_kimi_code, logout_kimi_code
@@ -11,7 +16,7 @@ from kimi_cli.auth.platforms import is_managed_provider_key, parse_managed_provi
 from kimi_cli.cli import Reload
 from kimi_cli.config import save_config
 from kimi_cli.soul.kimisoul import KimiSoul
-from kimi_cli.ui.shell.console import console
+from kimi_cli.ui.shell.console import console, render_to_ansi
 from kimi_cli.ui.shell.setup import select_platform, setup_platform
 from kimi_cli.ui.shell.slash import ensure_kimi_soul, registry
 
@@ -19,11 +24,64 @@ if TYPE_CHECKING:
     from kimi_cli.ui.shell import Shell
 
 
-async def _login_kimi_code(soul: KimiSoul) -> bool:
+class _OAuthLoginPromptDelegate:
+    modal_priority = 5
+
+    def __init__(self, cancel_event: asyncio.Event) -> None:
+        self._cancel_event = cancel_event
+
+    def render_running_prompt_body(self, columns: int) -> ANSI:
+        panel = Panel(
+            Text("Waiting for browser authorization. Press Esc or Ctrl+C to cancel.", style="dim"),
+            title="[bold]login[/bold]",
+            title_align="left",
+            border_style="cyan",
+            padding=(0, 1),
+        )
+        return ANSI(render_to_ansi(panel, columns=columns).rstrip("\n"))
+
+    def running_prompt_placeholder(self) -> None:
+        return None
+
+    def running_prompt_allows_text_input(self) -> bool:
+        return False
+
+    def running_prompt_hides_input_buffer(self) -> bool:
+        return True
+
+    def running_prompt_accepts_submission(self) -> bool:
+        return False
+
+    def should_handle_running_prompt_key(self, key: str) -> bool:
+        return key in {"escape", "c-c", "c-d"}
+
+    def handle_running_prompt_key(self, key: str, event: KeyPressEvent) -> None:
+        self._cancel_event.set()
+
+
+async def _watch_login_cancel(prompt_session: object, cancel_event: asyncio.Event) -> None:
+    while not cancel_event.is_set():
+        try:
+            await prompt_session.prompt_next()  # pyright: ignore[reportAttributeAccessIssue]
+        except (KeyboardInterrupt, EOFError):
+            cancel_event.set()
+            return
+
+
+async def _login_kimi_code(app: Shell, soul: KimiSoul) -> bool:
     status: Status | None = None
+    cancel_event = asyncio.Event()
+    prompt_task: asyncio.Task[None] | None = None
+    prompt_session = app._prompt_session  # pyright: ignore[reportPrivateUsage]
+    modal = None
     ok = True
     try:
-        async for event in login_kimi_code(soul.runtime.config):
+        if prompt_session is not None:
+            modal = _OAuthLoginPromptDelegate(cancel_event)
+            prompt_session.attach_modal(modal)
+            prompt_task = asyncio.create_task(_watch_login_cancel(prompt_session, cancel_event))
+
+        async for event in login_kimi_code(soul.runtime.config, cancel_event=cancel_event):
             if event.type == "waiting":
                 if status is None:
                     status = console.status("[cyan]Waiting for user authorization...[/cyan]")
@@ -43,6 +101,12 @@ async def _login_kimi_code(soul: KimiSoul) -> bool:
             if event.type == "error":
                 ok = False
     finally:
+        if prompt_task is not None:
+            prompt_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await prompt_task
+        if prompt_session is not None and modal is not None:
+            prompt_session.detach_modal(modal)
         if status is not None:
             status.stop()
     return ok
@@ -68,7 +132,7 @@ async def login(app: Shell, args: str) -> None:
     if platform is None:
         return
     if platform.id == KIMI_CODE_PLATFORM_ID:
-        ok = await _login_kimi_code(soul)
+        ok = await _login_kimi_code(app, soul)
     else:
         ok = await setup_platform(platform)
     if not ok:

--- a/tests/auth/test_oauth_login.py
+++ b/tests/auth/test_oauth_login.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kimi_cli.auth.oauth import DeviceAuthorization, login_kimi_code
+from kimi_cli.config import Config
+
+
+def _make_device_authorization(*, interval: int = 60) -> DeviceAuthorization:
+    return DeviceAuthorization(
+        user_code="TEST-CODE",
+        device_code="device-code",
+        verification_uri="https://example.com/verify",
+        verification_uri_complete="https://example.com/verify?user_code=TEST-CODE",
+        expires_in=600,
+        interval=interval,
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_kimi_code_cancel_event_interrupts_wait_loop() -> None:
+    config = Config(is_from_default_location=True)
+    cancel_event = asyncio.Event()
+
+    with (
+        patch(
+            "kimi_cli.auth.oauth.get_platform_by_id",
+            return_value=SimpleNamespace(id="kimi-code"),
+        ),
+        patch(
+            "kimi_cli.auth.oauth.request_device_authorization",
+            AsyncMock(return_value=_make_device_authorization()),
+        ),
+        patch(
+            "kimi_cli.auth.oauth._request_device_token",
+            AsyncMock(
+                return_value=(
+                    400,
+                    {
+                        "error": "authorization_pending",
+                        "error_description": "waiting for approval",
+                    },
+                )
+            ),
+        ),
+    ):
+        flow = login_kimi_code(config, open_browser=False, cancel_event=cancel_event)
+
+        assert (await anext(flow)).type == "info"
+        assert (await anext(flow)).type == "verification_url"
+        assert (await anext(flow)).type == "waiting"
+
+        cancel_event.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(anext(flow), timeout=0.2)

--- a/tests/ui_and_conv/test_shell_oauth.py
+++ b/tests/ui_and_conv/test_shell_oauth.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from kosong.tooling.empty import EmptyToolset
+
+from kimi_cli.auth.oauth import OAuthEvent
+from kimi_cli.soul.agent import Agent, Runtime
+from kimi_cli.soul.context import Context
+from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.ui.shell import Shell
+from kimi_cli.ui.shell import oauth as shell_oauth
+
+
+def _make_shell(runtime: Runtime, tmp_path: Path) -> Shell:
+    agent = Agent(
+        name="Test Agent",
+        system_prompt="Test system prompt.",
+        toolset=EmptyToolset(),
+        runtime=runtime,
+    )
+    soul = KimiSoul(agent, context=Context(file_backend=tmp_path / "history.jsonl"))
+    return Shell(soul)
+
+
+class _DummyStatus:
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+class _FakePromptSession:
+    def __init__(self) -> None:
+        self.modals: list[object] = []
+        self.prompt_calls = 0
+
+    def attach_modal(self, delegate: object) -> None:
+        self.modals.append(delegate)
+
+    def detach_modal(self, delegate: object) -> None:
+        self.modals.remove(delegate)
+
+    def invalidate(self) -> None:
+        return None
+
+    async def prompt_next(self) -> None:
+        self.prompt_calls += 1
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_shell_login_escape_cancels_waiting_oauth_flow(
+    runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shell = _make_shell(runtime, tmp_path)
+    prompt_session = _FakePromptSession()
+    shell._prompt_session = prompt_session  # pyright: ignore[reportPrivateUsage]
+
+    cancel_events: list[asyncio.Event | None] = []
+
+    async def _fake_login_kimi_code(config, *, open_browser=True, cancel_event=None):
+        cancel_events.append(cancel_event)
+        yield OAuthEvent("waiting", "Waiting for user authorization...")
+        assert cancel_event is not None
+        await cancel_event.wait()
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(shell_oauth, "login_kimi_code", _fake_login_kimi_code)
+    monkeypatch.setattr(shell_oauth.console, "status", lambda *_args, **_kwargs: _DummyStatus())
+    monkeypatch.setattr(shell_oauth.console, "print", lambda *args, **kwargs: None)
+
+    task = asyncio.create_task(shell_oauth._login_kimi_code(shell, shell.soul))
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert prompt_session.prompt_calls > 0
+    assert len(prompt_session.modals) == 1
+
+    prompt_session.modals[0].handle_running_prompt_key(  # pyright: ignore[reportAttributeAccessIssue]
+        "escape",
+        SimpleNamespace(app=None, current_buffer=None),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert len(cancel_events) == 1
+    assert cancel_events[0] is not None and cancel_events[0].is_set()
+    assert prompt_session.modals == []


### PR DESCRIPTION
## Summary

Fixes #1905.

This change makes the Kimi Code OAuth device login flow cancellable while the shell UI is waiting for browser authorization.

## What changed

- added a cancellable wait path to the OAuth device polling loop
- passed a cancel event from the shell `/login` flow into the OAuth login routine
- attached a temporary shell modal so `Esc`, `Ctrl+C`, and `Ctrl+D` can cancel the waiting state
- clarified the shell interaction: pressing `Esc` while waiting for browser authorization cancels the current login attempt and returns to the shell prompt, rather than navigating back to platform selection
- added regression tests for both the OAuth polling loop and the shell login cancel path

## Root cause

The device authorization loop only polled and slept, with no cancel signal. The shell-level `/login` flow also did not hook the waiting state into the existing running-prompt cancel handling.

## Validation

- `uv run pytest tests/auth/test_oauth_login.py tests/ui_and_conv/test_shell_oauth.py tests/ui_and_conv/test_shell_prompt_router.py`
- `uv run ruff check src/kimi_cli/auth/oauth.py src/kimi_cli/ui/shell/oauth.py tests/auth/test_oauth_login.py tests/ui_and_conv/test_shell_oauth.py`
