### PR TITLE
fix(kosong/anthropic): merge parallel tool_results into one user msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Kosong：修复 Anthropic 供应商将并行工具结果拆分到多个 user message 的问题——现在会将仅包含工具结果的连续 user message 合并为单条消息，以符合 Anthropic Messages API 规范（assistant 一轮中的所有 `tool_use` 必须在同一条 user message 内回答）；修复了严格兼容后端（如 DeepSeek `/anthropic` 接口）返回 400 错误的问题，并避免官方后端静默地引导模型放弃并行工具调用
+
 ## 1.37.0 (2026-04-20)
 
 - Print：退出前等待后台任务完成——在单次 `--print` 模式下，进程现在会等待仍在运行的后台 Agent 完成并让模型处理它们的结果，而不是直接退出并杀死它们。等待时长上限为 `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)`（默认上限 1 小时）；超时后杀死任务并通过 `<system-reminder>` 给模型最后一轮机会向用户总结后再退出

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Anthropic: Fix parallel tool results being split into multiple user messages — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
+
 ## 0.50.0 (2026-04-17)
 
 - Anthropic: Add adaptive thinking support for Claude Opus 4.7 — model capability detection now uses regex version extrapolation (covers `opus-4-7`, Bedrock/Vertex name variants such as `aws/claude-opus-4-7` and `anthropic.claude-opus-4-7-v1:0`, `claude-mythos-preview`, and future Claude versions ≥ 4.6) instead of hard-coded substring matching; adaptive requests now set `display: "summarized"` explicitly so thinking content still streams on Opus 4.7 (where the default flipped to `"omitted"`); the legacy `thinking: {type: "enabled", budget_tokens: N}` path is no longer used for Opus 4.7, which rejects it with 400

--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -297,7 +297,25 @@ class Anthropic:
         )
         messages: list[MessageParam] = []
         for message in history:
-            messages.append(self._convert_message(message))
+            converted = self._convert_message(message)
+            # Per Anthropic spec, tool_result blocks for the same assistant turn
+            # must live in a single user message. Internal Messages model one
+            # tool call per entry, so merge consecutive tool-result-only user
+            # messages here. Strict-compat backends (e.g. DeepSeek /anthropic)
+            # 400 on the split form, and the official backend silently teaches
+            # the model to stop calling tools in parallel.
+            if (
+                messages
+                and converted["role"] == "user"
+                and messages[-1]["role"] == "user"
+                and _is_tool_result_only(messages[-1]["content"])
+                and _is_tool_result_only(converted["content"])
+            ):
+                prev_content = cast(list[ContentBlockParam], messages[-1]["content"])
+                new_content = cast(list[ContentBlockParam], converted["content"])
+                messages[-1]["content"] = [*prev_content, *new_content]
+            else:
+                messages.append(converted)
         if messages:
             last_message = messages[-1]
             last_content = last_message["content"]
@@ -610,6 +628,19 @@ def _convert_tool(tool: Tool) -> ToolParam:
         "description": tool.description,
         "input_schema": tool.parameters,
     }
+
+
+def _is_tool_result_only(content: object) -> bool:
+    """True iff ``content`` is a non-empty list of only tool_result blocks.
+
+    Guards the parallel-tool-result merge in ``generate()``: we only collapse
+    consecutive user messages when both sides carry pure tool results, never
+    when a user message mixes in text, images, or anything else.
+    """
+    if not isinstance(content, list) or not content:
+        return False
+    blocks = cast(list[ContentBlockParam], content)
+    return all(b["type"] == "tool_result" for b in blocks)
 
 
 def _tool_result_message_to_block(

--- a/packages/kosong/tests/api_snapshot_tests/test_anthropic.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_anthropic.py
@@ -314,12 +314,7 @@ async def test_anthropic_message_conversion():
                                         },
                                         {"type": "text", "text": "5"},
                                     ],
-                                }
-                            ],
-                        },
-                        {
-                            "role": "user",
-                            "content": [
+                                },
                                 {
                                     "type": "tool_result",
                                     "tool_use_id": "call_mul",
@@ -332,7 +327,7 @@ async def test_anthropic_message_conversion():
                                         {"type": "text", "text": "20"},
                                     ],
                                     "cache_control": {"type": "ephemeral"},
-                                }
+                                },
                             ],
                         },
                     ],
@@ -852,3 +847,60 @@ async def test_anthropic_opus_46_xhigh_property_reflects_clamped_value():
     ).with_thinking("xhigh")
     # xhigh clamped to high for 4.6
     assert provider.thinking_effort == "high"
+
+
+async def test_anthropic_parallel_tool_results_merged_into_single_user_message():
+    """Parallel tool results must be packed into a single user message.
+
+    Per the Anthropic Messages API spec, every tool_use block in an assistant
+    message must be answered by tool_result blocks inside the same (single)
+    user message. Anthropic's official backend leniently merges consecutive
+    same-role turns, but strict Anthropic-compatible backends (e.g. DeepSeek's
+    /anthropic endpoint) reject the split form with 400 — and the docs warn
+    that the split form also silently teaches Claude to avoid parallel calls.
+    """
+    from common import ADD_TOOL, MUL_TOOL, capture_request
+
+    from kosong.message import ToolCall
+
+    history = [
+        Message(role="user", content="Calculate 2+3 and 4*5"),
+        Message(
+            role="assistant",
+            content="I'll calculate both.",
+            tool_calls=[
+                ToolCall(
+                    id="call_add",
+                    function=ToolCall.FunctionBody(name="add", arguments='{"a": 2, "b": 3}'),
+                ),
+                ToolCall(
+                    id="call_mul",
+                    function=ToolCall.FunctionBody(name="multiply", arguments='{"a": 4, "b": 5}'),
+                ),
+            ],
+        ),
+        Message(role="tool", content="5", tool_call_id="call_add"),
+        Message(role="tool", content="20", tool_call_id="call_mul"),
+    ]
+
+    with respx.mock(base_url="https://api.anthropic.com") as mock:
+        mock.post("/v1/messages").mock(return_value=Response(200, json=make_anthropic_response()))
+        provider = Anthropic(
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+            default_max_tokens=1024,
+            stream=False,
+        )
+        body = await capture_request(mock, provider, "", [ADD_TOOL, MUL_TOOL], history)
+
+    messages = body["messages"]
+    # Expected wire layout:
+    #   [0] user      — original question
+    #   [1] assistant — text + two tool_use blocks
+    #   [2] user      — *both* tool_result blocks packed together
+    assert [m["role"] for m in messages] == ["user", "assistant", "user"], (
+        f"Parallel tool results should collapse into one trailing user message, "
+        f"got roles: {[m['role'] for m in messages]}"
+    )
+    tool_results = [b for b in messages[-1]["content"] if b["type"] == "tool_result"]
+    assert {b["tool_use_id"] for b in tool_results} == {"call_add", "call_mul"}


### PR DESCRIPTION
## Related Issue

Resolve #1975

## Description

### Fix

`generate()` in the Anthropic chat provider now merges consecutive user messages whose contents are entirely `tool_result` blocks into a single user message before sending on the wire, matching the Anthropic Messages API [parallel-tool-use spec](https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use#troubleshooting).

Also updates the `parallel_tool_calls` snapshot in `test_anthropic.py` (which had locked in the buggy split shape), and adds an assertion-style regression test that documents the spec-required shape independently of the snapshot — so if anyone regenerates the snapshot against buggy output again, the assertion test still fails.

### Why this matters beyond DeepSeek

Two distinct impacts, as documented in #1975:

1. **Strict Anthropic-compatible backends hard-fail.** DeepSeek's `/anthropic` endpoint returns HTTP 400 on the second consecutive user message. Visible failure.
2. **Anthropic's own backend silently degrades.** `api.anthropic.com` leniently merges consecutive same-role turns so requests don't 400 — but Anthropic's parallel-tool-use docs explicitly warn the split form *"teaches"* Claude to avoid parallel tool calls in subsequent turns. Invisible degradation affecting every multi-turn agent session, not just DeepSeek users.

Because impact #2 is silent, this has likely been quietly reducing parallel-tool-use across all Anthropic-backed models in kimi-cli.

### Scope

Provider-layer wire-format fix only. No internal `Message` model changes; other providers (OpenAI, Google, Kimi) are untouched. Fix is ~20 lines in `anthropic.py::generate()` plus one private helper `_is_tool_result_only`, following the existing `_is_*` / `cast()` patterns in the same file.

### Related issues

- #1344, #778 — mirror direction (Claude Code → Kimi `/anthropic` 400s on tool calls). Likely the same class of bug on the inbound server side; worth a separate audit.
- #1762 / #1771 — structurally identical prior fix in the OpenAI Chat Completions provider.
- #382 — prior CLOSED DeepSeek `/anthropic` edge case (null `usage.input_*`). Same pattern: kosong too lax, strict compat backend exposed it.

### Test plan

- New regression test `test_anthropic_parallel_tool_results_merged_into_single_user_message` — asserts 3 messages total, both `tool_result` blocks in the trailing user message, correct `tool_use_id`s.
- Updated `parallel_tool_calls` snapshot matches the merged shape; `cache_control` correctly lands on the last `tool_result` block after merging (same block as before, now just colocated with its sibling).
- Edge-case verification of the merge loop:
  - Single (non-parallel) tool call — no merge triggered.
  - 3 parallel tool calls — collapse to one user message with 3 `tool_result` blocks.
  - Parallel tool results followed by a user text message — only the tool results merge; text stays in its own message.
- `ruff check`, `ruff format --check`, `pyright` — all clean on modified files.

### Note on pre-existing env issue

On `main`, 20 tests in `tests/api_snapshot_tests/test_anthropic.py` are failing locally with `APIConnectionError` due to a `respx` ↔ `AsyncAnthropic` httpx-transport compatibility issue. This is orthogonal to this PR; the new regression test uses the same `respx` pattern as existing tests and will recover together with them once the env issue is fixed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation. (No user-facing docs changed; this is a provider-layer wire-format fix. Confirmed with maintainer that doc updates are not needed.)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
