### PR TITLE
fix(mcp): propagate MCP configs to subagents and resume immediately

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -215,6 +215,7 @@ class KimiCLI:
             session,
             yolo,
             skills_dirs=skills_dirs,
+            mcp_configs=mcp_configs,
         )
         runtime.notifications.recover()
         runtime.background_tasks.reconcile()
@@ -236,6 +237,12 @@ class KimiCLI:
 
         if agent_file is None:
             agent_file = DEFAULT_AGENT_FILE
+        if resumed:
+            # When resuming a session, MCP tools must be loaded immediately so the
+            # agent can use them from the very first turn. Otherwise deferred loading
+            # may complete after the system prompt / context has already been fixed.
+            defer_mcp_loading = False
+
         if startup_progress is not None:
             startup_progress("Loading agent...")
 

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -208,6 +208,8 @@ class Runtime:
     role: Literal["root", "subagent"] = "root"
     hook_engine: Any = None
     """HookEngine instance, set by KimiCLI after soul creation."""
+    mcp_configs: list[Any] = field(default_factory=list)
+    """MCP configs inherited from the parent agent (for subagent use)."""
 
     def __post_init__(self) -> None:
         if self.subagent_store is None:
@@ -228,6 +230,7 @@ class Runtime:
         session: Session,
         yolo: bool,
         skills_dirs: list[KaosPath] | None = None,
+        mcp_configs: list[Any] | None = None,
     ) -> Runtime:
         ls_output, agents_md, environment = await asyncio.gather(
             list_directory(session.work_dir),
@@ -344,6 +347,7 @@ class Runtime:
             approval_runtime=ApprovalRuntime(),
             root_wire_hub=RootWireHub(),
             role="root",
+            mcp_configs=mcp_configs or [],
         )
 
     def copy_for_subagent(
@@ -376,6 +380,7 @@ class Runtime:
             subagent_id=agent_id,
             subagent_type=subagent_type,
             role="subagent",
+            mcp_configs=self.mcp_configs,
         )
 
 

--- a/src/kimi_cli/subagents/builder.py
+++ b/src/kimi_cli/subagents/builder.py
@@ -32,7 +32,7 @@ class SubagentBuilder:
         return await load_agent(
             type_def.agent_file,
             runtime,
-            mcp_configs=[],
+            mcp_configs=self._root_runtime.mcp_configs,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary

This PR fixes two related issues that prevented MCP tools from being usable in subagents and in resumed sessions.

### Problem 1: Subagents never received MCP configs
SubagentBuilder.build_builtin_instance hard-coded mcp_configs=[], so every subagent (e.g. explore, coder, plan) was completely blind to MCP servers registered in the root agent.

### Problem 2: Resumed sessions missed newly-added MCP tools
When a session was resumed with a newly-configured MCP server, defer_mcp_loading=True (in shell mode) caused the MCP connection to start in the background after the agent context / system prompt had already been fixed. The agent therefore never saw the new tools in its first turn.

### Changes
- Added mcp_configs field to Runtime and forwarded it through Runtime.create, copy_for_subagent, and SubagentBuilder.
- Forced defer_mcp_loading=False when resumed=True so MCP tools are loaded synchronously during agent setup.

### Testing
- All existing test_agent_tool.py and test_mcp_tool_result.py tests pass.
- No breaking changes to public API.

Fixes the scenario described in #518 (subagent MCP inheritance).
