### PR TITLE
fix(streaming): avoid replaying large tool call payloads

### DIFF
--- a/src/kimi_cli/acp/AGENTS.md
+++ b/src/kimi_cli/acp/AGENTS.md
@@ -48,7 +48,8 @@
 - Tool calls:
   - Start -> `ToolCallStart` with JSON args as text content.
   - Streaming args -> `ToolCallProgress` with the current accumulated args
-    snapshot when the tool title changes.
+    snapshot when the tool title changes, or per chunk until a streaming
+    subtitle becomes available.
   - Results -> `ToolCallProgress` with `completed` or `failed`.
   - Tool call IDs are prefixed with turn ID to avoid collisions across turns.
 - Plan updates:

--- a/src/kimi_cli/acp/AGENTS.md
+++ b/src/kimi_cli/acp/AGENTS.md
@@ -47,8 +47,8 @@
 - Think chunks -> `AgentThoughtChunk`.
 - Tool calls:
   - Start -> `ToolCallStart` with JSON args as text content.
-  - Streaming args -> `ToolCallProgress` with updated title and the latest
-    incremental argument chunk.
+  - Streaming args -> `ToolCallProgress` with the current accumulated args
+    snapshot when the tool title changes.
   - Results -> `ToolCallProgress` with `completed` or `failed`.
   - Tool call IDs are prefixed with turn ID to avoid collisions across turns.
 - Plan updates:

--- a/src/kimi_cli/acp/AGENTS.md
+++ b/src/kimi_cli/acp/AGENTS.md
@@ -47,7 +47,8 @@
 - Think chunks -> `AgentThoughtChunk`.
 - Tool calls:
   - Start -> `ToolCallStart` with JSON args as text content.
-  - Streaming args -> `ToolCallProgress` with updated title/args.
+  - Streaming args -> `ToolCallProgress` with updated title and the latest
+    incremental argument chunk.
   - Results -> `ToolCallProgress` with `completed` or `failed`.
   - Tool call IDs are prefixed with turn ID to avoid collisions across turns.
 - Plan updates:

--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -326,7 +326,8 @@ class ACPSession:
         # Append new arguments part to the last tool call
         self._turn_state.last_tool_call.append_args_part(part.arguments_part)
 
-        # Update the tool call with new content and title
+        # Keep the full args in state for title extraction, but only send the
+        # newly streamed chunk to avoid repeatedly resending large payloads.
         update = acp.schema.ToolCallProgress(
             session_update="tool_call_update",
             tool_call_id=self._turn_state.last_tool_call.acp_tool_call_id,
@@ -335,9 +336,7 @@ class ACPSession:
             content=[
                 acp.schema.ContentToolCallContent(
                     type="content",
-                    content=acp.schema.TextContentBlock(
-                        type="text", text=self._turn_state.last_tool_call.args
-                    ),
+                    content=acp.schema.TextContentBlock(type="text", text=part.arguments_part),
                 )
             ],
         )

--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -323,26 +323,32 @@ class ACPSession:
         ):
             return
 
-        # Append new arguments part to the last tool call
-        self._turn_state.last_tool_call.append_args_part(part.arguments_part)
+        state = self._turn_state.last_tool_call
+        previous_title = state.get_title()
+        state.append_args_part(part.arguments_part)
+        current_title = state.get_title()
 
-        # Keep the full args in state for title extraction, but only send the
-        # newly streamed chunk to avoid repeatedly resending large payloads.
+        # ToolCallProgress.content replaces the current content collection, so
+        # only emit an update when the user-visible title changes and send the
+        # current accumulated args snapshot for that state.
+        if current_title == previous_title:
+            return
+
         update = acp.schema.ToolCallProgress(
             session_update="tool_call_update",
-            tool_call_id=self._turn_state.last_tool_call.acp_tool_call_id,
-            title=self._turn_state.last_tool_call.get_title(),
+            tool_call_id=state.acp_tool_call_id,
+            title=current_title,
             status="in_progress",
             content=[
                 acp.schema.ContentToolCallContent(
                     type="content",
-                    content=acp.schema.TextContentBlock(type="text", text=part.arguments_part),
+                    content=acp.schema.TextContentBlock(type="text", text=state.args),
                 )
             ],
         )
 
         await self._conn.session_update(session_id=self._id, update=update)
-        logger.debug("Sent tool call update: {delta}", delta=part.arguments_part[:50])
+        logger.debug("Sent tool call update: {title}", title=current_title)
 
     async def _send_tool_result(self, result: ToolResult):
         """Send tool result to client."""

--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -329,9 +329,11 @@ class ACPSession:
         current_title = state.get_title()
 
         # ToolCallProgress.content replaces the current content collection, so
-        # only emit an update when the user-visible title changes and send the
-        # current accumulated args snapshot for that state.
-        if current_title == previous_title:
+        # once a tool has a stable user-visible subtitle we only emit updates
+        # when that title changes. Tools that never expose a streaming subtitle
+        # still need snapshot updates so ACP clients do not get stuck on the
+        # initial `{` fragment from ToolCallStart.
+        if current_title == previous_title and current_title != state.tool_call.function.name:
             return
 
         update = acp.schema.ToolCallProgress(

--- a/tests/acp/test_session_tool_call_streaming.py
+++ b/tests/acp/test_session_tool_call_streaming.py
@@ -30,6 +30,18 @@ class _StreamingToolCallCLI:
         yield TurnEnd()
 
 
+class _NoSubtitleStreamingToolCallCLI:
+    async def run(self, _user_input, _cancel_event):
+        yield TurnBegin(user_input="send a dmail")
+        yield ToolCall(
+            id="tc-1",
+            function=ToolCall.FunctionBody(name="SendDMail", arguments="{"),
+        )
+        yield ToolCallPart(arguments_part='"to":"a@example.com",')
+        yield ToolCallPart(arguments_part='"subject":"hello"}')
+        yield TurnEnd()
+
+
 @pytest.mark.asyncio
 async def test_acp_tool_call_progress_only_updates_when_streaming_title_changes() -> None:
     conn = _FakeConn()
@@ -55,3 +67,32 @@ async def test_acp_tool_call_progress_only_updates_when_streaming_title_changes(
 
     # Title extraction should still work even when the streamed JSON is incomplete.
     assert progress_update.title == "WriteFile: big.py"
+
+
+@pytest.mark.asyncio
+async def test_acp_tool_call_progress_keeps_streaming_when_title_never_changes() -> None:
+    conn = _FakeConn()
+    session = ACPSession("session-1", _NoSubtitleStreamingToolCallCLI(), conn)  # type: ignore[arg-type]
+
+    response = await session.prompt([acp.text_block("hello")])
+
+    assert response.stop_reason == "end_turn"
+    assert len(conn.updates) == 3
+
+    start_update = conn.updates[0][1]
+    first_progress_update = conn.updates[1][1]
+    second_progress_update = conn.updates[2][1]
+
+    assert start_update.session_update == "tool_call"
+    assert start_update.title == "SendDMail"
+    assert start_update.content[0].content.text == "{"
+
+    assert first_progress_update.session_update == "tool_call_update"
+    assert first_progress_update.title == "SendDMail"
+    assert first_progress_update.content[0].content.text == '{"to":"a@example.com",'
+
+    assert second_progress_update.session_update == "tool_call_update"
+    assert second_progress_update.title == "SendDMail"
+    assert second_progress_update.content[0].content.text == (
+        '{"to":"a@example.com","subject":"hello"}'
+    )

--- a/tests/acp/test_session_tool_call_streaming.py
+++ b/tests/acp/test_session_tool_call_streaming.py
@@ -31,30 +31,27 @@ class _StreamingToolCallCLI:
 
 
 @pytest.mark.asyncio
-async def test_acp_tool_call_progress_does_not_resend_accumulated_arguments() -> None:
+async def test_acp_tool_call_progress_only_updates_when_streaming_title_changes() -> None:
     conn = _FakeConn()
     session = ACPSession("session-1", _StreamingToolCallCLI(), conn)  # type: ignore[arg-type]
 
     response = await session.prompt([acp.text_block("hello")])
 
     assert response.stop_reason == "end_turn"
-    assert len(conn.updates) == 4
+    assert len(conn.updates) == 2
 
     start_update = conn.updates[0][1]
-    progress_updates = [update for _, update in conn.updates[1:]]
+    progress_update = conn.updates[1][1]
 
     assert start_update.session_update == "tool_call"
     assert start_update.content[0].content.text == "{"
 
-    # Intermediate progress updates may carry the new chunk for preview, but must
-    # not resend the full accumulated arguments each time.
-    assert all(update.session_update == "tool_call_update" for update in progress_updates)
-    assert all(update.status == "in_progress" for update in progress_updates)
-    assert [update.content[0].content.text for update in progress_updates] == [
-        '"path":"big.py",',
-        '"content":"line 1\\n',
-        'line 2\\nline 3"}',
-    ]
+    # ToolCallProgress.content replaces the current content collection, so ACP
+    # only sends a progress update when the title changes and includes the
+    # accumulated args snapshot for that new title.
+    assert progress_update.session_update == "tool_call_update"
+    assert progress_update.status == "in_progress"
+    assert progress_update.content[0].content.text == '{"path":"big.py",'
 
     # Title extraction should still work even when the streamed JSON is incomplete.
-    assert progress_updates[-1].title == "WriteFile: big.py"
+    assert progress_update.title == "WriteFile: big.py"

--- a/tests/acp/test_session_tool_call_streaming.py
+++ b/tests/acp/test_session_tool_call_streaming.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import acp
+import pytest
+
+from kimi_cli.acp.session import ACPSession
+from kimi_cli.wire.types import ToolCall, ToolCallPart, TurnBegin, TurnEnd
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        from typing import Any
+
+        self.updates: list[tuple[str, Any]] = []
+
+    async def session_update(self, session_id: str, update: object) -> None:
+        self.updates.append((session_id, update))
+
+
+class _StreamingToolCallCLI:
+    async def run(self, _user_input, _cancel_event):
+        yield TurnBegin(user_input="write a large file")
+        yield ToolCall(
+            id="tc-1",
+            function=ToolCall.FunctionBody(name="WriteFile", arguments="{"),
+        )
+        yield ToolCallPart(arguments_part='"path":"big.py",')
+        yield ToolCallPart(arguments_part='"content":"line 1\\n')
+        yield ToolCallPart(arguments_part='line 2\\nline 3"}')
+        yield TurnEnd()
+
+
+@pytest.mark.asyncio
+async def test_acp_tool_call_progress_does_not_resend_accumulated_arguments() -> None:
+    conn = _FakeConn()
+    session = ACPSession("session-1", _StreamingToolCallCLI(), conn)  # type: ignore[arg-type]
+
+    response = await session.prompt([acp.text_block("hello")])
+
+    assert response.stop_reason == "end_turn"
+    assert len(conn.updates) == 4
+
+    start_update = conn.updates[0][1]
+    progress_updates = [update for _, update in conn.updates[1:]]
+
+    assert start_update.session_update == "tool_call"
+    assert start_update.content[0].content.text == "{"
+
+    # Intermediate progress updates may carry the new chunk for preview, but must
+    # not resend the full accumulated arguments each time.
+    assert all(update.session_update == "tool_call_update" for update in progress_updates)
+    assert all(update.status == "in_progress" for update in progress_updates)
+    assert [update.content[0].content.text for update in progress_updates] == [
+        '"path":"big.py",',
+        '"content":"line 1\\n',
+        'line 2\\nline 3"}',
+    ]
+
+    # Title extraction should still work even when the streamed JSON is incomplete.
+    assert progress_updates[-1].title == "WriteFile: big.py"

--- a/web/src/hooks/useSessionStream.ts
+++ b/web/src/hooks/useSessionStream.ts
@@ -262,6 +262,30 @@ type PendingQuestionEntry = {
   submitted?: boolean;
 };
 
+function summarizeStreamingToolInput(
+  toolName: string,
+  input: unknown,
+): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input;
+  }
+
+  const record = input as Record<string, unknown>;
+
+  switch (toolName) {
+    case "WriteFile": {
+      const { content: _content, ...rest } = record;
+      return rest;
+    }
+    case "StrReplaceFile": {
+      const { old: _old, new: _new, ...rest } = record;
+      return rest;
+    }
+    default:
+      return input;
+  }
+}
+
 /**
  * Hook for connecting to a session's WebSocket stream
  */
@@ -1203,7 +1227,10 @@ export function useSessionStream(
           let parsedInput: unknown;
           if (initialArgs) {
             try {
-              parsedInput = JSON.parse(initialArgs);
+              parsedInput = summarizeStreamingToolInput(
+                toolCall.function.name,
+                JSON.parse(initialArgs),
+              );
             } catch {
               // Not valid JSON yet, leave as undefined
             }
@@ -1243,9 +1270,14 @@ export function useSessionStream(
 
               const messageId = tc.messageId;
               if (messageId) {
-                let parsedInput: unknown = tc.arguments;
+                let parsedInput: unknown;
+                let hasParsedInput = false;
                 try {
-                  parsedInput = JSON.parse(tc.arguments);
+                  parsedInput = summarizeStreamingToolInput(
+                    tc.name,
+                    JSON.parse(tc.arguments),
+                  );
+                  hasParsedInput = true;
                 } catch {
                   // Not complete JSON yet
                 }
@@ -1253,14 +1285,25 @@ export function useSessionStream(
                 setMessages((prev) =>
                   prev.map((msg) =>
                     msg.id === messageId && msg.toolCall
-                      ? {
-                          ...msg,
-                          toolCall: {
-                            ...msg.toolCall,
-                            state: "input-available" as ToolUIPart["state"],
-                            input: parsedInput,
-                          },
-                        }
+                      ? (() => {
+                          const nextState = "input-available" as ToolUIPart["state"];
+                          const stateChanged = msg.toolCall.state !== nextState;
+                          const inputChanged =
+                            hasParsedInput && parsedInput !== msg.toolCall.input;
+
+                          if (!stateChanged && !inputChanged) {
+                            return msg;
+                          }
+
+                          return {
+                            ...msg,
+                            toolCall: {
+                              ...msg.toolCall,
+                              state: nextState,
+                              ...(hasParsedInput ? { input: parsedInput } : {}),
+                            },
+                          };
+                        })()
                       : msg,
                   ),
                 );

--- a/web/src/hooks/useSessionStream.ts
+++ b/web/src/hooks/useSessionStream.ts
@@ -278,12 +278,53 @@ function summarizeStreamingToolInput(
       return rest;
     }
     case "StrReplaceFile": {
-      const { old: _old, new: _new, ...rest } = record;
-      return rest;
+      const summarizeEdit = (edit: unknown): unknown => {
+        if (!edit || typeof edit !== "object" || Array.isArray(edit)) {
+          return edit;
+        }
+
+        const { old: _old, new: _new, ...rest } = edit as Record<string, unknown>;
+        return rest;
+      };
+
+      const { edit, ...rest } = record;
+      return {
+        ...rest,
+        ...(edit === undefined
+          ? {}
+          : {
+              edit: Array.isArray(edit)
+                ? edit.map((item) => summarizeEdit(item))
+                : summarizeEdit(edit),
+            }),
+      };
     }
     default:
       return input;
   }
+}
+
+function areStreamingToolInputsEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (
+    a &&
+    b &&
+    typeof a === "object" &&
+    typeof b === "object" &&
+    !Array.isArray(a) &&
+    !Array.isArray(b)
+  ) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  return false;
 }
 
 /**
@@ -1289,7 +1330,8 @@ export function useSessionStream(
                           const nextState = "input-available" as ToolUIPart["state"];
                           const stateChanged = msg.toolCall.state !== nextState;
                           const inputChanged =
-                            hasParsedInput && parsedInput !== msg.toolCall.input;
+                            hasParsedInput &&
+                            !areStreamingToolInputsEqual(parsedInput, msg.toolCall.input);
 
                           if (!stateChanged && !inputChanged) {
                             return msg;

--- a/web/src/hooks/useSessionStream.ts
+++ b/web/src/hooks/useSessionStream.ts
@@ -1323,8 +1323,10 @@ export function useSessionStream(
                   // Not complete JSON yet
                 }
 
-                setMessages((prev) =>
-                  prev.map((msg) =>
+                setMessages((prev) => {
+                  let changed = false;
+
+                  const next = prev.map((msg) =>
                     msg.id === messageId && msg.toolCall
                       ? (() => {
                           const nextState = "input-available" as ToolUIPart["state"];
@@ -1337,6 +1339,7 @@ export function useSessionStream(
                             return msg;
                           }
 
+                          changed = true;
                           return {
                             ...msg,
                             toolCall: {
@@ -1347,8 +1350,10 @@ export function useSessionStream(
                           };
                         })()
                       : msg,
-                  ),
-                );
+                  );
+
+                  return changed ? next : prev;
+                });
               }
             }
           }


### PR DESCRIPTION
## Related Issue

Resolve #1786

## Description

This PR fixes the large-file write lag by removing two sources of repeated large tool-call payload replay.

### Changes

- ACP no longer resends the full accumulated tool-call arguments on every `ToolCallProgress` update.
- `ACPSession` still keeps the full accumulated arguments internally for title extraction, but emitted progress updates now send only the latest `arguments_part` chunk.
- Web no longer stores large incomplete raw tool-call JSON in React state while a tool call is still streaming.
- `useSessionStream` now marks the tool call as `input-available` during streaming, and stores a summarized input only after the JSON becomes parseable.
- `WriteFile` removes `content` from the UI summary.
- `StrReplaceFile` removes `old` and `new` from the UI summary.
- Added ACP regression coverage to verify that progress updates stream incremental chunks while preserving title extraction.

### Scope

Issue #1786 reports UI lag that scales with long `WriteFile` payloads in both ACP and Web mode. This PR keeps the fix intentionally narrow and avoids broader protocol or tool-behavior changes. It addresses two concrete problems:

- ACP repeatedly sending the full accumulated arguments to clients.
- Web repeatedly copying large in-progress tool-call input into UI state.

### Local benchmark notes

The benchmark scripts used during investigation are not included in this PR. Local measurements on this branch were:

- ACP, 800-line payload
  - total serialized bytes: `4,640,681 -> 143,854` (`-96.9%`)
  - max update size: `25,168 -> 400` (`-98.41%`)
- Web, 800-line payload
  - cumulative UI state bytes: `4,097,047 -> 36`
  - max UI state size: `23,209 -> 36` (`-99.84%`)
  - state updates: `351 -> 2` (`-99.43%`)

### Verification

- `uv run pytest tests/acp/test_session_tool_call_streaming.py tests/acp/test_session_notifications.py tests/core/test_auth_error_handling.py -q`
- `npm --prefix web run typecheck`
- Manual Web verification against a local dev server confirmed that long `WriteFile` tool calls no longer surface the raw accumulated JSON payload in the chat UI while streaming.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
