### PR TITLE
fix(acp): list_sessions without cwd returns all sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- ACP: Fix `list_sessions` without `cwd` returning an empty list — when no working directory is provided, the endpoint now correctly returns sessions from all work directories via `Session.list_all()` instead of an empty result
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- ACP: Fix `list_sessions` without `cwd` returning an empty list — when no working directory is provided, the endpoint now correctly returns sessions from all work directories via `Session.list_all()` instead of an empty result
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- ACP：修复 `list_sessions` 未提供 `cwd` 时返回空列表的问题——当请求中不包含工作目录参数时，接口现在会通过 `Session.list_all()` 正确返回所有工作目录下的会话，而非空结果
+
 ## 1.37.0 (2026-04-20)
 
 - Print：退出前等待后台任务完成——在单次 `--print` 模式下，进程现在会等待仍在运行的后台 Agent 完成并让模型处理它们的结果，而不是直接退出并杀死它们。等待时长上限为 `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)`（默认上限 1 小时）；超时后杀死任务并通过 `<system-reminder>` 给模型最后一轮机会向用户总结后再退出

--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -295,13 +295,14 @@ class ACPServer:
     ) -> acp.schema.ListSessionsResponse:
         logger.info("Listing sessions for working directory: {cwd}", cwd=cwd)
         if cwd is None:
-            return acp.schema.ListSessionsResponse(sessions=[], next_cursor=None)
-        work_dir = KaosPath.unsafe_from_local_path(Path(cwd))
-        sessions = await Session.list(work_dir)
+            sessions = await Session.list_all()
+        else:
+            work_dir = KaosPath.unsafe_from_local_path(Path(cwd))
+            sessions = await Session.list(work_dir)
         return acp.schema.ListSessionsResponse(
             sessions=[
                 acp.schema.SessionInfo(
-                    cwd=cwd,
+                    cwd=cwd or str(s.work_dir),
                     session_id=s.id,
                     title=s.title,
                     updated_at=datetime.fromtimestamp(s.updated_at).astimezone().isoformat(),

--- a/tests/acp/test_protocol_v1.py
+++ b/tests/acp/test_protocol_v1.py
@@ -99,6 +99,29 @@ async def test_list_sessions(
     assert session_resp.session_id in session_ids
 
 
+async def test_list_sessions_without_cwd(
+    acp_client: tuple[acp.ClientSideConnection, ACPTestClient],
+    tmp_path,
+):
+    """list_sessions without cwd returns sessions from all work directories."""
+    conn, _ = acp_client
+    await conn.initialize(protocol_version=1)
+
+    work_dir = tmp_path / "workdir"
+    work_dir.mkdir(exist_ok=True)
+    session_resp = await conn.new_session(cwd=str(work_dir))
+
+    # Must prompt first; Session.list() skips empty sessions
+    await conn.prompt(
+        prompt=[acp.text_block("Hello")],
+        session_id=session_resp.session_id,
+    )
+
+    list_resp = await conn.list_sessions()
+    session_ids = [s.session_id for s in list_resp.sessions]
+    assert session_resp.session_id in session_ids
+
+
 async def test_resume_session(
     acp_client: tuple[acp.ClientSideConnection, ACPTestClient],
     tmp_path,

--- a/tests/acp/test_protocol_v1.py
+++ b/tests/acp/test_protocol_v1.py
@@ -107,19 +107,28 @@ async def test_list_sessions_without_cwd(
     conn, _ = acp_client
     await conn.initialize(protocol_version=1)
 
-    work_dir = tmp_path / "workdir"
-    work_dir.mkdir(exist_ok=True)
-    session_resp = await conn.new_session(cwd=str(work_dir))
+    work_dir_a = tmp_path / "workdir_a"
+    work_dir_a.mkdir(exist_ok=True)
+    session_resp_a = await conn.new_session(cwd=str(work_dir_a))
+
+    work_dir_b = tmp_path / "workdir_b"
+    work_dir_b.mkdir(exist_ok=True)
+    session_resp_b = await conn.new_session(cwd=str(work_dir_b))
 
     # Must prompt first; Session.list() skips empty sessions
     await conn.prompt(
-        prompt=[acp.text_block("Hello")],
-        session_id=session_resp.session_id,
+        prompt=[acp.text_block("Hello from A")],
+        session_id=session_resp_a.session_id,
+    )
+    await conn.prompt(
+        prompt=[acp.text_block("Hello from B")],
+        session_id=session_resp_b.session_id,
     )
 
     list_resp = await conn.list_sessions()
     session_ids = [s.session_id for s in list_resp.sessions]
-    assert session_resp.session_id in session_ids
+    assert session_resp_a.session_id in session_ids
+    assert session_resp_b.session_id in session_ids
 
 
 async def test_resume_session(


### PR DESCRIPTION

## Related Issue

https://github.com/MoonshotAI/kimi-cli/issues/1956

Resolve #1956

## Description

**Problem**

When an ACP client called `list_sessions` without a `cwd` argument, the server returned an empty list. This broke session history in editors like Zed.

The ACP protocol says `cwd` [is optional](https://github.com/agentclientprotocol/python-sdk/blob/88621c5a24abded0e4dee52f1d4e39b0d5ba600f/src/acp/schema.py#L442). But kimi-cli treated it as required. When `cwd` was missing, the server gave up and returned `[]`.

**Fix**

- If `cwd` is provided, behavior is the same as before.
- If `cwd` is missing, the server now returns all sessions across all work directories.

Also added a test to catch this in the future.

**Before (in Zed)**
<img width="696" height="87" alt="Screenshot 2026-04-20 at 17 07 34" src="https://github.com/user-attachments/assets/5d02b648-5326-4701-a536-7bca14800de8" />

**After (in Zed)**
<img width="854" height="95" alt="Screenshot 2026-04-20 at 17 07 48" src="https://github.com/user-attachments/assets/912e73fb-9f85-4314-ae44-f12b99ab3da6" />

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] No user-facing docs changes needed (pure behavior fix; no new config, flag, or UI surface).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
