### PR TITLE
fix(soul): carry approval cancellation feedback to ApprovalResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended
+
 ## 1.37.0 (2026-04-20)
 
 - Print: Wait for background tasks before exiting — in one-shot `--print` mode, the process now waits for running background agents to finish and lets the model process their results, instead of exiting and killing them. The wait is capped at `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)` (default ceiling 1h); on timeout the tasks are killed and the model gets one more turn via a `<system-reminder>` to summarise before exit

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Shell：修复 approval 弹窗超时后被误报为 `Rejected by user` 的问题——300 秒安全超时后，工具调用会以 `Rejected: approval timed out` 拒绝，让离开电脑一段时间后回来的用户能分辨出这是超时而非自己的手动拒绝。经常长时间离开的话可以加 `--yolo`/`-y` 自动批准工具调用
+
 ## 1.37.0 (2026-04-20)
 
 - Print：退出前等待后台任务完成——在单次 `--print` 模式下，进程现在会等待仍在运行的后台 Agent 完成并让模型处理它们的结果，而不是直接退出并杀死它们。等待时长上限为 `min(max(active_task.timeout_s or agent_task_timeout_s), print_wait_ceiling_s)`（默认上限 1 小时）；超时后杀死任务并通过 `<system-reminder>` 给模型最后一轮机会向用户总结后再退出

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -177,7 +177,8 @@ class Approval:
                 tool_name=tool_call.function.name,
                 approval_mode="cancelled",
             )
-            return ApprovalResult(approved=False)
+            record = self._runtime.get_request(request_id)
+            return ApprovalResult(approved=False, feedback=record.feedback if record else "")
         from kimi_cli.telemetry import track
 
         match response:

--- a/tests/core/test_approval_runtime.py
+++ b/tests/core/test_approval_runtime.py
@@ -231,3 +231,49 @@ async def test_approval_runtime_wait_for_response_times_out() -> None:
     record = runtime.get_request(request.id)
     assert record is not None
     assert record.status == "cancelled"
+    assert record.feedback == "approval timed out"
+
+
+@pytest.mark.asyncio
+async def test_approval_request_timeout_carries_feedback_to_result() -> None:
+    """Timeout feedback must survive round-trip through ``Approval.request``.
+
+    Regression test: when the 300s ``wait_for_response`` safety timeout fires
+    (e.g. the user stepped away from their session), ``_cancel_request`` sets
+    ``record.feedback = "approval timed out"`` before raising
+    ``ApprovalCancelledError``. ``Approval.request`` must read that feedback
+    back into the returned ``ApprovalResult`` — otherwise the resulting
+    ``ToolRejectedError`` falls back to the generic "Rejected by user" brief,
+    hiding the timeout cause from the user.
+    """
+    from kimi_cli.soul.approval import Approval, ApprovalState
+    from kimi_cli.soul.toolset import current_tool_call
+    from kimi_cli.wire.types import ToolCall
+
+    runtime = ApprovalRuntime()
+    approval = Approval(state=ApprovalState(), runtime=runtime)
+
+    token = current_tool_call.set(
+        ToolCall(id="test", function=ToolCall.FunctionBody(name="Shell", arguments=None))
+    )
+    try:
+        request_task = asyncio.create_task(
+            approval.request(sender="Shell", action="shell_exec", description="ls")
+        )
+        while not runtime.list_pending():
+            await asyncio.sleep(0)
+        pending = runtime.list_pending()[0]
+        # Drive the timeout path directly instead of waiting 300s: this is
+        # the same internal call ``wait_for_response`` makes when its own
+        # timeout expires (runtime.py uses ``feedback="approval timed out"``).
+        runtime._cancel_request(pending.id, feedback="approval timed out")
+        result = await request_task
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is False
+    assert result.feedback == "approval timed out"
+    # The user-visible rejection surface reflects the real reason rather
+    # than the generic "Rejected by user" fallback.
+    err = result.rejection_error()
+    assert err.brief == "Rejected: approval timed out"


### PR DESCRIPTION
## Related Issue

Related to #1823 — addresses only the UX/display aspect described in the issue (the `Rejected by user` misleading message on timeout). Does **not** resolve #1823; the broader *configurable timeout* feature request is already being tracked by #1837.

## Description

### Bug

When the 300 s safety timeout in `ApprovalRuntime.wait_for_response` fires (e.g. the user stepped away from their SSH/tmux session), `_cancel_request` writes `request.feedback = "approval timed out"` to the record before raising `ApprovalCancelledError`:

```python
# src/kimi_cli/approval_runtime/runtime.py
self._cancel_request(request_id, feedback="approval timed out")
raise ApprovalCancelledError(request_id) from None
```

But the outer `Approval.request` was dropping that feedback:

```python
# Before
except ApprovalCancelledError:
    return ApprovalResult(approved=False)
```

With empty `feedback`, `ApprovalResult.rejection_error()` fell back to `ToolRejectedError()`'s default `Rejected by user` brief — so users returning to their terminal saw a message implying they had manually rejected the tool call, when they had just walked away.

### Fix

Read the feedback back from the record via the existing public `get_request` API:

```python
except ApprovalCancelledError:
    record = self._runtime.get_request(request_id)
    return ApprovalResult(approved=False, feedback=record.feedback if record else "")
```

After the fix, the rejection surface reads:

- **Brief:** `Rejected: approval timed out`
- **Message:** `The tool call is rejected by the user. User feedback: approval timed out`

The `if record else ""` fallback preserves pre-fix behavior for the theoretical `record is None` case, and the read-from-record approach keeps all cancel paths uniform without inflating `ApprovalCancelledError` with state.

### Tests

- Extended `test_approval_runtime_wait_for_response_times_out` to assert `record.feedback == "approval timed out"` after timeout (guards the upstream invariant the fix depends on).
- New regression test `test_approval_request_timeout_carries_feedback_to_result` exercising `Approval.request` through the cancellation path; asserts both `ApprovalResult.feedback` round-trips and `rejection_error().brief == "Rejected: approval timed out"`. Verified locally that reverting the fix makes this test fail with `AssertionError: assert '' == 'approval timed out'`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue (#1823, related not resolved).
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the changelog (root `CHANGELOG.md` + en/zh release-notes mirrors).
- [x] No user-facing docs changes needed (pure behavior fix; no new config, flag, or UI surface).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
