### PR TITLE
feat(hooks): support updatedInput for transparent command rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Support `updatedInput` for transparent command rewriting in `PreToolUse` hooks — hooks can now rewrite tool input via `hookSpecificOutput.updatedInput`, enabling integrations like RTK to transparently rewrite commands (e.g. `git status` → `rtk git status`) without blocking and retrying
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -117,6 +117,20 @@ When exiting with code 0, you can output structured JSON for more detailed infor
 
 When `permissionDecision` is `deny`, the operation is blocked and `permissionDecisionReason` is fed back to the LLM.
 
+For `PreToolUse` hooks, you can also provide `updatedInput` to transparently rewrite the tool input before execution:
+
+```json
+{
+  "hookSpecificOutput": {
+    "updatedInput": {
+      "command": "rtk git status"
+    }
+  }
+}
+```
+
+When `updatedInput` is provided (and the hook does not deny), the tool receives the updated input instead of the original. This is useful for integrations that need to transparently modify commands without blocking and retrying.
+
 ## Hook Script Examples
 
 ### Protect Sensitive Files

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Support `updatedInput` for transparent command rewriting in `PreToolUse` hooks — hooks can now rewrite tool input via `hookSpecificOutput.updatedInput`, enabling integrations like RTK to transparently rewrite commands (e.g. `git status` → `rtk git status`) without blocking and retrying
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -117,6 +117,20 @@ Hook 命令从标准输入接收 JSON 格式的上下文信息，包含通用字
 
 当 `permissionDecision` 为 `deny` 时，会阻止操作并将 `permissionDecisionReason` 反馈给 LLM。
 
+对于 `PreToolUse` hooks，你还可以提供 `updatedInput` 来在执行前透明地重写工具输入：
+
+```json
+{
+  "hookSpecificOutput": {
+    "updatedInput": {
+      "command": "rtk git status"
+    }
+  }
+}
+```
+
+当提供了 `updatedInput`（且 hook 没有拒绝）时，工具会收到更新后的输入而非原始输入。这对于需要透明修改命令而无需阻塞和重试的集成场景非常有用。
+
 ## Hook 脚本示例
 
 ### 保护敏感文件

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Core：支持 PreToolUse hooks 的 `updatedInput` 透明命令重写——hooks 现在可以通过 `hookSpecificOutput.updatedInput` 重写工具输入，使 RTK 等集成能够透明地重写命令（如 `git status` → `rtk git status`），无需阻塞和重试
+
 ## 1.37.0 (2026-04-20)
 
 - Print：退出前等待后台任务完成——在单次 `--print` 模式下，进程现在会等待仍在运行的后台 Agent 完成并让模型处理它们的结果，而不是直接退出并杀死它们。等待时长上限为 `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)`（默认上限 1 小时）；超时后杀死任务并通过 `<system-reminder>` 给模型最后一轮机会向用户总结后再退出

--- a/src/kimi_cli/hooks/runner.py
+++ b/src/kimi_cli/hooks/runner.py
@@ -87,7 +87,9 @@ async def run_hook(
                     )
                 # Parse updatedInput for transparent command rewriting (e.g. RTK)
                 if "updatedInput" in hook_output:
-                    updated_input = cast(dict[str, Any], hook_output["updatedInput"])
+                    _ui = hook_output["updatedInput"]
+                    if isinstance(_ui, dict):
+                        updated_input = cast(dict[str, Any], _ui)
         except (json.JSONDecodeError, TypeError):
             pass
 

--- a/src/kimi_cli/hooks/runner.py
+++ b/src/kimi_cli/hooks/runner.py
@@ -18,6 +18,7 @@ class HookResult:
     stderr: str = ""
     exit_code: int = 0
     timed_out: bool = False
+    updated_input: dict[str, Any] | None = None
 
 
 async def run_hook(
@@ -69,6 +70,7 @@ async def run_hook(
         )
 
     # Exit 0 + JSON stdout = structured decision
+    updated_input: dict[str, Any] | None = None
     if exit_code == 0 and stdout.strip():
         try:
             raw = json.loads(stdout)
@@ -83,7 +85,16 @@ async def run_hook(
                         stderr=stderr,
                         exit_code=0,
                     )
+                # Parse updatedInput for transparent command rewriting (e.g. RTK)
+                if "updatedInput" in hook_output:
+                    updated_input = cast(dict[str, Any], hook_output["updatedInput"])
         except (json.JSONDecodeError, TypeError):
             pass
 
-    return HookResult(action="allow", stdout=stdout, stderr=stderr, exit_code=exit_code)
+    return HookResult(
+        action="allow",
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
+        updated_input=updated_input,
+    )

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -184,6 +184,12 @@ class KimiToolset:
                             ),
                         )
 
+                # Apply updatedInput from hooks (transparent rewrite, e.g. RTK)
+                if isinstance(arguments, dict):
+                    for result in results:
+                        if result.updated_input:
+                            arguments.update(result.updated_input)
+
                 # --- Execute tool ---
                 t0 = time.monotonic()
                 try:

--- a/tests/hooks/test_runner.py
+++ b/tests/hooks/test_runner.py
@@ -43,3 +43,19 @@ async def test_stdin_receives_json():
     cmd = """python3 -c "import sys,json; d=json.load(sys.stdin); print(d['tool_name'])" """
     result = await run_hook(cmd, {"tool_name": "WriteFile"}, timeout=5)
     assert result.stdout.strip() == "WriteFile"
+
+
+@pytest.mark.asyncio
+async def test_json_updated_input_parsing():
+    cmd = """echo '{"hookSpecificOutput": {"updatedInput": {"command": "rtk git status"}}}' """
+    result = await run_hook(cmd, {"tool_name": "Shell"}, timeout=5)
+    assert result.action == "allow"
+    assert result.updated_input == {"command": "rtk git status"}
+
+
+@pytest.mark.asyncio
+async def test_json_deny_takes_precedence_over_updated_input():
+    cmd = """echo '{"hookSpecificOutput": {"permissionDecision": "deny", "updatedInput": {"command": "rtk git status"}}}' """
+    result = await run_hook(cmd, {"tool_name": "Shell"}, timeout=5)
+    assert result.action == "block"
+    assert result.updated_input is None

--- a/tests/hooks/test_runner.py
+++ b/tests/hooks/test_runner.py
@@ -59,3 +59,25 @@ async def test_json_deny_takes_precedence_over_updated_input():
     result = await run_hook(cmd, {"tool_name": "Shell"}, timeout=5)
     assert result.action == "block"
     assert result.updated_input is None
+
+
+@pytest.mark.asyncio
+async def test_json_invalid_updated_input_is_ignored():
+    """Non-dict updatedInput values are ignored to prevent crashes in toolset."""
+    # string
+    cmd = """echo '{"hookSpecificOutput": {"updatedInput": "not-a-dict"}}' """
+    result = await run_hook(cmd, {"tool_name": "Shell"}, timeout=5)
+    assert result.action == "allow"
+    assert result.updated_input is None
+
+    # null
+    cmd = """echo '{"hookSpecificOutput": {"updatedInput": null}}' """
+    result = await run_hook(cmd, {"tool_name": "Shell"}, timeout=5)
+    assert result.action == "allow"
+    assert result.updated_input is None
+
+    # list
+    cmd = """echo '{"hookSpecificOutput": {"updatedInput": [1, 2]}}' """
+    result = await run_hook(cmd, {"tool_name": "Shell"}, timeout=5)
+    assert result.action == "allow"
+    assert result.updated_input is None


### PR DESCRIPTION
## Related Issue

N/A — This is a small feature addition (34 lines) that enables transparent command rewriting via PreToolUse hooks, aligning with the existing hooks Beta documentation.

## Description

This PR adds support for `hookSpecificOutput.updatedInput` in the PreToolUse hook lifecycle, enabling hooks to **transparently rewrite tool arguments** without blocking and requiring a retry.

### Motivation

The current Kimi CLI hook system supports two actions from a PreToolUse hook:
- `allow` — execute the tool as-is
- `block` — prevent execution and return an error to the LLM

This works well for guardrails (e.g. "don't rm -rf /"), but is insufficient for integrations like [RTK](https://github.com/rtk-ai/rtk) that want to **rewrite** commands for token optimization (e.g. `git status` → `rtk git status`) without forcing the LLM to retry.

With this change, a hook can output:

```json
{
  "hookSpecificOutput": {
    "updatedInput": {
      "command": "rtk git status"
    }
  }
}
```

And Kimi will execute the tool with the rewritten arguments, transparently to the LLM.

### Changes

**`src/kimi_cli/hooks/runner.py`**
- Added `updated_input: dict[str, Any] | None = None` to `HookResult`
- Extended `run_hook()` to parse `hookSpecificOutput.updatedInput` from JSON stdout
- Deny decisions still take precedence over `updatedInput`

**`src/kimi_cli/soul/toolset.py`**
- After PreToolUse hooks fire, if any result contains `updated_input`, merge it into the tool arguments dict before `tool.call(arguments)`
- Guarded by `isinstance(arguments, dict)` to ensure type safety

**`tests/hooks/test_runner.py`**
- `test_json_updated_input_parsing` — verifies `updatedInput` is parsed into `HookResult.updated_input`
- `test_json_deny_takes_precedence_over_updated_input` — verifies `permissionDecision: deny` still blocks even when `updatedInput` is present

### Backward Compatibility

- Fully backward compatible. Hooks that don't output `updatedInput` behave exactly as before.
- The feature is opt-in on the hook side — no config changes required.

### Use Case: RTK Integration

[RTK](https://github.com/rtk-ai/rtk) (Rust Token Killer) is a CLI proxy that reduces LLM token consumption by 60–90% on common commands. With this PR + the [RTK PR #1391](https://github.com/rtk-ai/rtk/pull/1391), Kimi users can:

```bash
rtk init -g --kimi
```

And have all `Shell` tool calls transparently rewritten to their RTK equivalents.

### Testing

```bash
uv run pytest tests/hooks/test_runner.py -v
```

All 8 tests pass, including the 2 new ones:
```
tests/hooks/test_runner.py::test_json_updated_input_parsing PASSED
tests/hooks/test_runner.py::test_json_deny_takes_precedence_over_updated_input PASSED
```

The full hooks test suite (36 tests) also passes:
```bash
uv run pytest tests/hooks/ -v
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any. (N/A for this small feature)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog. (Command timed out in this environment)
- [ ] I have run `make gen-docs` to update the user documentation. (Command timed out in this environment)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
