### PR TITLE
fix(install): fix uv not found error on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,6 +2,11 @@ $ErrorActionPreference = "Stop"
 
 function Install-Uv {
   Invoke-RestMethod -Uri "https://astral.sh/uv/install.ps1" | Invoke-Expression
+
+  # Update the PATH environment variable for the current session
+  $MachinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $env:PATH = "$($MachinePath.TrimEnd(';'));$($UserPath.TrimEnd(';'))"
 }
 
 if (Get-Command uv -ErrorAction SilentlyContinue) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,8 +5,10 @@ function Install-Uv {
 
   # Update the PATH environment variable for the current session
   $MachinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  if (-not $MachinePath) { $MachinePath = '' }
   $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-  $env:PATH = "$($MachinePath.TrimEnd(';'));$($UserPath.TrimEnd(';'))"
+  if (-not $UserPath) { $UserPath = '' }
+  $env:PATH = "$($MachinePath.TrimEnd(';'));$($UserPath.TrimEnd(';'))".Split(';', [System.StringSplitOptions]::RemoveEmptyEntries) -join ';'
 }
 
 if (Get-Command uv -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

Related to #1107 and #1108, but for Windows.

## Description

If uv is installed to a new directory (typically `C:\Users\<username>\.local\bin`, but it may vary), and the directory is not in `$env:PATH`, the install script would complain: `Error: uv not found after installation.`.

This PR resolves this by reconstructing `$env:PATH` from the Windows registry, which uv's install script always updates.

Manually tested.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/1993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
