### PR TITLE
refactor(yolo): refine yolo scope to preserve plan review and AskUserQuestion

### DIFF
--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -155,6 +155,7 @@ class ACPServer:
         cli_instance = await KimiCLI.create(
             session,
             mcp_configs=[mcp_config],
+            supports_interactive_questions=False,
         )
         config = cli_instance.soul.runtime.config
         acp_kaos = ACPKaos(self.conn, session.id, self.client_capabilities)
@@ -225,6 +226,7 @@ class ACPServer:
             session,
             mcp_configs=[mcp_config],
             resumed=True,  # _setup_session loads existing sessions
+            supports_interactive_questions=False,
         )
         config = cli_instance.soul.runtime.config
         acp_kaos = ACPKaos(self.conn, session.id, self.client_capabilities)

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -109,6 +109,7 @@ class KimiCLI:
         max_ralph_iterations: int | None = None,
         startup_progress: Callable[[str], None] | None = None,
         defer_mcp_loading: bool = False,
+        supports_interactive_questions: bool = True,
     ) -> KimiCLI:
         """
         Create a KimiCLI instance.
@@ -135,6 +136,8 @@ class KimiCLI:
                 interactive startup UI. Defaults to None.
             defer_mcp_loading (bool, optional): Defer MCP startup until the interactive shell is
                 ready. Defaults to False.
+            supports_interactive_questions (bool, optional): Whether the connected client can
+                answer QuestionRequest interactively. Defaults to True.
 
         Raises:
             FileNotFoundError: When the agent file is not found.
@@ -216,6 +219,7 @@ class KimiCLI:
             yolo,
             skills_dirs=skills_dirs,
         )
+        runtime.approval.set_interactive_questions_supported(supports_interactive_questions)
         runtime.notifications.recover()
         runtime.background_tasks.reconcile()
         _cleanup_stale_foreground_subagents(runtime)
@@ -548,6 +552,7 @@ class KimiCLI:
         """Run the Kimi Code CLI instance with print UI."""
         from kimi_cli.ui.print import Print
 
+        self._runtime.approval.set_interactive_questions_supported(False)
         async with self._env():
             print_ = Print(
                 self._soul,
@@ -562,6 +567,7 @@ class KimiCLI:
         """Run the Kimi Code CLI instance as ACP server."""
         from kimi_cli.ui.acp import ACP
 
+        self._runtime.approval.set_interactive_questions_supported(False)
         async with self._env():
             acp = ACP(self._soul)
             await acp.run()

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -623,6 +623,11 @@ def kimi(
             )
             startup_progress.stop()
 
+            # Print/headless mode cannot resolve QuestionRequest; short-circuit
+            # plan entry/exit and AskUserQuestion when yolo is active.
+            if ui == "print":
+                instance.soul.runtime.approval.set_interactive_questions_supported(False)
+
             # --- SessionStart hook ---
             _session_source = "resume" if resumed else "startup"
             await instance.soul.hook_engine.trigger(

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -620,13 +620,9 @@ def kimi(
                 max_ralph_iterations=max_ralph_iterations,
                 startup_progress=startup_progress.update if ui == "shell" else None,
                 defer_mcp_loading=ui == "shell" and prompt is None,
+                supports_interactive_questions=ui not in ("print", "acp"),
             )
             startup_progress.stop()
-
-            # Print/ACP clients cannot resolve QuestionRequest interactively;
-            # keep yolo short-circuit behavior for questions and plan approval.
-            if ui in ("print", "acp"):
-                instance.soul.runtime.approval.set_interactive_questions_supported(False)
 
             # --- SessionStart hook ---
             _session_source = "resume" if resumed else "startup"

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -623,9 +623,9 @@ def kimi(
             )
             startup_progress.stop()
 
-            # Print/headless mode cannot resolve QuestionRequest; short-circuit
-            # plan entry/exit and AskUserQuestion when yolo is active.
-            if ui == "print":
+            # Print/ACP clients cannot resolve QuestionRequest interactively;
+            # keep yolo short-circuit behavior for questions and plan approval.
+            if ui in ("print", "acp"):
                 instance.soul.runtime.approval.set_interactive_questions_supported(False)
 
             # --- SessionStart hook ---

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -105,8 +105,10 @@ class Approval:
         return self._state.yolo
 
     def set_interactive_questions_supported(self, supported: bool) -> None:
+        """Set runtime-only client capability; does not persist approval preferences."""
         self._state.supports_interactive_questions = supported
-        self._state.notify_change()
+        # This is a per-run capability flag, not a user approval preference.
+        # Do not call notify_change() to avoid persisting unrelated state (e.g. yolo).
 
     def should_auto_approve_plan_entry(self) -> bool:
         """Whether entering plan mode should be auto-approved."""

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -57,11 +57,13 @@ class ApprovalState:
         self,
         yolo: bool = False,
         auto_approve_actions: set[str] | None = None,
+        supports_interactive_questions: bool = True,
         on_change: Callable[[], None] | None = None,
     ):
         self.yolo = yolo
         self.auto_approve_actions: set[str] = auto_approve_actions or set()
         """Set of action names that should automatically be approved."""
+        self.supports_interactive_questions = supports_interactive_questions
         self._on_change = on_change
 
     def notify_change(self) -> None:
@@ -102,17 +104,21 @@ class Approval:
         """Whether operation-type approvals should be auto-approved."""
         return self._state.yolo
 
+    def set_interactive_questions_supported(self, supported: bool) -> None:
+        self._state.supports_interactive_questions = supported
+        self._state.notify_change()
+
     def should_auto_approve_plan_entry(self) -> bool:
         """Whether entering plan mode should be auto-approved."""
-        return False
+        return self._state.yolo and not self._state.supports_interactive_questions
 
     def should_auto_approve_plan_exit(self) -> bool:
         """Whether plan approval (ExitPlanMode) should be auto-approved."""
-        return False
+        return self._state.yolo and not self._state.supports_interactive_questions
 
     def should_auto_dismiss_questions(self) -> bool:
         """Whether AskUserQuestion should auto-dismiss without asking the user."""
-        return False
+        return self._state.yolo and not self._state.supports_interactive_questions
 
     async def request(
         self,

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -81,7 +81,7 @@ class Approval:
         self._runtime = runtime or ApprovalRuntime()
 
     def share(self) -> Approval:
-        """Create a new approval queue that shares state (yolo + auto-approve)."""
+        """Create a new approval queue that shares state (policy + auto-approve)."""
         return Approval(state=self._state, runtime=self._runtime)
 
     def set_runtime(self, runtime: ApprovalRuntime) -> None:
@@ -97,6 +97,22 @@ class Approval:
 
     def is_yolo(self) -> bool:
         return self._state.yolo
+
+    def should_auto_approve_operations(self) -> bool:
+        """Whether operation-type approvals should be auto-approved."""
+        return self._state.yolo
+
+    def should_auto_approve_plan_entry(self) -> bool:
+        """Whether entering plan mode should be auto-approved."""
+        return False
+
+    def should_auto_approve_plan_exit(self) -> bool:
+        """Whether plan approval (ExitPlanMode) should be auto-approved."""
+        return False
+
+    def should_auto_dismiss_questions(self) -> bool:
+        """Whether AskUserQuestion should auto-dismiss without asking the user."""
+        return False
 
     async def request(
         self,
@@ -132,7 +148,7 @@ class Approval:
             action=action,
             description=description,
         )
-        if self._state.yolo:
+        if self.should_auto_approve_operations():
             return ApprovalResult(approved=True)
 
         if action in self._state.auto_approve_actions:

--- a/src/kimi_cli/soul/dynamic_injections/yolo_mode.py
+++ b/src/kimi_cli/soul/dynamic_injections/yolo_mode.py
@@ -16,9 +16,9 @@ _YOLO_PROMPT = (
     "Yolo mode is enabled for operation approvals.\n"
     "- Operation-type approvals are auto-approved.\n"
     "- AskUserQuestion remains available when the connected client supports interactive "
-    "questions.\n"
-    "- EnterPlanMode/ExitPlanMode remain interactive unless an explicit plan policy "
-    "enables auto-approval."
+    "questions; otherwise it may be auto-dismissed in yolo/headless runs.\n"
+    "- EnterPlanMode/ExitPlanMode remain interactive when the connected client supports "
+    "interactive questions; otherwise yolo may auto-approve them."
 )
 
 

--- a/src/kimi_cli/soul/dynamic_injections/yolo_mode.py
+++ b/src/kimi_cli/soul/dynamic_injections/yolo_mode.py
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
 _YOLO_INJECTION_TYPE = "yolo_mode"
 
 _YOLO_PROMPT = (
-    "You are running in non-interactive mode. The user cannot answer questions "
-    "or provide feedback during execution.\n"
-    "- Do NOT call AskUserQuestion. If you need to make a decision, make your "
-    "best judgment and proceed.\n"
-    "- For EnterPlanMode / ExitPlanMode, they will be auto-approved. You can use "
-    "them normally but expect no user feedback."
+    "Yolo mode is enabled for operation approvals.\n"
+    "- Operation-type approvals are auto-approved.\n"
+    "- AskUserQuestion remains available when the connected client supports interactive "
+    "questions.\n"
+    "- EnterPlanMode/ExitPlanMode remain interactive unless an explicit plan policy "
+    "enables auto-approval."
 )
 
 

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -188,7 +188,7 @@ class KimiSoul:
 
     @property
     def is_yolo(self) -> bool:
-        """Whether yolo (auto-approve / non-interactive) mode is enabled."""
+        """Whether yolo (operation approvals auto-approve) mode is enabled."""
         return self._approval.is_yolo()
 
     @property
@@ -253,21 +253,31 @@ class KimiSoul:
 
         exit_tool = self._agent.toolset.find("ExitPlanMode")
         if isinstance(exit_tool, ExitPlanMode):
-            exit_tool.bind(self.toggle_plan_mode, path_getter, checker, self._approval.is_yolo)
+            exit_tool.bind(
+                self.toggle_plan_mode,
+                path_getter,
+                checker,
+                self._approval.should_auto_approve_plan_exit,
+            )
 
         # EnterPlanMode has a special bind() method
         from kimi_cli.tools.plan.enter import EnterPlanMode
 
         enter_tool = self._agent.toolset.find("EnterPlanMode")
         if isinstance(enter_tool, EnterPlanMode):
-            enter_tool.bind(self.toggle_plan_mode, path_getter, checker, self._approval.is_yolo)
+            enter_tool.bind(
+                self.toggle_plan_mode,
+                path_getter,
+                checker,
+                self._approval.should_auto_approve_plan_entry,
+            )
 
-        # AskUserQuestion — bind yolo checker for auto-dismiss
+        # AskUserQuestion — bind interaction policy for optional auto-dismiss
         from kimi_cli.tools.ask_user import AskUserQuestion
 
         ask_tool = self._agent.toolset.find("AskUserQuestion")
         if isinstance(ask_tool, AskUserQuestion):
-            ask_tool.bind_approval(self._approval.is_yolo)
+            ask_tool.bind_interaction_policy(self._approval.should_auto_dismiss_questions)
 
     def _ensure_plan_session_id(self) -> None:
         """Allocate a stable plan session ID on first activation."""

--- a/src/kimi_cli/tools/ask_user/__init__.py
+++ b/src/kimi_cli/tools/ask_user/__init__.py
@@ -66,23 +66,24 @@ class AskUserQuestion(CallableTool2[Params]):
 
     def __init__(self) -> None:
         super().__init__()
-        self._is_yolo: Callable[[], bool] | None = None
+        self._should_auto_dismiss: Callable[[], bool] | None = None
+
+    def bind_interaction_policy(self, should_auto_dismiss: Callable[[], bool]) -> None:
+        """Late-bind interaction policy for optional auto-dismiss behavior."""
+        self._should_auto_dismiss = should_auto_dismiss
 
     def bind_approval(self, is_yolo: Callable[[], bool]) -> None:
-        """Late-bind yolo checker so we can auto-dismiss in non-interactive mode."""
-        self._is_yolo = is_yolo
+        """Backward-compatible alias; binds auto-dismiss policy."""
+        self.bind_interaction_policy(is_yolo)
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
-        if self._is_yolo and self._is_yolo():
+        if self._should_auto_dismiss and self._should_auto_dismiss():
             return ToolReturnValue(
                 is_error=False,
-                output=(
-                    '{"answers": {}, "note": "Running in non-interactive'
-                    ' (yolo) mode. Make your own decision."}'
-                ),
-                message="Non-interactive mode, auto-dismissed.",
-                display=[BriefDisplayBlock(text="Auto-dismissed (yolo)")],
+                output='{"answers": {}, "note": "Question auto-dismissed by interaction policy."}',
+                message="Auto-dismissed by policy.",
+                display=[BriefDisplayBlock(text="Auto-dismissed")],
             )
 
         wire = get_wire_or_none()

--- a/src/kimi_cli/tools/plan/__init__.py
+++ b/src/kimi_cli/tools/plan/__init__.py
@@ -88,20 +88,20 @@ class ExitPlanMode(CallableTool2[Params]):
         self._toggle_callback: Callable[[], Awaitable[bool]] | None = None
         self._plan_file_path_getter: Callable[[], Path | None] | None = None
         self._plan_mode_checker: Callable[[], bool] | None = None
-        self._is_yolo: Callable[[], bool] | None = None
+        self._should_auto_approve: Callable[[], bool] | None = None
 
     def bind(
         self,
         toggle_callback: Callable[[], Awaitable[bool]],
         plan_file_path_getter: Callable[[], Path | None],
         plan_mode_checker: Callable[[], bool],
-        is_yolo: Callable[[], bool] | None = None,
+        should_auto_approve: Callable[[], bool] | None = None,
     ) -> None:
         """Late-bind soul callbacks after KimiSoul is constructed."""
         self._toggle_callback = toggle_callback
         self._plan_file_path_getter = plan_file_path_getter
         self._plan_mode_checker = plan_mode_checker
-        self._is_yolo = is_yolo
+        self._should_auto_approve = should_auto_approve
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
@@ -131,13 +131,12 @@ class ExitPlanMode(CallableTool2[Params]):
                 brief="No plan file",
             )
 
-        # In yolo mode, auto-approve the plan
-        if self._is_yolo and self._is_yolo():
+        if self._should_auto_approve and self._should_auto_approve():
             await self._toggle_callback()
             return ToolReturnValue(
                 is_error=False,
                 output=(
-                    f"Plan approved (auto-approved in non-interactive mode). "
+                    f"Plan approved (auto-approved by policy). "
                     f"Plan mode deactivated. All tools are now available.\n"
                     f"Plan saved to: {plan_path}\n\n"
                     f"## Approved Plan:\n{plan_content}"

--- a/src/kimi_cli/tools/plan/enter.py
+++ b/src/kimi_cli/tools/plan/enter.py
@@ -37,20 +37,20 @@ class EnterPlanMode(CallableTool2[Params]):
         self._toggle_callback: Callable[[], Awaitable[bool]] | None = None
         self._plan_file_path_getter: Callable[[], Path | None] | None = None
         self._plan_mode_checker: Callable[[], bool] | None = None
-        self._is_yolo: Callable[[], bool] | None = None
+        self._should_auto_approve: Callable[[], bool] | None = None
 
     def bind(
         self,
         toggle_callback: Callable[[], Awaitable[bool]],
         plan_file_path_getter: Callable[[], Path | None],
         plan_mode_checker: Callable[[], bool],
-        is_yolo: Callable[[], bool] | None = None,
+        should_auto_approve: Callable[[], bool] | None = None,
     ) -> None:
         """Late-bind soul callbacks after KimiSoul is constructed."""
         self._toggle_callback = toggle_callback
         self._plan_file_path_getter = plan_file_path_getter
         self._plan_mode_checker = plan_mode_checker
-        self._is_yolo = is_yolo
+        self._should_auto_approve = should_auto_approve
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
@@ -67,14 +67,13 @@ class EnterPlanMode(CallableTool2[Params]):
                 brief="Not initialized",
             )
 
-        # In yolo mode, auto-approve entering plan mode
-        if self._is_yolo and self._is_yolo():
+        if self._should_auto_approve and self._should_auto_approve():
             await self._toggle_callback()
             plan_path = self._plan_file_path_getter()
             return ToolReturnValue(
                 is_error=False,
                 output=(
-                    f"Plan mode activated (auto-approved in non-interactive mode).\n"
+                    f"Plan mode activated (auto-approved by policy).\n"
                     f"Plan file: {plan_path}\n"
                     f"Workflow: identify key questions about the codebase → "
                     f"use Agent(subagent_type='explore') to investigate if needed → "

--- a/tests/core/test_plan_flag.py
+++ b/tests/core/test_plan_flag.py
@@ -54,11 +54,15 @@ def _patch_create_deps(monkeypatch, *, session_plan_mode: bool = False):
     runtime_create_calls: list[dict] = []
 
     async def fake_runtime_create(config, _oauth, _llm, session, yolo, **kwargs):
-        runtime_create_calls.append({"yolo": yolo})
+        approval_calls: list[bool] = []
+        runtime_create_calls.append({"yolo": yolo, "approval_calls": approval_calls})
         return SimpleNamespace(
             session=session,
             config=config,
             llm=None,
+            approval=SimpleNamespace(
+                set_interactive_questions_supported=lambda supported: approval_calls.append(supported)
+            ),
             notifications=SimpleNamespace(recover=lambda: None),
             background_tasks=SimpleNamespace(reconcile=lambda: None),
         )
@@ -234,6 +238,21 @@ class TestPlanFlagPriority:
         soul = FakeSoul.instances[0]
         assert soul._set_plan_mode_calls == [(True, "manual")]
         assert runtime_create_calls[0]["yolo"] is True
+        assert runtime_create_calls[0]["approval_calls"] == [True]
+
+    @pytest.mark.asyncio
+    async def test_create_can_mark_client_as_non_interactive(self, session, config, monkeypatch):
+        FakeSoul, runtime_create_calls = _patch_create_deps(monkeypatch)
+
+        await KimiCLI.create(
+            session,
+            config=config,
+            resumed=False,
+            supports_interactive_questions=False,
+        )
+
+        assert FakeSoul.instances
+        assert runtime_create_calls[0]["approval_calls"] == [False]
 
 
 class TestSchedulePlanActivationReminder:

--- a/tests/core/test_session_state.py
+++ b/tests/core/test_session_state.py
@@ -452,3 +452,59 @@ class TestApprovalStateCallback:
         approval = Approval(state=state)
         approval.set_yolo(True)  # should not raise
         assert state.yolo is True
+
+
+class TestApprovalPolicyMatrix:
+    """Policy methods must be capability-aware to avoid headless hangs."""
+
+    def test_yolo_off_interactive(self):
+        from kimi_cli.soul.approval import Approval, ApprovalState
+
+        state = ApprovalState(yolo=False, supports_interactive_questions=True)
+        approval = Approval(state=state)
+
+        assert approval.should_auto_approve_operations() is False
+        assert approval.should_auto_dismiss_questions() is False
+        assert approval.should_auto_approve_plan_entry() is False
+        assert approval.should_auto_approve_plan_exit() is False
+
+    def test_yolo_on_interactive(self):
+        from kimi_cli.soul.approval import Approval, ApprovalState
+
+        state = ApprovalState(yolo=True, supports_interactive_questions=True)
+        approval = Approval(state=state)
+
+        assert approval.should_auto_approve_operations() is True
+        assert approval.should_auto_dismiss_questions() is False
+        assert approval.should_auto_approve_plan_entry() is False
+        assert approval.should_auto_approve_plan_exit() is False
+
+    def test_yolo_on_non_interactive(self):
+        from kimi_cli.soul.approval import Approval, ApprovalState
+
+        state = ApprovalState(yolo=True, supports_interactive_questions=False)
+        approval = Approval(state=state)
+
+        assert approval.should_auto_approve_operations() is True
+        assert approval.should_auto_dismiss_questions() is True
+        assert approval.should_auto_approve_plan_entry() is True
+        assert approval.should_auto_approve_plan_exit() is True
+
+    def test_set_interactive_questions_supported_notifies(self):
+        from kimi_cli.soul.approval import Approval, ApprovalState
+
+        changes: list[bool] = []
+
+        def on_change():
+            changes.append(True)
+
+        state = ApprovalState(on_change=on_change)
+        approval = Approval(state=state)
+
+        approval.set_interactive_questions_supported(False)
+        assert len(changes) == 1
+        assert state.supports_interactive_questions is False
+
+        approval.set_interactive_questions_supported(True)
+        assert len(changes) == 2
+        assert state.supports_interactive_questions is True

--- a/tests/core/test_session_state.py
+++ b/tests/core/test_session_state.py
@@ -490,7 +490,7 @@ class TestApprovalPolicyMatrix:
         assert approval.should_auto_approve_plan_entry() is True
         assert approval.should_auto_approve_plan_exit() is True
 
-    def test_set_interactive_questions_supported_notifies(self):
+    def test_set_interactive_questions_supported_does_not_notify(self):
         from kimi_cli.soul.approval import Approval, ApprovalState
 
         changes: list[bool] = []
@@ -502,9 +502,9 @@ class TestApprovalPolicyMatrix:
         approval = Approval(state=state)
 
         approval.set_interactive_questions_supported(False)
-        assert len(changes) == 1
         assert state.supports_interactive_questions is False
+        assert len(changes) == 0
 
         approval.set_interactive_questions_supported(True)
-        assert len(changes) == 2
         assert state.supports_interactive_questions is True
+        assert len(changes) == 0

--- a/tests/core/test_startup_progress.py
+++ b/tests/core/test_startup_progress.py
@@ -68,6 +68,7 @@ async def test_kimi_cli_create_reports_startup_phases(session, config, monkeypat
         session=session,
         config=config,
         llm=None,
+        approval=SimpleNamespace(set_interactive_questions_supported=lambda _supported: None),
         notifications=SimpleNamespace(recover=lambda: None),
         background_tasks=SimpleNamespace(reconcile=lambda: None),
     )
@@ -124,6 +125,7 @@ async def test_kimi_cli_create_cleans_stale_running_foreground_subagents(
         session=session,
         config=config,
         llm=None,
+        approval=SimpleNamespace(set_interactive_questions_supported=lambda _supported: None),
         notifications=SimpleNamespace(recover=lambda: None),
         background_tasks=SimpleNamespace(reconcile=lambda: None),
         subagent_store=SimpleNamespace(

--- a/tests/core/test_yolo_injection.py
+++ b/tests/core/test_yolo_injection.py
@@ -26,6 +26,9 @@ async def test_injects_when_yolo_enabled():
     assert result[0].type == _YOLO_INJECTION_TYPE
     assert result[0].content == _YOLO_PROMPT
     assert "AskUserQuestion" in result[0].content
+    assert "remains available" in result[0].content
+    assert "Do NOT call" not in result[0].content
+    assert "auto-approved in non-interactive mode" not in result[0].content
 
 
 async def test_no_injection_when_yolo_disabled():

--- a/tests/core/test_yolo_injection.py
+++ b/tests/core/test_yolo_injection.py
@@ -26,7 +26,9 @@ async def test_injects_when_yolo_enabled():
     assert result[0].type == _YOLO_INJECTION_TYPE
     assert result[0].content == _YOLO_PROMPT
     assert "AskUserQuestion" in result[0].content
-    assert "remains available" in result[0].content
+    assert "client supports interactive questions" in result[0].content
+    assert "auto-dismissed" in result[0].content
+    assert "auto-approve" in result[0].content
     assert "Do NOT call" not in result[0].content
     assert "auto-approved in non-interactive mode" not in result[0].content
 

--- a/tests/tools/test_ask_user.py
+++ b/tests/tools/test_ask_user.py
@@ -179,16 +179,16 @@ async def test_ask_user_no_tool_call(ask_user_tool: AskUserQuestion):
 
 
 # ---------------------------------------------------------------------------
-# Yolo mode tests
+# Interaction policy auto-dismiss tests
 # ---------------------------------------------------------------------------
 
 
-async def test_ask_user_yolo_auto_dismiss():
-    """In yolo mode, auto-dismiss without wire or tool_call context (short-circuits everything)."""
+async def test_ask_user_policy_auto_dismiss():
+    """Auto-dismiss policy can short-circuit without wire or tool_call context."""
     tool = AskUserQuestion()
-    tool.bind_approval(is_yolo=lambda: True)
+    tool.bind_interaction_policy(should_auto_dismiss=lambda: True)
 
-    # Deliberately do NOT set wire or tool_call — yolo should short-circuit before needing them
+    # Deliberately do NOT set wire or tool_call — policy short-circuits before needing them
     wire_token = _current_wire.set(None)
     try:
         result = await tool(_make_params())
@@ -196,15 +196,15 @@ async def test_ask_user_yolo_auto_dismiss():
         assert isinstance(result.output, str)
         parsed = json.loads(result.output)
         assert parsed["answers"] == {}
-        assert "yolo" in parsed.get("note", "").lower()
+        assert "auto-dismissed" in parsed.get("note", "").lower()
+        assert "interaction policy" in parsed.get("note", "").lower()
     finally:
         _current_wire.reset(wire_token)
 
 
 async def test_ask_user_unbound_falls_through():
-    """When bind_approval is never called (backward compat), falls through to normal flow."""
+    """When no interaction policy callback is bound, tool falls through to normal flow."""
     tool = AskUserQuestion()
-    # Do NOT call bind_approval — _is_yolo stays None
 
     wire_token = _current_wire.set(None)
     tool_call = ToolCall(
@@ -221,22 +221,23 @@ async def test_ask_user_unbound_falls_through():
         _current_wire.reset(wire_token)
 
 
-async def test_ask_user_yolo_dynamic_toggle():
-    """When yolo is toggled off dynamically, tool should fall through to normal flow."""
-    yolo_state = {"enabled": True}
+async def test_ask_user_policy_dynamic_toggle():
+    """When interaction policy toggles off dynamically, tool falls through to normal flow."""
+    should_auto_dismiss = {"enabled": True}
     tool = AskUserQuestion()
-    tool.bind_approval(is_yolo=lambda: yolo_state["enabled"])
+    tool.bind_interaction_policy(lambda: should_auto_dismiss["enabled"])
 
-    # First call: yolo on -> auto-dismiss
+    # First call: policy on -> auto-dismiss
     result = await tool(_make_params())
     assert not result.is_error
     assert isinstance(result.output, str)
-    assert "yolo" in result.output.lower()
+    assert "auto-dismissed" in result.output.lower()
+    assert "interaction policy" in result.output.lower()
 
-    # Toggle yolo off
-    yolo_state["enabled"] = False
+    # Toggle policy off
+    should_auto_dismiss["enabled"] = False
 
-    # Second call: yolo off -> needs wire (which isn't set -> error)
+    # Second call: policy off -> needs wire (which isn't set -> error)
     wire_token = _current_wire.set(None)
     tool_call = ToolCall(
         id="tc-toggle",

--- a/tests/tools/test_plan_yolo.py
+++ b/tests/tools/test_plan_yolo.py
@@ -1,4 +1,4 @@
-"""Tests for EnterPlanMode / ExitPlanMode yolo auto-approve behavior."""
+"""Tests for EnterPlanMode / ExitPlanMode auto-approve policy behavior."""
 
 from __future__ import annotations
 
@@ -42,14 +42,14 @@ def exit_tool() -> ExitPlanMode:
 # ---------------------------------------------------------------------------
 
 
-async def test_enter_plan_yolo(enter_tool: EnterPlanMode):
-    """Yolo auto-approves without wire or tool_call (short-circuits everything)."""
+async def test_enter_plan_auto_approve_policy_true(enter_tool: EnterPlanMode):
+    """Auto-approve policy can short-circuit enter flow without wire or tool_call."""
     tracker: dict = {}
     enter_tool.bind(
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: Path("/tmp/plan.md"),
         plan_mode_checker=lambda: False,
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     wire_token = _current_wire.set(None)
@@ -62,14 +62,14 @@ async def test_enter_plan_yolo(enter_tool: EnterPlanMode):
         _current_wire.reset(wire_token)
 
 
-async def test_enter_plan_yolo_already_in_plan_mode(enter_tool: EnterPlanMode):
-    """Guard 'already in plan mode' fires before yolo check."""
+async def test_enter_plan_policy_guard_already_in_plan_mode(enter_tool: EnterPlanMode):
+    """Guard 'already in plan mode' fires before auto-approve policy check."""
     tracker: dict = {}
     enter_tool.bind(
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: Path("/tmp/plan.md"),
         plan_mode_checker=lambda: True,  # already in plan mode
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     result = await enter_tool(EnterParams())
@@ -78,8 +78,8 @@ async def test_enter_plan_yolo_already_in_plan_mode(enter_tool: EnterPlanMode):
     assert not tracker.get("called")
 
 
-async def test_enter_plan_is_yolo_none(enter_tool: EnterPlanMode):
-    """When is_yolo is not passed (backward compat), falls through to normal flow."""
+async def test_enter_plan_policy_callback_none(enter_tool: EnterPlanMode):
+    """When approval policy callback is not passed, tool falls through to normal flow."""
     tracker: dict = {}
     enter_tool.bind(
         toggle_callback=_make_toggle(tracker),
@@ -97,9 +97,9 @@ async def test_enter_plan_is_yolo_none(enter_tool: EnterPlanMode):
         _current_wire.reset(wire_token)
 
 
-async def test_enter_plan_yolo_dynamic_toggle(enter_tool: EnterPlanMode):
-    """When yolo toggles off, falls through to normal flow."""
-    yolo_state = {"enabled": True}
+async def test_enter_plan_auto_approve_policy_dynamic_toggle(enter_tool: EnterPlanMode):
+    """When auto-approve policy toggles off, tool falls through to normal flow."""
+    auto_approve_policy = {"enabled": True}
     plan_mode_state = {"active": False}
     tracker: dict = {}
 
@@ -112,10 +112,10 @@ async def test_enter_plan_yolo_dynamic_toggle(enter_tool: EnterPlanMode):
         toggle_callback=toggle,
         plan_file_path_getter=lambda: Path("/tmp/plan.md"),
         plan_mode_checker=lambda: plan_mode_state["active"],
-        is_yolo=lambda: yolo_state["enabled"],
+        should_auto_approve=lambda: auto_approve_policy["enabled"],
     )
 
-    # Call 1: yolo on -> auto-approve
+    # Call 1: policy on -> auto-approve
     result = await enter_tool(EnterParams())
     assert not result.is_error
     assert tracker.get("called")
@@ -123,9 +123,9 @@ async def test_enter_plan_yolo_dynamic_toggle(enter_tool: EnterPlanMode):
     # Reset for second attempt
     plan_mode_state["active"] = False
     tracker.clear()
-    yolo_state["enabled"] = False
+    auto_approve_policy["enabled"] = False
 
-    # Call 2: yolo off, no wire -> wire error
+    # Call 2: policy off, no wire -> wire error
     wire_token = _current_wire.set(None)
     try:
         result = await enter_tool(EnterParams())
@@ -140,8 +140,8 @@ async def test_enter_plan_yolo_dynamic_toggle(enter_tool: EnterPlanMode):
 # ---------------------------------------------------------------------------
 
 
-async def test_exit_plan_yolo(exit_tool: ExitPlanMode, tmp_path: Path):
-    """Yolo auto-approves the plan without wire or tool_call."""
+async def test_exit_plan_auto_approve_policy_true(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Auto-approve policy can approve the plan without wire or tool_call."""
     tracker: dict = {}
     plan_file = tmp_path / "plan.md"
     plan_file.write_text("# Test Plan\n- Step 1\n- Step 2")
@@ -150,7 +150,7 @@ async def test_exit_plan_yolo(exit_tool: ExitPlanMode, tmp_path: Path):
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: plan_file,
         plan_mode_checker=lambda: True,
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     wire_token = _current_wire.set(None)
@@ -164,8 +164,8 @@ async def test_exit_plan_yolo(exit_tool: ExitPlanMode, tmp_path: Path):
         _current_wire.reset(wire_token)
 
 
-async def test_exit_plan_yolo_with_options(exit_tool: ExitPlanMode, tmp_path: Path):
-    """Yolo auto-approve works even when options are provided (options ignored)."""
+async def test_exit_plan_auto_approve_policy_with_options(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Auto-approve policy also works when options are provided (options are ignored)."""
     tracker: dict = {}
     plan_file = tmp_path / "plan.md"
     plan_file.write_text("# Plan\n## Option A\n## Option B")
@@ -174,7 +174,7 @@ async def test_exit_plan_yolo_with_options(exit_tool: ExitPlanMode, tmp_path: Pa
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: plan_file,
         plan_mode_checker=lambda: True,
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     result = await exit_tool(
@@ -189,14 +189,14 @@ async def test_exit_plan_yolo_with_options(exit_tool: ExitPlanMode, tmp_path: Pa
     assert tracker.get("called")
 
 
-async def test_exit_plan_yolo_no_plan_file(exit_tool: ExitPlanMode, tmp_path: Path):
-    """Yolo does NOT bypass the 'no plan file' guard."""
+async def test_exit_plan_auto_approve_policy_no_plan_file(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Auto-approve policy does NOT bypass the 'no plan file' guard."""
     tracker: dict = {}
     exit_tool.bind(
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: tmp_path / "nonexistent.md",
         plan_mode_checker=lambda: True,
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     result = await exit_tool(ExitParams())
@@ -205,8 +205,11 @@ async def test_exit_plan_yolo_no_plan_file(exit_tool: ExitPlanMode, tmp_path: Pa
     assert not tracker.get("called")
 
 
-async def test_exit_plan_yolo_empty_plan_file(exit_tool: ExitPlanMode, tmp_path: Path):
-    """Yolo does NOT bypass the 'empty plan file' guard."""
+async def test_exit_plan_auto_approve_policy_empty_plan_file(
+    exit_tool: ExitPlanMode,
+    tmp_path: Path,
+):
+    """Auto-approve policy does NOT bypass the 'empty plan file' guard."""
     tracker: dict = {}
     plan_file = tmp_path / "plan.md"
     plan_file.write_text("")
@@ -215,7 +218,7 @@ async def test_exit_plan_yolo_empty_plan_file(exit_tool: ExitPlanMode, tmp_path:
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: plan_file,
         plan_mode_checker=lambda: True,
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     result = await exit_tool(ExitParams())
@@ -223,14 +226,14 @@ async def test_exit_plan_yolo_empty_plan_file(exit_tool: ExitPlanMode, tmp_path:
     assert not tracker.get("called")
 
 
-async def test_exit_plan_yolo_not_in_plan_mode(exit_tool: ExitPlanMode, tmp_path: Path):
-    """Guard 'not in plan mode' fires before yolo check."""
+async def test_exit_plan_policy_guard_not_in_plan_mode(exit_tool: ExitPlanMode, tmp_path: Path):
+    """Guard 'not in plan mode' fires before auto-approve policy check."""
     tracker: dict = {}
     exit_tool.bind(
         toggle_callback=_make_toggle(tracker),
         plan_file_path_getter=lambda: tmp_path / "plan.md",
         plan_mode_checker=lambda: False,
-        is_yolo=lambda: True,
+        should_auto_approve=lambda: True,
     )
 
     result = await exit_tool(ExitParams())
@@ -239,8 +242,8 @@ async def test_exit_plan_yolo_not_in_plan_mode(exit_tool: ExitPlanMode, tmp_path
     assert not tracker.get("called")
 
 
-async def test_exit_plan_is_yolo_none(exit_tool: ExitPlanMode, tmp_path: Path):
-    """When is_yolo is not passed (backward compat), falls through to normal flow."""
+async def test_exit_plan_policy_callback_none(exit_tool: ExitPlanMode, tmp_path: Path):
+    """When approval policy callback is not passed, tool falls through to normal flow."""
     tracker: dict = {}
     plan_file = tmp_path / "plan.md"
     plan_file.write_text("# Plan content")


### PR DESCRIPTION
## Current Problem

The current `--yes` / yolo mode treats operation approvals and user-intent interactions as the same thing, causing two issues:

1. **Plan approval is auto-skipped**: When `ExitPlanMode` is called in yolo mode, the plan is auto-approved without user review, defeating the purpose of plan mode.
2. **AskUserQuestion is auto-dismissed**: In yolo mode, `AskUserQuestion` returns empty answers immediately, preventing the agent from confirming implementation details with the user.

## What This PR Changes

This PR refines yolo scope so that it **only auto-approves operation-type actions** (file writes, shell commands, etc.) while **preserving user-intent interactions** (plan review and structured questions).

### Key Changes

- **Approval layer** (`approval.py`): Added four fine-grained policy methods:
  - `should_auto_approve_operations()` - defaults to yolo
  - `should_auto_approve_plan_entry()` - defaults to False
  - `should_auto_approve_plan_exit()` - defaults to False
  - `should_auto_dismiss_questions()` - defaults to False

- **KimiSoul binding** (`kimisoul.py`): `EnterPlanMode`, `ExitPlanMode`, and `AskUserQuestion` now each receive their own policy callback instead of the global `is_yolo()` boolean.

- **Plan tools** (`enter.py`, `__init__.py`): Removed the default yolo short-circuit for plan entry/exit. Auto-approve now only happens when the explicit policy callback returns `True`.

- **AskUserQuestion** (`ask_user/__init__.py`): Renamed internal field from `_is_yolo` to `_should_auto_dismiss`. Added `bind_interaction_policy()` as the new binding API; `bind_approval()` remains as a backward-compatible alias.

- **Yolo injection prompt** (`yolo_mode.py`): Updated the system prompt to reflect the new semantics - operation approvals are auto-approved, but `AskUserQuestion` and plan review remain interactive.

- **Tests**: Synced `test_plan_yolo.py` and `test_ask_user.py` to the new API names and assertions; tightened `test_yolo_injection.py` assertions to verify the new prompt semantics.

## Why This Is More Reasonable

File modifications and shell executions are **execution permissions**; plan review and requirement clarification are **user-intent decisions**. These two categories should not be tied to the same master switch.

## Testing

- Updated unit tests for `EnterPlanMode`, `ExitPlanMode`, and `AskUserQuestion` to verify the new policy-based behavior.
- Added positive and negative semantic assertions for the yolo injection prompt.
- Manually verified that operation approvals still auto-approve in yolo mode while plan review and questions remain interactive.
