### PR TITLE
fix(proxy): strip unsupported IPv6 CIDRs from NO_PROXY

### DIFF
--- a/src/kimi_cli/utils/proxy.py
+++ b/src/kimi_cli/utils/proxy.py
@@ -32,12 +32,16 @@ def _is_unsupported_ipv6_cidr(value: str) -> bool:
 
 
 def normalize_proxy_env() -> None:
-    """Rewrite ``socks://`` to ``socks5://`` in proxy environment variables.
+    """Normalize proxy environment variables for downstream HTTP clients.
 
     Many proxy tools (V2RayN, Clash, etc.) set ``ALL_PROXY=socks://...``, but
-    httpx and aiohttp only recognise ``socks5://``.  Since ``socks://`` is
-    effectively an alias for ``socks5://``, this function performs a safe
-    in-place replacement so that downstream HTTP clients work correctly.
+    httpx and aiohttp only recognise ``socks5://``. Since ``socks://`` is
+    effectively an alias for ``socks5://``, rewrite those values in place.
+
+    When a proxy is configured, current httpx releases can also crash during
+    startup if ``NO_PROXY`` contains IPv6 CIDR entries such as ``fd00::/8``.
+    Filter those unsupported patterns while preserving host-style entries like
+    ``::1``.
     """
     for var in _PROXY_ENV_VARS:
         value = os.environ.get(var)

--- a/src/kimi_cli/utils/proxy.py
+++ b/src/kimi_cli/utils/proxy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 
 _PROXY_ENV_VARS = (
@@ -12,9 +13,22 @@ _PROXY_ENV_VARS = (
     "HTTPS_PROXY",
     "https_proxy",
 )
+_NO_PROXY_ENV_VARS = ("NO_PROXY", "no_proxy")
 
 _SOCKS_PREFIX = "socks://"
 _SOCKS5_PREFIX = "socks5://"
+
+
+def _is_unsupported_ipv6_cidr(value: str) -> bool:
+    if ":" not in value or "/" not in value:
+        return False
+
+    try:
+        network = ipaddress.ip_network(value, strict=False)
+    except ValueError:
+        return False
+
+    return isinstance(network, ipaddress.IPv6Network)
 
 
 def normalize_proxy_env() -> None:
@@ -29,3 +43,13 @@ def normalize_proxy_env() -> None:
         value = os.environ.get(var)
         if value is not None and value.lower().startswith(_SOCKS_PREFIX):
             os.environ[var] = _SOCKS5_PREFIX + value[len(_SOCKS_PREFIX) :]
+
+    for var in _NO_PROXY_ENV_VARS:
+        value = os.environ.get(var)
+        if value is None:
+            continue
+
+        hosts = [host.strip() for host in value.split(",")]
+        filtered_hosts = [host for host in hosts if not _is_unsupported_ipv6_cidr(host)]
+        if filtered_hosts != hosts:
+            os.environ[var] = ",".join(host for host in filtered_hosts if host)

--- a/tests/utils/test_proxy.py
+++ b/tests/utils/test_proxy.py
@@ -96,5 +96,5 @@ class TestNormalizeProxyEnv:
 
         normalize_proxy_env()
 
-        client = httpx.Client()
-        client.close()
+        with httpx.Client() as client:
+            assert client is not None

--- a/tests/utils/test_proxy.py
+++ b/tests/utils/test_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import httpx
 import pytest
 
 from kimi_cli.utils.proxy import normalize_proxy_env
@@ -74,3 +75,26 @@ class TestNormalizeProxyEnv:
         monkeypatch.setenv("ALL_PROXY", "Socks://127.0.0.1:10808/")
         normalize_proxy_env()
         assert os.environ["ALL_PROXY"] == "socks5://127.0.0.1:10808/"
+
+    def test_ipv6_cidr_in_no_proxy_does_not_break_httpx(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for var in (
+            "ALL_PROXY",
+            "all_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:8080")
+        monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1,::1,fd00::/8,fe80::/10")
+
+        normalize_proxy_env()
+
+        client = httpx.Client()
+        client.close()


### PR DESCRIPTION
## Related Issue

Resolve #1959

## Description

- Strip unsupported IPv6 CIDR entries from `NO_PROXY` / `no_proxy` before `httpx` client initialization.
- Preserve valid non-CIDR entries such as `localhost`, `127.0.0.1`, and `::1`.
- Add a regression test that reproduces the proxy + IPv6 CIDR startup crash path.

### Verification

- `uv run pytest tests/utils/test_proxy.py`
- `uv run ruff check src/kimi_cli/utils/proxy.py tests/utils/test_proxy.py`
- Reproduced the original environment shape with `HTTP_PROXY=http://127.0.0.1:7890` and `NO_PROXY=localhost,127.0.0.1,::1,fd00::/8,fe80::/10`; `httpx.Client()` now initializes successfully after normalization.
- `make test`

### Notes

- `make ai-test` currently fails on the existing `tests_ai/scripts/main.yaml` reference to `kimi_cli.tools.multiagent:Task`, which is unrelated to this change.
- `make check` still reports existing non-blocking `ty` diagnostics and fails on pre-existing web Biome lint errors in `web/src/features/chat/components/approval-dialog.tsx` and `web/src/features/chat/components/session-files-panel.tsx`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
