### PR TITLE
fix(kosong): support adaptive thinking for Opus 4.7+ models

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -255,7 +255,7 @@ class Anthropic:
                 case "off":
                     thinking_config = {"type": "disabled"}
                 case _:
-                    thinking_config = {"type": "adaptive"}  # type: ignore[typeddict-item]
+                    thinking_config = {"type": "adaptive", "display": "summarized"}  # type: ignore[typeddict-item]
             new = self.with_generation_kwargs(thinking=thinking_config)
             # Remove the now-unnecessary interleaved-thinking beta header.
             if (

--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -240,7 +240,7 @@ class Anthropic:
         model = self._model.lower()
         if "opus" not in model:
             return False
-        match = re.search(r"opus[.-]?(\d+)[.-](\d+)", model)
+        match = re.search(r"opus[.-]?(\d+)[.-](\d{1,3})(?!\d)", model)
         if match:
             major, minor = int(match.group(1)), int(match.group(2))
             return (major, minor) >= (4, 6)

--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -8,6 +8,7 @@ except ModuleNotFoundError as exc:
 
 import copy
 import json
+import re
 from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Self, TypedDict, Unpack, cast
 
@@ -237,7 +238,13 @@ class Anthropic:
     def _use_adaptive_thinking(self) -> bool:
         """Whether to use adaptive thinking (Opus 4.6+) instead of budget-based thinking."""
         model = self._model.lower()
-        return "opus-4.6" in model or "opus-4-6" in model
+        if "opus" not in model:
+            return False
+        match = re.search(r"opus[.-]?(\d+)[.-](\d+)", model)
+        if match:
+            major, minor = int(match.group(1)), int(match.group(2))
+            return (major, minor) >= (4, 6)
+        return False
 
     def with_thinking(self, effort: "ThinkingEffort") -> Self:
         thinking_config: ThinkingConfigParam


### PR DESCRIPTION
## Summary

- Fix `_use_adaptive_thinking()` to support Claude Opus 4.7 and future Opus versions (>= 4.6)
- The method was hardcoded to only match `opus-4.6` / `opus-4-6`, causing Opus 4.7 to use the legacy `{"type": "enabled", "budget_tokens": ...}` thinking format, which Opus 4.7 rejects with `invalid_request_error`
- Replace hardcoded string matching with regex-based version comparison so any Opus >= 4.6 automatically uses adaptive thinking

## Changes

- Add `import re` at the top of the file
- Rewrite `_use_adaptive_thinking()` to extract major.minor version from model name and compare against (4, 6)

## Test

Manually verified with various model names:

| Model | `_use_adaptive_thinking()` |
|---|---|
| `claude-opus-4-7` | `True` ✅ |
| `claude-opus-4.7` | `True` ✅ |
| `claude-opus-4-6` | `True` ✅ |
| `aws/claude-opus-4-6` | `True` ✅ |
| `claude-opus-4-8` | `True` ✅ (future-proof) |
| `claude-sonnet-4-5` | `False` ✅ (non-opus unaffected) |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
