### PR TITLE
fix(web): guard web imports from cwd module shadowing

### DIFF
--- a/src/kimi_cli/web/__init__.py
+++ b/src/kimi_cli/web/__init__.py
@@ -1,5 +1,12 @@
 """Kimi Code CLI Web Interface."""
 
-from kimi_cli.web.app import create_app, run_web_server
+import importlib
+
+from . import _safe_imports as _safe_imports
+
+_ = _safe_imports
+_app = importlib.import_module("kimi_cli.web.app")
+create_app = _app.create_app
+run_web_server = _app.run_web_server
 
 __all__ = ["create_app", "run_web_server"]

--- a/src/kimi_cli/web/_safe_imports.py
+++ b/src/kimi_cli/web/_safe_imports.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def remove_current_workdir_from_sys_path() -> None:
+    """Avoid importing user project files as third-party dependencies."""
+
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return
+
+    filtered: list[str] = []
+    for entry in sys.path:
+        candidate = Path(entry or os.curdir)
+        try:
+            if candidate.resolve() == cwd:
+                continue
+        except OSError:
+            pass
+        filtered.append(entry)
+    sys.path[:] = filtered
+
+
+remove_current_workdir_from_sys_path()

--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -201,6 +201,7 @@ class SessionProcess:
             else:
                 worker_cmd = [
                     sys.executable,
+                    "-P",
                     "-m",
                     "kimi_cli.web.runner.worker",
                     str(self.session_id),

--- a/tests/web/test_import_shadowing.py
+++ b/tests/web/test_import_shadowing.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def _run_python(code: str, *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(SRC) if not existing else f"{SRC}{os.pathsep}{existing}"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_web_app_import_ignores_local_typing_extensions(tmp_path: Path) -> None:
+    (tmp_path / "typing_extensions.py").write_text("", encoding="utf-8")
+
+    proc = _run_python(
+        """
+from kimi_cli.web.app import create_app
+assert callable(create_app)
+print("ok")
+""",
+        cwd=tmp_path,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "ok"

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -7,12 +7,15 @@ that sessions don't get stuck in a permanent "busy" state.
 from __future__ import annotations
 
 import asyncio
+import sys
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
 
+import kimi_cli.web.runner.process as process_module
 from kimi_cli.web.models import SessionStatus
 from kimi_cli.web.runner.process import SessionProcess
 
@@ -162,3 +165,38 @@ def test_session_in_error_state_clears_stale_ids_on_new_prompt() -> None:
         sp.clear_in_flight()
 
     assert sp.is_busy is False
+
+
+@pytest.mark.asyncio
+async def test_session_process_start_uses_safe_python_path_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sp = SessionProcess(uuid4())
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(
+            returncode=None,
+            stdin=object(),
+            stdout=object(),
+            stderr=object(),
+        )
+
+    def fake_create_task(coro):
+        coro.close()
+        return SimpleNamespace(done=lambda: False)
+
+    monkeypatch.setattr(process_module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(process_module.asyncio, "create_task", fake_create_task)
+
+    await sp.start()
+
+    assert captured["args"] == (
+        sys.executable,
+        "-P",
+        "-m",
+        "kimi_cli.web.runner.worker",
+        str(sp.session_id),
+    )


### PR DESCRIPTION
## Related Issue

Resolve #1949

## Description

The web entrypoints were vulnerable to Python module shadowing from the user's working directory. If a project root contained a file such as `typing_extensions.py`, starting the Web UI could fail during import because Python prepended the current working directory to `sys.path` and third-party dependencies resolved against the user file instead of the installed package.

This change fixes that in two places:

- add a small web import guard that removes the current working directory from `sys.path` before web modules import third-party dependencies
- start the web worker subprocess with Python's `-P` safe-path flag so worker startup does not reintroduce the same shadowing problem

## Validation

- `uv run ruff check src/kimi_cli/web/__init__.py src/kimi_cli/web/_safe_imports.py src/kimi_cli/web/app.py src/kimi_cli/web/runner/process.py tests/web/test_import_shadowing.py tests/web/test_session_error_recovery.py`
- `uv run pytest tests/web/test_import_shadowing.py tests/web/test_session_error_recovery.py`
- Reproduced with a temporary `typing_extensions.py` in the working directory and verified `uv run --project /Users/shenghuikevin/dev/AI/kimi-cli python -c 'from kimi_cli.web.app import create_app; print("ok")'` now succeeds

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
