### PR TITLE
fix(term, app): prevent TTY hang on exit and close MCP connections during shutdown

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -27,6 +27,7 @@ from kimi_cli.soul import RunCancelled, run_soul
 from kimi_cli.soul.agent import Runtime, load_agent
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.soul.toolset import KimiToolset
 from kimi_cli.utils.aioqueue import QueueShutDown
 from kimi_cli.utils.envvar import get_env_bool
 from kimi_cli.utils.logging import logger, open_original_stderr, redirect_stderr_to_logger
@@ -414,6 +415,15 @@ class KimiCLI:
         # so it does not outlive the CLI process.
         if self._bg_refresh_task is not None and not self._bg_refresh_task.done():
             self._bg_refresh_task.cancel()
+
+        # Close MCP client connections so stdio/WebSocket transports do not
+        # outlive the CLI process and trigger firewall warnings.
+        try:
+            toolset = self.soul.agent.toolset
+            if isinstance(toolset, KimiToolset):
+                await toolset.cleanup()
+        except Exception:
+            logger.warning("Error during toolset cleanup; continuing exit", exc_info=True)
 
         bg_config = self._runtime.config.background
         if bg_config.keep_alive_on_exit:

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -422,7 +422,7 @@ class KimiCLI:
             toolset = self.soul.agent.toolset
             if isinstance(toolset, KimiToolset):
                 await toolset.cleanup()
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             logger.warning("Error during toolset cleanup; continuing exit", exc_info=True)
 
         bg_config = self._runtime.config.background

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -674,11 +674,14 @@ class KimiToolset:
         self._deferred_mcp_load = None
         if self._mcp_loading_task:
             self._mcp_loading_task.cancel()
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(Exception, asyncio.CancelledError):
                 await self._mcp_loading_task
         for server_info in self._mcp_servers.values():
             if server_info.client is not None:
-                await server_info.client.close()
+                try:
+                    await server_info.client.close()
+                except Exception:
+                    logger.warning("Failed to close MCP client", exc_info=True)
 
 
 @dataclass(slots=True)

--- a/src/kimi_cli/utils/term.py
+++ b/src/kimi_cli/utils/term.py
@@ -46,6 +46,10 @@ def ensure_tty_sane() -> None:
         return
 
     attrs[3] |= desired
+    # Reset VMIN/VTIME to canonical defaults so the terminal is not left
+    # in cbreak mode after a hang or crash in _cursor_position_unix().
+    attrs[6][termios.VMIN] = 1
+    attrs[6][termios.VTIME] = 0
     with contextlib.suppress(OSError):
         termios.tcsetattr(fd, termios.TCSADRAIN, attrs)
 
@@ -66,6 +70,10 @@ def _cursor_position_unix() -> tuple[int, int] | None:
 
     try:
         tty.setcbreak(fd)
+        # Make reads non-blocking so that asyncio cancellation (or a race
+        # with prompt_toolkit's own stdin reader) cannot leave us stuck in
+        # an uninterruptible os.read() syscall.
+        os.set_blocking(fd, False)
         sys.stdout.write(_CURSOR_QUERY)
         sys.stdout.flush()
 
@@ -78,6 +86,8 @@ def _cursor_position_unix() -> tuple[int, int] | None:
                 continue
             try:
                 chunk = os.read(fd, 32)
+            except BlockingIOError:
+                continue
             except OSError:
                 break
             if not chunk:
@@ -87,6 +97,8 @@ def _cursor_position_unix() -> tuple[int, int] | None:
             if match:
                 return int(match.group(1)), int(match.group(2))
     finally:
+        with contextlib.suppress(OSError):
+            os.set_blocking(fd, True)
         termios.tcsetattr(fd, termios.TCSADRAIN, oldterm)
 
     return None

--- a/src/kimi_cli/utils/term.py
+++ b/src/kimi_cli/utils/term.py
@@ -67,12 +67,14 @@ def _cursor_position_unix() -> tuple[int, int] | None:
 
     fd = sys.stdin.fileno()
     oldterm = termios.tcgetattr(fd)
+    was_blocking = True
 
     try:
         tty.setcbreak(fd)
         # Make reads non-blocking so that asyncio cancellation (or a race
         # with prompt_toolkit's own stdin reader) cannot leave us stuck in
         # an uninterruptible os.read() syscall.
+        was_blocking = os.get_blocking(fd)
         os.set_blocking(fd, False)
         sys.stdout.write(_CURSOR_QUERY)
         sys.stdout.flush()
@@ -98,7 +100,7 @@ def _cursor_position_unix() -> tuple[int, int] | None:
                 return int(match.group(1)), int(match.group(2))
     finally:
         with contextlib.suppress(OSError):
-            os.set_blocking(fd, True)
+            os.set_blocking(fd, was_blocking)
         termios.tcsetattr(fd, termios.TCSADRAIN, oldterm)
 
     return None


### PR DESCRIPTION
Fixes #1984

## 变更内容 / Changes

### 1. `src/kimi_cli/utils/term.py`

- **`_cursor_position_unix()`**：在 `tty.setcbreak(fd)` 之后添加 `os.set_blocking(fd, False)`，使 `os.read()` 变为非阻塞调用。这样即使 asyncio 任务被取消，或 `prompt_toolkit` 的 stdin reader 与 CPR 响应发生竞争，`os.read()` 也不会陷入不可中断的系统调用阻塞。`finally` 块中恢复阻塞模式，确保终端状态正确还原。

- **`_cursor_position_unix()`**: Added `os.set_blocking(fd, False)` after `tty.setcbreak(fd)` to make `os.read()` non-blocking. This prevents the syscall from getting stuck in an uninterruptible blocking state during asyncio task cancellation or when `prompt_toolkit`'s stdin reader races for the CPR response. Blocking mode is restored in the `finally` block.

- **`ensure_tty_sane()`**：在恢复 `c_lflag` 标志位后，额外重置 `c_cc[VMIN]` 和 `c_cc[VTIME]` 为默认值（1 和 0）。此前若进程在 cbreak 模式下崩溃或挂起，终端会保持在 `VMIN=1, VTIME=0` 状态，导致 Ctrl+C 发送原始字节而非 SIGINT。

- **`ensure_tty_sane()`**: Resets `c_cc[VMIN]` and `c_cc[VTIME]` to defaults (1 and 0) after restoring `c_lflag` flags. Previously, if the process crashed or hung in cbreak mode, the terminal remained in `VMIN=1, VTIME=0`, causing Ctrl+C to emit raw bytes instead of SIGINT.

### 2. `src/kimi_cli/app.py`

- **`shutdown_background_tasks()`**：在取消后台刷新任务后，调用 `KimiToolset.cleanup()` 关闭所有 `fastmcp.Client` 连接。此前该方法从未被调用，导致 stdio/WebSocket 传输在 CLI 进程退出后仍保持连接，触发系统防火墙关于孤立连接的警告。

- **`shutdown_background_tasks()`**: Calls `KimiToolset.cleanup()` after cancelling the background refresh task to close all `fastmcp.Client` connections. Previously this method was never invoked, leaving stdio/WebSocket transports connected after the CLI process exited and triggering system firewall warnings about orphaned connections.

## 测试 / Testing

- `pyright src/kimi_cli/utils/term.py src/kimi_cli/app.py`：0 errors, 0 warnings
- `ruff check src/kimi_cli/utils/term.py src/kimi_cli/app.py`：All checks passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
