### PR TITLE
fix(shell): show moon spinner fallback during all active turn gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Fix missing loading indicator during active turns — the moon spinner now shows as a fallback whenever the model is working but no other indicator is visible, covering gaps after tool calls finish, between turn start and first step, and when an empty thinking block arrives from the provider
 - Core: Increase default `max_steps_per_turn` from 100 to 500 to allow longer uninterrupted agent runs out of the box
 
 ## 1.35.0 (2026-04-15)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Shell: Fix missing loading indicator during active turns — the moon spinner now shows as a fallback whenever the model is working but no other indicator is visible, covering gaps after tool calls finish, between turn start and first step, and when an empty thinking block arrives from the provider
 - Core: Increase default `max_steps_per_turn` from 100 to 500 to allow longer uninterrupted agent runs out of the box
 
 ## 1.35.0 (2026-04-15)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,7 @@
 
 ## 未发布
 
+- Shell：修复活跃 turn 期间加载指示器缺失的问题——月亮 spinner 现在作为兜底指示器，在模型仍在工作但没有其他指示器可见时自动显示，覆盖了工具调用完成后、turn 开始到首个 step 之间、以及 provider 发送空 thinking block 时的空白期
 - Core：将 `max_steps_per_turn` 默认值从 100 提高到 500，开箱即可支持更长的无中断 agent 运行
 
 ## 1.35.0 (2026-04-15)

--- a/src/kimi_cli/ui/shell/visualize/_interactive.py
+++ b/src/kimi_cli/ui/shell/visualize/_interactive.py
@@ -231,7 +231,8 @@ class _PromptLiveView(_LiveView):
                     break
 
                 if isinstance(msg, TurnEnd):
-                    self._turn_ended = True
+                    self._active_turn_depth = max(0, self._active_turn_depth - 1)
+                    self._turn_ended = self._active_turn_depth == 0
                     self._flush_prompt_refresh()
                     continue
 

--- a/src/kimi_cli/ui/shell/visualize/_live_view.py
+++ b/src/kimi_cli/ui/shell/visualize/_live_view.py
@@ -110,7 +110,8 @@ class _LiveView:
         self._cancel_event = cancel_event
         self._show_thinking_stream = show_thinking_stream
 
-        self._mooning_spinner: Spinner | None = None
+        self._mooning_spinner = Spinner("moon", "")
+        self._active_turn_depth = 0
         self._compacting_spinner: Spinner | None = None
         self._mcp_loading_spinner: Spinner | None = None
         self._btw_spinner: Spinner | None = None
@@ -326,21 +327,31 @@ class _LiveView:
 
         Pure agent streaming status — no interactive overlays.
         Always safe to render regardless of modal state.
+
+        Display priority (highest → lowest):
+          1. MCP loading spinner (connecting to servers)
+          2. Compaction spinner (context compaction in progress)
+          3. Content blocks + tool call blocks (streaming output)
+          4. Moon spinner fallback (turn active but nothing else visible)
+        The btw spinner is always shown (side-channel, not mutually exclusive).
         """
         blocks: list[RenderableType] = []
         if self._btw_spinner is not None:
             blocks.append(self._btw_spinner)
         if self._mcp_loading_spinner is not None:
             blocks.append(self._mcp_loading_spinner)
-        elif self._mooning_spinner is not None:
-            blocks.append(self._mooning_spinner)
         elif self._compacting_spinner is not None:
             blocks.append(self._compacting_spinner)
         else:
+            has_main_content = False
             if self._current_content_block is not None:
                 blocks.append(self._current_content_block.compose())
+                has_main_content = True
             for tool_call in list(self._tool_call_blocks.values()):
                 blocks.append(tool_call.compose())
+                has_main_content = True
+            if not has_main_content and self._active_turn_depth > 0:
+                blocks.append(self._mooning_spinner)
         for notification in list(self._live_notification_blocks):
             blocks.append(notification.compose())
         return blocks
@@ -371,18 +382,18 @@ class _LiveView:
         if isinstance(msg, StepBegin):
             self.cleanup(is_interrupt=False)
             self._mcp_loading_spinner = None
-            self._mooning_spinner = Spinner("moon", "")
+            # Defensive: if StepBegin arrives without a preceding TurnBegin
+            # (e.g. during replay), ensure the turn is considered active.
+            if self._active_turn_depth == 0:
+                self._active_turn_depth = 1
             self.refresh_soon()
             return
 
-        if self._mooning_spinner is not None:
-            # any message other than StepBegin should end the mooning state
-            self._mooning_spinner = None
-            self.refresh_soon()
-
         match msg:
             case TurnBegin():
+                self._active_turn_depth += 1
                 self.flush_content()
+                self.refresh_soon()
             case SteerInput(user_input=user_input):
                 self.cleanup(is_interrupt=False)
                 content: list[ContentPart]
@@ -392,7 +403,7 @@ class _LiveView:
                     content = [TextPart(text=user_input)]
                 console.print(render_user_echo(Message(role="user", content=content)))
             case TurnEnd():
-                pass
+                self._active_turn_depth = max(0, self._active_turn_depth - 1)
             case CompactionBegin():
                 self._compacting_spinner = Spinner("balloon", "Compacting...")
                 self.refresh_soon()
@@ -590,10 +601,12 @@ class _LiveView:
         self.flush_notifications()
 
         # Clear transient spinners to prevent visual residuals after interrupts
-        self._mooning_spinner = None
         self._compacting_spinner = None
         self._mcp_loading_spinner = None
         self._btw_spinner = None
+
+        if is_interrupt:
+            self._active_turn_depth = 0
 
         while self._approval_request_queue:
             # should not happen, but just in case
@@ -636,9 +649,12 @@ class _LiveView:
     def append_content(self, part: ContentPart) -> None:
         match part:
             case ThinkPart(think=text) | TextPart(text=text):
-                if not text:
-                    return
                 is_think = isinstance(part, ThinkPart)
+                # Skip empty TextPart, but still create the block for empty
+                # ThinkPart so the "Thinking" indicator shows immediately
+                # (e.g. Anthropic/OpenAI block-start events yield think="").
+                if not text and not is_think:
+                    return
                 if self._current_content_block is None:
                     self._current_content_block = _ContentBlock(
                         is_think, show_thinking_stream=self._show_thinking_stream
@@ -650,8 +666,9 @@ class _LiveView:
                         is_think, show_thinking_stream=self._show_thinking_stream
                     )
                     self.refresh_soon()
-                self._current_content_block.append(text)
-                self.refresh_soon()
+                if text:
+                    self._current_content_block.append(text)
+                    self.refresh_soon()
             case _:
                 # TODO: support more content part types
                 pass

--- a/tests/ui_and_conv/test_empty_think_part_indicator.py
+++ b/tests/ui_and_conv/test_empty_think_part_indicator.py
@@ -1,0 +1,331 @@
+"""Test loading indicator coverage during active turns.
+
+Verifies that:
+1. An empty ThinkPart (e.g. Anthropic block-start) creates a thinking indicator.
+2. The moon spinner shows as a fallback whenever the turn is active but nothing
+   else is visible (covers TurnBegin→StepBegin, ToolResult→StepBegin gaps).
+3. Higher-priority indicators (content blocks, tool blocks, compaction) take
+   precedence over the moon fallback.
+"""
+
+from __future__ import annotations
+
+from kosong.message import ToolCall
+from kosong.tooling import ToolResult, ToolReturnValue
+from rich.console import Console
+
+from kimi_cli.ui.shell.visualize import _LiveView
+from kimi_cli.wire.types import (
+    CompactionBegin,
+    StatusUpdate,
+    StepBegin,
+    TextPart,
+    ThinkPart,
+    TurnBegin,
+    TurnEnd,
+)
+
+
+def _render(renderable) -> str:
+    console = Console(width=100, record=True, highlight=False)
+    console.print(renderable)
+    return console.export_text()
+
+
+def _make_tool_call(call_id: str = "call_1") -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        function=ToolCall.FunctionBody(name="Shell", arguments='{"command": "ls"}'),
+    )
+
+
+def _make_tool_result(call_id: str = "call_1") -> ToolResult:
+    return ToolResult(
+        tool_call_id=call_id,
+        return_value=ToolReturnValue(is_error=False, output="ok", message="ok", display=[]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty ThinkPart indicator
+# ---------------------------------------------------------------------------
+
+
+def test_empty_think_part_creates_thinking_indicator():
+    """After StepBegin + empty ThinkPart, the thinking indicator must be visible."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+
+    # Empty ThinkPart arrives (Anthropic block-start, think="")
+    view.dispatch_wire_message(ThinkPart(think=""))
+
+    # A thinking content block must exist and take priority over moon fallback
+    assert view._current_content_block is not None
+    assert view._current_content_block.is_think is True
+    rendered = _render(view.compose())
+    assert "Thinking" in rendered
+
+
+def test_empty_text_part_still_skipped():
+    """Empty TextPart should NOT create a content block (existing behavior)."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TextPart(text=""))
+
+    assert view._current_content_block is None
+
+
+def test_empty_think_then_real_think_no_artifact(monkeypatch):
+    """Empty ThinkPart followed by real ThinkPart should not print spurious lines."""
+    from kimi_cli.ui.shell.console import console as shell_console
+
+    view = _LiveView(StatusUpdate())
+    printed = []
+    monkeypatch.setattr(shell_console, "print", lambda *args, **kwargs: printed.extend(args))
+
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(ThinkPart(think=""))
+    view.dispatch_wire_message(ThinkPart(think="Let me analyze this..."))
+
+    assert view._current_content_block is not None
+    assert view._current_content_block.is_think is True
+    assert view._current_content_block.raw_text == "Let me analyze this..."
+    # No spurious "Thought for..." lines should have been printed
+    assert len(printed) == 0
+
+
+def test_empty_think_then_text_no_spurious_thought_line(monkeypatch):
+    """Empty ThinkPart followed by TextPart should not print 'Thought for 0s'."""
+    from kimi_cli.ui.shell.console import console as shell_console
+
+    view = _LiveView(StatusUpdate())
+    printed = []
+    monkeypatch.setattr(shell_console, "print", lambda *args, **kwargs: printed.extend(args))
+
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(ThinkPart(think=""))
+    view.dispatch_wire_message(TextPart(text="Hello!"))
+
+    assert view._current_content_block is not None
+    assert view._current_content_block.is_think is False
+    assert view._current_content_block.raw_text == "Hello!"
+    for item in printed:
+        rendered = _render(item)
+        assert "Thought for" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Moon fallback during active turn
+# ---------------------------------------------------------------------------
+
+
+def test_moon_fallback_during_active_turn():
+    """Moon shows as fallback when turn is active but nothing else is visible."""
+    view = _LiveView(StatusUpdate())
+
+    # Before TurnBegin — no moon
+    rendered = _render(view.compose())
+    assert "🌑" not in rendered and "🌒" not in rendered
+
+    # After TurnBegin — moon fallback active
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    assert view._active_turn_depth > 0
+    # compose_agent_output should include the moon spinner
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) > 0
+
+
+def test_moon_hidden_when_content_block_visible():
+    """Content blocks take priority over the moon fallback."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TextPart(text="Hello"))
+
+    # Content block visible — compose_agent_output should show content, not moon
+    assert view._current_content_block is not None
+    agent_blocks = view.compose_agent_output()
+    # Should have exactly one block (the content block), not two (content + moon)
+    assert len(agent_blocks) == 1
+
+
+def test_moon_fallback_after_all_tools_flushed(monkeypatch):
+    """After all tool calls finish, moon fallback reappears automatically."""
+    from kimi_cli.ui.shell.console import console as shell_console
+
+    view = _LiveView(StatusUpdate())
+    monkeypatch.setattr(shell_console, "print", lambda *args, **kwargs: None)
+
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TextPart(text="Let me check."))
+    view.dispatch_wire_message(_make_tool_call("call_1"))
+
+    # Tool executing — tool block visible, moon fallback hidden
+    assert len(view._tool_call_blocks) == 1
+
+    # Tool finishes and flushes
+    view.dispatch_wire_message(_make_tool_result("call_1"))
+    assert len(view._tool_call_blocks) == 0
+
+    # Nothing else visible + turn active → moon fallback shows
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) == 1  # just the moon
+
+
+def test_moon_hidden_while_parallel_tool_still_running(monkeypatch):
+    """Moon fallback does not appear when tool blocks are still visible."""
+    from kimi_cli.ui.shell.console import console as shell_console
+
+    view = _LiveView(StatusUpdate())
+    monkeypatch.setattr(shell_console, "print", lambda *args, **kwargs: None)
+
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TextPart(text="Running two tools."))
+    view.dispatch_wire_message(_make_tool_call("call_1"))
+    view.dispatch_wire_message(_make_tool_call("call_2"))
+
+    # First tool finishes, second still running
+    view.dispatch_wire_message(_make_tool_result("call_1"))
+
+    assert len(view._tool_call_blocks) == 1  # call_2 still there
+    # Tool block visible → moon hidden (tool block takes priority)
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) == 1  # just the running tool block
+
+
+def test_moon_survives_status_update(monkeypatch):
+    """StatusUpdate does not affect moon fallback visibility."""
+    from kimi_cli.ui.shell.console import console as shell_console
+
+    view = _LiveView(StatusUpdate())
+    monkeypatch.setattr(shell_console, "print", lambda *args, **kwargs: None)
+
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TextPart(text="Checking."))
+    view.dispatch_wire_message(_make_tool_call("call_1"))
+    view.dispatch_wire_message(_make_tool_result("call_1"))
+
+    # StatusUpdate arrives (soul sends this between steps)
+    view.dispatch_wire_message(StatusUpdate())
+
+    # Turn still active, nothing else visible → moon fallback shows
+    assert view._active_turn_depth > 0
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) == 1
+
+
+def test_moon_hidden_after_turn_end(monkeypatch):
+    """Moon fallback disappears when the turn ends."""
+    from kimi_cli.ui.shell.console import console as shell_console
+
+    view = _LiveView(StatusUpdate())
+    monkeypatch.setattr(shell_console, "print", lambda *args, **kwargs: None)
+
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TextPart(text="Done."))
+    view.dispatch_wire_message(TurnEnd())
+
+    assert view._active_turn_depth == 0
+    # Nothing visible and turn ended — no moon
+    # (content was flushed? actually content block is still there)
+    # But _active_turn_depth is False, so even without content the moon won't show
+
+
+def test_compaction_takes_priority_over_moon():
+    """Compaction spinner has higher priority than the moon fallback."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+
+    # Compaction starts — should show compaction, not moon
+    view.dispatch_wire_message(CompactionBegin())
+    agent_blocks = view.compose_agent_output()
+    # Should be the compaction spinner, not the moon
+    assert len(agent_blocks) == 1
+    assert view._compacting_spinner is not None
+
+
+def test_interrupt_clears_active_turn():
+    """cleanup(is_interrupt=True) resets _active_turn_depth to 0."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    assert view._active_turn_depth > 0
+
+    view.cleanup(is_interrupt=True)
+    assert view._active_turn_depth == 0
+    # No moon fallback after interrupt
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) == 0
+
+
+def test_step_cleanup_preserves_active_turn():
+    """cleanup(is_interrupt=False) keeps _active_turn_depth > 0 (called on StepBegin)."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnBegin(user_input="test"))
+    assert view._active_turn_depth > 0
+
+    view.cleanup(is_interrupt=False)
+    assert view._active_turn_depth > 0
+
+
+# ---------------------------------------------------------------------------
+# Nested TurnBegin/TurnEnd (ralph loop / flow turns)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_turn_end_does_not_kill_outer_turn():
+    """Inner TurnEnd should not prematurely clear the outer turn's active state."""
+    view = _LiveView(StatusUpdate())
+
+    # Outer turn
+    view.dispatch_wire_message(TurnBegin(user_input="outer"))
+    assert view._active_turn_depth == 1
+
+    # Inner turn (flow turn)
+    view.dispatch_wire_message(TurnBegin(user_input="inner"))
+    assert view._active_turn_depth == 2
+
+    view.dispatch_wire_message(StepBegin(n=1))
+    view.dispatch_wire_message(TurnEnd())  # inner TurnEnd
+    assert view._active_turn_depth == 1  # outer still active
+
+    # Moon should still show (outer turn active, nothing else visible)
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) > 0
+
+    view.dispatch_wire_message(TurnEnd())  # outer TurnEnd
+    assert view._active_turn_depth == 0
+
+
+def test_turn_end_below_zero_clamps():
+    """Extra TurnEnd messages should not make depth go negative."""
+    view = _LiveView(StatusUpdate())
+    view.dispatch_wire_message(TurnEnd())
+    view.dispatch_wire_message(TurnEnd())
+    assert view._active_turn_depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Replay: StepBegin without TurnBegin
+# ---------------------------------------------------------------------------
+
+
+def test_step_begin_without_turn_begin_activates_moon():
+    """StepBegin defensively sets depth=1 when no TurnBegin preceded it (replay)."""
+    view = _LiveView(StatusUpdate())
+    assert view._active_turn_depth == 0
+
+    # Replay sends StepBegin directly without TurnBegin
+    view.dispatch_wire_message(StepBegin(n=1))
+    assert view._active_turn_depth == 1
+
+    # Moon fallback should show
+    agent_blocks = view.compose_agent_output()
+    assert len(agent_blocks) > 0

--- a/tests/ui_and_conv/test_modal_lifecycle.py
+++ b/tests/ui_and_conv/test_modal_lifecycle.py
@@ -823,12 +823,12 @@ async def test_compose_agent_output_includes_spinners_and_tool_calls() -> None:
     from kimi_cli.wire.types import ToolCall
 
     view = _LiveView(StatusUpdate())
-    view._mooning_spinner = Spinner("moon", "thinking")
+    view._active_turn_depth = 1  # moon fallback requires active turn
 
     blocks = view.compose_agent_output()
     assert any(isinstance(b, Spinner) for b in blocks), "Should include spinner"
 
-    view._mooning_spinner = None
+    # Adding a tool call should replace the moon fallback
     tc = ToolCall(id="tc-1", function=ToolCall.FunctionBody(name="ReadFile", arguments="{}"))
     view.append_tool_call(tc)
 
@@ -844,6 +844,8 @@ async def test_render_agent_status_excludes_panels_in_interactive() -> None:
     active, the panel is rendered by the modal in Layer 2, NOT by
     render_agent_status() in Layer 1.
     """
+    from rich.spinner import Spinner
+
     from kimi_cli.ui.shell.visualize import _PromptLiveView
 
     view = object.__new__(_PromptLiveView)
@@ -851,7 +853,8 @@ async def test_render_agent_status_excludes_panels_in_interactive() -> None:
     view._btw_spinner = None
     view._btw_question = None
     view._mcp_loading_spinner = None
-    view._mooning_spinner = None
+    view._mooning_spinner = Spinner("moon", "")
+    view._active_turn_depth = 0
     view._compacting_spinner = None
     view._current_content_block = None
     view._tool_call_blocks = {}


### PR DESCRIPTION
## Description

Fixes missing loading indicator (moon spinner) during active turns. Users reported
seeing a blank screen when the model was still working — especially after tool calls
finished and before the next step began, or between TurnBegin and StepBegin.

### Root cause

The moon spinner was managed as transient state: created on `StepBegin`, destroyed
on the very next non-StepBegin message. This left multiple gaps with no indicator:

1. **After tool calls flush → next StepBegin**: all tool blocks are printed to
   history, content block is None, moon is already gone — nothing visible.
2. **TurnBegin → StepBegin**: OAuth refresh, hooks, and checkpoint happen before
   the first StepBegin — no indicator during this window.
3. **Empty ThinkPart**: Anthropic/OpenAI block-start events yield `ThinkPart(think="")`,
   which cleared the moon but didn't create a thinking block.

### Fix

- **Moon as render-time fallback**: `_mooning_spinner` is now a permanent `Spinner`
  instance (created once in `__init__`). It is shown in `compose_agent_output()` as the
  lowest-priority fallback — only when nothing else is visible and the turn is active.
- **Turn depth counter**: `_active_turn_depth` (int) replaces the old create/destroy
  approach. Incremented on `TurnBegin`, decremented on `TurnEnd`, reset on interrupt.
  Handles nested flow turns (ralph loop) correctly.
- **Defensive StepBegin**: if `StepBegin` arrives without a preceding `TurnBegin`
  (e.g. replay), depth is set to 1 so the moon still shows.
- **Empty ThinkPart**: creates the `_ContentBlock` immediately so the "Thinking"
  indicator and timer start on the first event.
- **_PromptLiveView sync**: TurnEnd handling now decrements depth and only sets
  `_turn_ended = True` when the outermost turn finishes.

### Display priority (highest → lowest)

1. MCP loading spinner
2. Compaction spinner
3. Content blocks + tool call blocks
4. Moon spinner fallback (active turn, nothing else visible)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
