### PR TITLE
feat: allow PreToolUse hooks to modify tool input via updatedInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Allow `PreToolUse` hooks to rewrite tool input via `updatedInput` — hooks can now return either `{"updatedInput": {...}}` or `{"hookSpecificOutput": {"updatedInput": {...}}}` on stdout to merge updated fields into the pending tool call before execution; rewritten inputs are also forwarded to wire external tools
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -117,6 +117,26 @@ When exiting with code 0, you can output structured JSON for more detailed infor
 
 When `permissionDecision` is `deny`, the operation is blocked and `permissionDecisionReason` is fed back to the LLM.
 
+For `PreToolUse`, an allowed hook can also return `updatedInput` to rewrite the pending tool call before it runs. Kimi Code CLI merges the object into the original tool input, so hooks can update one field while preserving the rest:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "rtk git status"
+    }
+  }
+}
+```
+
+The shorter top-level form is also supported:
+
+```json
+{"updatedInput": {"command": "rtk git status"}}
+```
+
 ## Hook Script Examples
 
 ### Protect Sensitive Files

--- a/docs/en/customization/print-mode.md
+++ b/docs/en/customization/print-mode.md
@@ -19,6 +19,7 @@ Print mode characteristics:
 - **Non-interactive**: Exits automatically after executing instructions
 - **Auto-approval**: Implicitly enables `--yolo` mode, all operations are auto-approved, and interactive questions (`AskUserQuestion`) and plan mode switches are also handled automatically
 - **Text output**: AI responses are output to stdout
+- **Waits for background tasks**: If the agent launches background tasks during execution (e.g. `Shell` or `Agent` tool with `run_in_background=true`), the process waits for them to finish and lets the model process their results before exiting, instead of killing them immediately
 
 <!-- TODO: Enable this example after supporting reading content from stdin and instructions from -p simultaneously
 **Pipeline examples**
@@ -128,6 +129,28 @@ Assistant message with tool calls:
 ```json
 {"role": "tool", "tool_call_id": "tc_1", "content": "Tool execution result"}
 ```
+
+## Background task wait
+
+In `--print` mode, if the agent starts background tasks, Kimi Code CLI continues waiting for them to reach a terminal state after the main flow ends, then gives the model an extra turn to summarize results before exiting. This ensures background agents or long-running shell commands are not accidentally interrupted.
+
+The wait duration is calculated as the maximum remaining timeout across all active tasks, clipped by `print_wait_ceiling_s` (default 3600 seconds, i.e. 1 hour). You can adjust this ceiling in the `[background]` section of the config file:
+
+```toml
+[background]
+print_wait_ceiling_s = 1800  # Set ceiling to 30 minutes
+```
+
+If the wait times out, background tasks are forcibly terminated, and the model receives a `<system-reminder>` summarizing the current state before exit. If you prefer to keep background tasks running on exit (without waiting or terminating them), set `keep_alive_on_exit = true`:
+
+```toml
+[background]
+keep_alive_on_exit = true
+```
+
+::: info Note
+On exit, the CLI lists each background task being killed (ID + description) on stderr, and reports any tasks that have not reached terminal state after the configured grace period.
+:::
 
 ## Exit codes
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Allow `PreToolUse` hooks to rewrite tool input via `updatedInput` — hooks can now return either `{"updatedInput": {...}}` or `{"hookSpecificOutput": {"updatedInput": {...}}}` on stdout to merge updated fields into the pending tool call before execution; rewritten inputs are also forwarded to wire external tools
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -117,6 +117,26 @@ Hook 命令从标准输入接收 JSON 格式的上下文信息，包含通用字
 
 当 `permissionDecision` 为 `deny` 时，会阻止操作并将 `permissionDecisionReason` 反馈给 LLM。
 
+对于 `PreToolUse`，允许继续的 hook 还可以返回 `updatedInput`，在工具调用执行前重写工具输入。Kimi Code CLI 会将该对象合并到原始工具输入中，因此 hook 可以只更新一个字段，同时保留其他字段：
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "rtk git status"
+    }
+  }
+}
+```
+
+也支持更简短的顶层格式：
+
+```json
+{"updatedInput": {"command": "rtk git status"}}
+```
+
 ## Hook 脚本示例
 
 ### 保护敏感文件

--- a/docs/zh/customization/print-mode.md
+++ b/docs/zh/customization/print-mode.md
@@ -148,7 +148,7 @@ print_wait_ceiling_s = 1800  # 将上限设为 30 分钟
 keep_alive_on_exit = true
 ```
 
-::: info 注意
+::: info 说明
 退出时，CLI 会在 stderr 上列出每个正在被终止的后台任务（ID + 描述），并在配置的宽限期后报告仍未到达终态的任务。
 :::
 

--- a/docs/zh/customization/print-mode.md
+++ b/docs/zh/customization/print-mode.md
@@ -19,6 +19,7 @@ Print 模式的特点：
 - **非交互**：执行完指令后自动退出
 - **自动审批**：隐式启用 `--yolo` 模式，所有操作自动批准，交互式问答（`AskUserQuestion`）和计划模式切换也会自动处理
 - **文本输出**：AI 的回复输出到 stdout
+- **等待后台任务**：如果 Agent 在执行过程中启动了后台任务（如 `Shell` 或 `Agent` 工具的 `run_in_background=true`），进程会等待这些任务完成并让模型处理结果后再退出，而不是直接杀死它们
 
 <!-- TODO: 支持同时从 stdin 读取内容和 -p 读取指令后启用此示例
 **管道组合示例**
@@ -128,6 +129,28 @@ echo '{"role":"user","content":"你好"}' | kimi --print --input-format=stream-j
 ```json
 {"role": "tool", "tool_call_id": "tc_1", "content": "工具执行结果"}
 ```
+
+## 后台任务等待
+
+在 `--print` 模式下，如果 Agent 启动了后台任务，Kimi Code CLI 会在主流程结束后继续等待这些任务到达终态，然后给模型一轮额外机会来总结结果，最后才退出。这确保了后台 Agent 或长时间运行的 shell 命令不会被意外中断。
+
+等待时长的计算方式为：取所有活跃任务剩余超时时间的最大值，再用 `print_wait_ceiling_s` 封顶（默认 3600 秒，即 1 小时）。你可以在配置文件的 `[background]` 节中调整这个上限：
+
+```toml
+[background]
+print_wait_ceiling_s = 1800  # 将上限设为 30 分钟
+```
+
+如果等待超时，后台任务会被强制终止，模型会收到一条 `<system-reminder>` 来总结当前状态后再退出。如果你希望在退出时保留后台任务运行（不等待也不终止），可以设置 `keep_alive_on_exit = true`：
+
+```toml
+[background]
+keep_alive_on_exit = true
+```
+
+::: info 注意
+退出时，CLI 会在 stderr 上列出每个正在被终止的后台任务（ID + 描述），并在配置的宽限期后报告仍未到达终态的任务。
+:::
 
 ## 退出码
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Core：允许 `PreToolUse` hooks 通过 `updatedInput` 重写工具输入——hook 现在可以在标准输出中返回 `{"updatedInput": {...}}` 或 `{"hookSpecificOutput": {"updatedInput": {...}}}`，在工具调用执行前将更新字段合并到待执行的工具调用中；重写后的输入也会转发给 Wire 外部工具
+
 ## 1.37.0 (2026-04-20)
 
 - Print：退出前等待后台任务完成——在单次 `--print` 模式下，进程现在会等待仍在运行的后台 Agent 完成并让模型处理它们的结果，而不是直接退出并杀死它们。等待时长上限为 `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)`（默认上限 1 小时）；超时后杀死任务并通过 `<system-reminder>` 给模型最后一轮机会向用户总结后再退出

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -184,6 +184,26 @@ class KimiToolset:
                             ),
                         )
 
+                # --- Apply updatedInput from allowed hooks ---
+                if isinstance(arguments, dict):
+                    for result in results:
+                        if result.action != "allow" or not result.stdout:
+                            continue
+                        try:
+                            parsed = json.loads(result.stdout)
+                            if isinstance(parsed, dict):
+                                # Support both direct updatedInput and nested
+                                # hookSpecificOutput.updatedInput (Claude Code / rtk format)
+                                updated = parsed.get("updatedInput")
+                                if updated is None:
+                                    updated = parsed.get("hookSpecificOutput", {}).get("updatedInput")
+                                if isinstance(updated, dict):
+                                    arguments.update(updated)
+                                    tool_input_dict = arguments
+                                    tool_call.function.arguments = json.dumps(arguments)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+
                 # --- Execute tool ---
                 t0 = time.monotonic()
                 try:

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -196,7 +196,9 @@ class KimiToolset:
                                 # hookSpecificOutput.updatedInput (Claude Code / rtk format)
                                 updated = parsed.get("updatedInput")
                                 if updated is None:
-                                    updated = parsed.get("hookSpecificOutput", {}).get("updatedInput")
+                                    hook_specific_output = parsed.get("hookSpecificOutput")
+                                    if isinstance(hook_specific_output, dict):
+                                        updated = hook_specific_output.get("updatedInput")
                                 if isinstance(updated, dict):
                                     arguments.update(updated)
                                     tool_input_dict = arguments

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import tempfile
+from pathlib import Path
 
 from kosong.tooling import CallableTool2, ToolOk, ToolReturnValue
 from kosong.tooling.error import ToolNotFoundError as KosongToolNotFoundError
 from pydantic import BaseModel
 
+from kimi_cli.hooks.config import HookDef
+from kimi_cli.hooks.engine import HookEngine
+from kimi_cli.soul import _current_wire
 from kimi_cli.soul.toolset import KimiToolset
-from kimi_cli.wire.types import ToolCall, ToolResult
+from kimi_cli.wire import Wire
+from kimi_cli.wire.types import ToolCall, ToolCallRequest, ToolResult
 
 
 class DummyParams(BaseModel):
@@ -186,3 +192,213 @@ def test_hide_unhide_cycle():
 
     ts.unhide("ToolA")
     assert "ToolA" in _tool_names(ts)
+
+
+# --- PreToolUse hook updatedInput ---
+
+
+class UpdatableParams(BaseModel):
+    command: str = ""
+    extra: str = ""
+
+
+class UpdatableTool(CallableTool2[UpdatableParams]):
+    name: str = "UpdatableTool"
+    description: str = "Tool with updatable params"
+    params: type[UpdatableParams] = UpdatableParams
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured: dict[str, str] = {}
+
+    async def __call__(self, params: UpdatableParams) -> ToolReturnValue:
+        self.captured = {"command": params.command, "extra": params.extra}
+        return ToolOk(output="ok")
+
+
+async def test_pre_tool_use_hook_updates_tool_input():
+    """PreToolUse hook returning updatedInput modifies the tool arguments."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        hook_script = Path(tmpdir) / "update.sh"
+        hook_script.write_text(
+            '#!/bin/bash\n'
+            'echo \'{"updatedInput": {"extra": "injected"}}\'\n'
+        )
+        hook_script.chmod(0o755)
+
+        ts = KimiToolset()
+        tool = UpdatableTool()
+        ts.add(tool)
+
+        hooks = [
+            HookDef(
+                event="PreToolUse",
+                matcher="UpdatableTool",
+                command=str(hook_script),
+                timeout=5,
+            )
+        ]
+        engine = HookEngine(hooks, cwd=tmpdir)
+        ts.set_hook_engine(engine)
+
+        tool_call = ToolCall(
+            id="tc-1",
+            function=ToolCall.FunctionBody(
+                name="UpdatableTool",
+                arguments=json.dumps({"command": "original"}),
+            ),
+        )
+        result = ts.handle(tool_call)
+        assert isinstance(result, asyncio.Task)
+        resolved = await result
+
+        assert isinstance(resolved, ToolResult)
+        assert resolved.return_value.output == "ok"
+        assert tool.captured["command"] == "original"
+        assert tool.captured["extra"] == "injected"
+
+
+async def test_pre_tool_use_hook_updates_nested_updated_input():
+    """PreToolUse hook returning hookSpecificOutput.updatedInput (rtk format) works."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        hook_script = Path(tmpdir) / "update-rtk.sh"
+        hook_script.write_text(
+            '#!/bin/bash\n'
+            'echo \'{"hookSpecificOutput": {"updatedInput": {"extra": "rtk-injected"}}}\'\n'
+        )
+        hook_script.chmod(0o755)
+
+        ts = KimiToolset()
+        tool = UpdatableTool()
+        ts.add(tool)
+
+        hooks = [
+            HookDef(
+                event="PreToolUse",
+                matcher="UpdatableTool",
+                command=str(hook_script),
+                timeout=5,
+            )
+        ]
+        engine = HookEngine(hooks, cwd=tmpdir)
+        ts.set_hook_engine(engine)
+
+        tool_call = ToolCall(
+            id="tc-2",
+            function=ToolCall.FunctionBody(
+                name="UpdatableTool",
+                arguments=json.dumps({"command": "original"}),
+            ),
+        )
+        result = ts.handle(tool_call)
+        assert isinstance(result, asyncio.Task)
+        resolved = await result
+
+        assert isinstance(resolved, ToolResult)
+        assert tool.captured["extra"] == "rtk-injected"
+
+
+async def test_pre_tool_use_hook_ignores_non_dict_arguments():
+    """PreToolUse updatedInput is ignored when tool arguments are not a dict."""
+    from kosong.tooling.error import ToolValidateError
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        hook_script = Path(tmpdir) / "update.sh"
+        hook_script.write_text(
+            '#!/bin/bash\n'
+            'echo \'{"updatedInput": {"extra": "injected"}}\'\n'
+        )
+        hook_script.chmod(0o755)
+
+        ts = KimiToolset()
+        tool = UpdatableTool()
+        ts.add(tool)
+
+        hooks = [
+            HookDef(
+                event="PreToolUse",
+                matcher="UpdatableTool",
+                command=str(hook_script),
+                timeout=5,
+            )
+        ]
+        engine = HookEngine(hooks, cwd=tmpdir)
+        ts.set_hook_engine(engine)
+
+        # Pass a JSON array instead of an object
+        tool_call = ToolCall(
+            id="tc-3",
+            function=ToolCall.FunctionBody(
+                name="UpdatableTool",
+                arguments=json.dumps(["item1", "item2"]),
+            ),
+        )
+        result = ts.handle(tool_call)
+        assert isinstance(result, asyncio.Task)
+        resolved = await result
+
+        # Hook should not crash; tool fails validation because args are not a dict
+        assert isinstance(resolved, ToolResult)
+        assert isinstance(resolved.return_value, ToolValidateError)
+        assert tool.captured == {}
+
+
+async def test_pre_tool_use_hook_updates_external_tool_request_arguments():
+    """updatedInput should be forwarded to wire external tools, not only local tools."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        hook_script = Path(tmpdir) / "update.sh"
+        hook_script.write_text(
+            '#!/bin/bash\n'
+            'echo \'{"updatedInput": {"command": "rtk git status"}}\'\n'
+        )
+        hook_script.chmod(0o755)
+
+        ts = KimiToolset()
+        ok, reason = ts.register_external_tool(
+            name="ExternalShell",
+            description="External shell tool",
+            parameters={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        )
+        assert ok, reason
+
+        hooks = [
+            HookDef(
+                event="PreToolUse",
+                matcher="ExternalShell",
+                command=str(hook_script),
+                timeout=5,
+            )
+        ]
+        engine = HookEngine(hooks, cwd=tmpdir)
+        ts.set_hook_engine(engine)
+
+        wire = Wire()
+        wire_token = _current_wire.set(wire)
+        try:
+            tool_call = ToolCall(
+                id="tc-4",
+                function=ToolCall.FunctionBody(
+                    name="ExternalShell",
+                    arguments=json.dumps({"command": "git status"}),
+                ),
+            )
+            result = ts.handle(tool_call)
+            assert isinstance(result, asyncio.Task)
+
+            ui_side = wire.ui_side(merge=False)
+            request = await asyncio.wait_for(ui_side.receive(), timeout=1)
+            assert isinstance(request, ToolCallRequest)
+            assert json.loads(request.arguments or "{}") == {"command": "rtk git status"}
+
+            request.resolve(ToolOk(output="ok"))
+            resolved = await result
+        finally:
+            _current_wire.reset(wire_token)
+            wire.shutdown()
+
+        assert isinstance(resolved, ToolResult)
+        assert resolved.return_value.output == "ok"


### PR DESCRIPTION
## Related Issue

N/A - no related issue.  Add support for [rtk](https://github.com/rtk-ai/rtk) - CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies.

## Description

This PR allows `PreToolUse` hooks to modify tool arguments by returning `updatedInput`
in stdout, matching the hook format used by Claude Code-compatible tooling such as rtk.

Before this change, Kimi CLI `PreToolUse` hooks could allow or block a tool call, but
could not rewrite the tool input before execution. That made transparent command
rewriters ineffective: a hook could decide that a shell command should become
`rtk git status`, but the original `git status` arguments would still be executed.

The toolset now consumes `updatedInput` from allowed `PreToolUse` hook results before
running the tool. It supports both formats below:

```json
{"updatedInput": {"command": "rtk git status"}}
```

```json
{
  "hookSpecificOutput": {
    "updatedInput": {"command": "rtk git status"}
  }
}
```

Implementation details:

- Applies `updatedInput` only for allowed hook results.
- Merges updated fields into the original argument object so hooks can rewrite one
  field while preserving the rest.
- Ignores non-object tool arguments and malformed hook stdout to keep the existing
  fail-open behavior.
- Keeps `PostToolUse` and `PostToolUseFailure` payloads aligned with the rewritten
  input.
- Synchronizes the serialized `tool_call.function.arguments` after rewriting so
  wire external tools receive the updated arguments as well.

Tests added in `tests/core/test_toolset.py` cover:

- Direct `updatedInput` output.
- Nested `hookSpecificOutput.updatedInput` output.
- Non-object tool arguments.
- Wire external tools receiving rewritten request arguments.

Verification run locally:

```bash
.venv/bin/python -m pytest tests/core/test_toolset.py tests/hooks/test_runner.py tests/hooks/test_engine.py tests/hooks/test_integration.py
```

Result: `45 passed`.

Documentation updates:

- Added an Unreleased changelog entry in `CHANGELOG.md`.
- Synced the English release notes with `node docs/scripts/sync-changelog.mjs`.
- Added the matching Chinese changelog entry.
- Updated the Hooks documentation in English and Chinese to describe `PreToolUse.updatedInput`.
- Updated the Print mode documentation in English and Chinese to describe background
  task waiting before one-shot `--print` exits.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
