### PR TITLE
fix(build): set PYINSTALLER_ONEDIR env in Makefile and fix skills path in frozen env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ build-bin: build-web build-vis ## Build the standalone executable with PyInstall
 build-bin-onedir: build-web build-vis ## Build the standalone executable with PyInstaller (one-dir mode).
 	@echo "==> Building PyInstaller binary (one-dir)"
 	@rm -rf dist/onedir dist/kimi
-	@uv run pyinstaller kimi.spec
+	@PYINSTALLER_ONEDIR=1 uv run pyinstaller kimi.spec
 	@if [ -f dist/kimi/kimi-exe.exe ]; then mv dist/kimi/kimi-exe.exe dist/kimi/kimi.exe; elif [ -f dist/kimi/kimi-exe ]; then mv dist/kimi/kimi-exe dist/kimi/kimi; fi
 	@mkdir -p dist/onedir && mv dist/kimi dist/onedir/
 .PHONY: ai-test

--- a/src/kimi_cli/skill/__init__.py
+++ b/src/kimi_cli/skill/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from kaos import get_current_kaos
 from kaos.local import local_kaos
@@ -24,6 +25,11 @@ def get_builtin_skills_dir() -> Path:
     """
     Get the built-in skills directory path.
     """
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        # Running in a PyInstaller bundle; use _MEIPASS to locate bundled resources
+        # reliably on all platforms (avoids __file__ path issues in frozen envs on Windows)
+        meipass = cast(str, sys._MEIPASS)  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType]
+        return Path(meipass) / "kimi_cli" / "skills"
     return Path(__file__).parent.parent / "skills"
 
 

--- a/tests/core/test_skill.py
+++ b/tests/core/test_skill.py
@@ -1,5 +1,6 @@
 """Tests for skill discovery and formatting behavior."""
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -564,6 +565,26 @@ async def test_find_project_skills_dirs_merge_brands(tmp_path):
     )
     assert KaosPath.unsafe_from_local_path(kimi_dir) in dirs
     assert KaosPath.unsafe_from_local_path(claude_dir) in dirs
+
+
+def test_get_builtin_skills_dir_frozen_env(monkeypatch, tmp_path):
+    """In a PyInstaller frozen env, get_builtin_skills_dir uses sys._MEIPASS."""
+    fake_meipass = tmp_path / "_meipass"
+    fake_meipass.mkdir()
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(fake_meipass), raising=False)
+
+    result = get_builtin_skills_dir()
+    assert result == fake_meipass / "kimi_cli" / "skills"
+
+
+def test_get_builtin_skills_dir_normal_env():
+    """In a normal (non-frozen) env, get_builtin_skills_dir uses __file__."""
+    result = get_builtin_skills_dir()
+    # Should resolve relative to the skill package
+    assert result.name == "skills"
+    assert result.parent.name == "kimi_cli"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix PyInstaller onedir build mode for built-in skills path resolution.

## Changes

- **Makefile**: Pass `PYINSTALLER_ONEDIR=1` env var in `build-bin-onedir` target to align with `kimi.spec` which already reads this variable to switch between onefile/onedir mode.
- **src/kimi_cli/skill/__init__.py**: Add `sys.frozen` / `sys._MEIPASS` detection in `get_builtin_skills_dir()` so bundled skills are correctly located when running from a PyInstaller bundle. This fixes `__file__`-based path resolution issues on Windows in onedir mode, consistent with the same pattern used in `background/manager.py` and `web/runner/process.py`.

## Test

- Verified `make build-bin-onedir` passes `PYINSTALLER_ONEDIR=1` to PyInstaller.
- Verified skills directory resolves correctly in both frozen and non-frozen environments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
