### PR TITLE
test(background): fix flaky approval-wait tests via wait_for_status

### DIFF
--- a/src/kimi_cli/background/manager.py
+++ b/src/kimi_cli/background/manager.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import signal
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -50,6 +52,12 @@ class BackgroundTaskManager:
         self._runtime: Runtime | None = None
         self._live_agent_tasks: dict[str, asyncio.Task[None]] = {}
         self._completion_event: asyncio.Event = asyncio.Event()
+        # Per-task futures awakened whenever a status transition is observed.
+        # Populated by wait_for_status() and resolved by _notify_status_changed().
+        self._status_waiters: dict[str, list[asyncio.Future[None]]] = {}
+        # Lazily-captured event loop so _notify_status_changed can be called
+        # from threads (via asyncio.to_thread) and still reach waiters.
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     @property
     def completion_event(self) -> asyncio.Event:
@@ -344,6 +352,135 @@ class BackgroundTaskManager:
                 return view
             await asyncio.sleep(self._config.wait_poll_interval_ms / 1000)
 
+    async def wait_for_status(
+        self,
+        task_id: str,
+        target: TaskStatus | Callable[[TaskStatus], bool],
+        *,
+        timeout_s: float = 5.0,
+    ) -> TaskView:
+        """Await until the task's status matches ``target``, or raise ``TimeoutError``.
+
+        ``target`` is either a specific ``TaskStatus`` or a predicate over the
+        current status. The wait is event-driven: the ``_mark_task_*`` writers
+        on *this* manager instance call :meth:`_notify_status_changed` after
+        updating the store, which resolves any pending futures registered here.
+
+        Scope (important):
+            This primitive only observes transitions that are produced by
+            ``_mark_task_*`` on the same manager instance. It is intended for
+            agent-task transitions driven in-process by ``BackgroundAgentRunner``
+            (notably ``"awaiting_approval"`` and the terminal statuses emitted
+            by ``_mark_task_{completed,failed,killed,timed_out}``).
+
+            Transitions written directly through the store bypass the notifier
+            and will NOT wake waiters here. Known bypass paths include:
+
+            * bash worker process updates to ``runtime.json`` (a separate
+              process; heartbeats, exit status, etc.)
+            * initial ``"starting"`` writes in ``create_bash_task`` and
+              ``create_agent_task``
+            * ``recover()`` writes of ``"lost"``/``"killed"`` for orphaned
+              tasks on startup
+
+            For observing statuses produced by any of those paths, use
+            :meth:`wait` (polling-based, terminal-only) instead.
+        """
+        if callable(target):
+            predicate: Callable[[TaskStatus], bool] = target
+        else:
+            target_status = target
+
+            def _match(status: TaskStatus) -> bool:
+                return status == target_status
+
+            predicate = _match
+
+        loop = asyncio.get_running_loop()
+        self._loop = loop  # lazy capture so thread-side notifiers can reach us
+        deadline = loop.time() + timeout_s
+        while True:
+            # Register the waiter BEFORE reading the store, so a notification
+            # that fires between our read and the registration cannot be lost.
+            # If the target was already reached (or reached between registration
+            # and this check), the post-registration merged_view below returns
+            # it immediately.
+            fut: asyncio.Future[None] = loop.create_future()
+            waiters = self._status_waiters.setdefault(task_id, [])
+            waiters.append(fut)
+            try:
+                view = self._store.merged_view(task_id)
+                if predicate(view.runtime.status):
+                    return view
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Timed out after {timeout_s}s waiting for status on task "
+                        f"{task_id!r}; current status: {view.runtime.status!r}"
+                    )
+                try:
+                    await asyncio.wait_for(fut, timeout=remaining)
+                except TimeoutError:
+                    # Loop around for a final predicate check; if still not
+                    # matching, the remaining<=0 branch above raises with a
+                    # descriptive message.
+                    continue
+            finally:
+                # Drop our future from the waiter list so timed-out or cancelled
+                # waits don't accumulate stale entries. _resolve_status_waiters
+                # pops the whole list, so if it already fired this is a no-op.
+                current = self._status_waiters.get(task_id)
+                if current is not None:
+                    with contextlib.suppress(ValueError):
+                        current.remove(fut)
+                    if not current:
+                        self._status_waiters.pop(task_id, None)
+                # If we're returning via an early predicate-match (or any other
+                # path that never awaited the future), cancel it so it doesn't
+                # get GC'd while still pending and emit 'Future was destroyed
+                # but it is pending!' via the loop's exception handler.
+                if not fut.done():
+                    fut.cancel()
+
+    def _notify_status_changed(self, task_id: str) -> None:
+        """Wake any :meth:`wait_for_status` waiters for this task.
+
+        Safe to call from the event loop or from another thread (e.g. via
+        ``asyncio.to_thread``). If the manager has not yet observed its event
+        loop (no ``wait_for_status`` call has been made), the notification is a
+        no-op because there cannot be any waiters.
+        """
+        # Use getattr so minimally-constructed instances (e.g. test harnesses
+        # that bypass __init__) cannot turn a best-effort notification into a
+        # real AttributeError.
+        if not getattr(self, "_status_waiters", None):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = getattr(self, "_loop", None)
+            if loop is None or loop.is_closed():
+                return
+            # call_soon_threadsafe can still race with loop shutdown and raise
+            # RuntimeError if the loop is closed between the check above and
+            # the scheduling call. Treat that as a best-effort no-op so a
+            # background agent_runner thread does not surface a spurious error.
+            try:
+                loop.call_soon_threadsafe(self._resolve_status_waiters, task_id)
+            except RuntimeError:
+                return
+            return
+        self._loop = loop
+        self._resolve_status_waiters(task_id)
+
+    def _resolve_status_waiters(self, task_id: str) -> None:
+        waiters = getattr(self, "_status_waiters", None)
+        if waiters is None:
+            return
+        for fut in waiters.pop(task_id, []):
+            if not fut.done():
+                fut.set_result(None)
+
     def _best_effort_kill(self, runtime: TaskRuntime) -> None:
         try:
             if os.name == "nt":
@@ -624,6 +761,7 @@ class BackgroundTaskManager:
             task_id=task_id,
             ts=runtime.updated_at,
         )
+        self._notify_status_changed(task_id)
 
     def _mark_task_awaiting_approval(self, task_id: str, reason: str) -> None:
         runtime = self._store.read_runtime(task_id)
@@ -633,6 +771,7 @@ class BackgroundTaskManager:
         runtime.updated_at = time.time()
         runtime.failure_reason = reason
         self._store.write_runtime(task_id, runtime)
+        self._notify_status_changed(task_id)
 
     def _mark_task_completed(self, task_id: str) -> None:
         runtime = self._store.read_runtime(task_id)
@@ -655,6 +794,7 @@ class BackgroundTaskManager:
             finished_at=runtime.finished_at,
             started_at=runtime.started_at,
         )
+        self._notify_status_changed(task_id)
         from kimi_cli.telemetry import track
 
         if runtime.started_at and runtime.finished_at:
@@ -670,6 +810,7 @@ class BackgroundTaskManager:
         runtime.finished_at = runtime.updated_at
         runtime.failure_reason = reason
         self._store.write_runtime(task_id, runtime)
+        self._notify_status_changed(task_id)
         from kimi_cli.telemetry import track
 
         if runtime.started_at and runtime.finished_at:
@@ -692,6 +833,7 @@ class BackgroundTaskManager:
         runtime.timed_out = True
         runtime.failure_reason = reason
         self._store.write_runtime(task_id, runtime)
+        self._notify_status_changed(task_id)
         from kimi_cli.telemetry import track
 
         if runtime.started_at and runtime.finished_at:
@@ -713,6 +855,7 @@ class BackgroundTaskManager:
         runtime.interrupted = True
         runtime.failure_reason = reason
         self._store.write_runtime(task_id, runtime)
+        self._notify_status_changed(task_id)
         from kimi_cli.telemetry import track
 
         if runtime.started_at and runtime.finished_at:

--- a/tests/background/test_manager.py
+++ b/tests/background/test_manager.py
@@ -1173,3 +1173,248 @@ async def test_manager_surfaces_timeout_failure(runtime):
     assert waited.runtime.interrupted is True
     assert waited.runtime.timed_out is True
     assert waited.runtime.failure_reason == "Command timed out after 1s"
+
+
+# ---------------------------------------------------------------------------
+# wait_for_status primitive
+# ---------------------------------------------------------------------------
+
+
+def _seed_running_task(manager, task_id: str) -> None:
+    """Persist a minimal 'running' agent task directly to the store."""
+    spec = TaskSpec(
+        id=task_id,
+        kind="agent",
+        session_id=manager._session.id,
+        description="wait_for_status test",
+        tool_call_id=f"tc-{task_id}",
+    )
+    manager.store.create_task(spec)
+    manager.store.write_runtime(task_id, TaskRuntime(status="running", updated_at=time.time()))
+
+
+async def test_wait_for_status_returns_immediately_when_already_matching(runtime):
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00001")
+
+    view = await manager.wait_for_status("wfs00001", "running", timeout_s=1)
+    assert view.runtime.status == "running"
+
+
+async def test_wait_for_status_wakes_on_transition_event(runtime):
+    """wait_for_status must return as soon as _mark_task_* writes the target status."""
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00002")
+
+    async def _flip_later() -> None:
+        await asyncio.sleep(0.01)
+        manager._mark_task_awaiting_approval("wfs00002", "please approve")
+
+    flipper = asyncio.create_task(_flip_later())
+    try:
+        view = await manager.wait_for_status("wfs00002", "awaiting_approval", timeout_s=2)
+    finally:
+        await flipper
+
+    assert view.runtime.status == "awaiting_approval"
+
+
+async def test_wait_for_status_times_out_when_never_matching(runtime):
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00003")
+
+    with pytest.raises(TimeoutError, match="Timed out"):
+        await manager.wait_for_status("wfs00003", "awaiting_approval", timeout_s=0.05)
+
+
+async def test_wait_for_status_notifies_across_thread_boundary(runtime):
+    """Simulate _mark_task_* being called from asyncio.to_thread; the waiter must wake."""
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00004")
+
+    async def _flip_via_thread() -> None:
+        await asyncio.sleep(0.01)
+        await asyncio.to_thread(manager._mark_task_awaiting_approval, "wfs00004", "x")
+
+    flipper = asyncio.create_task(_flip_via_thread())
+    try:
+        view = await manager.wait_for_status("wfs00004", "awaiting_approval", timeout_s=2)
+    finally:
+        await flipper
+
+    assert view.runtime.status == "awaiting_approval"
+
+
+async def test_wait_for_status_does_not_leave_pending_future_on_early_return(runtime):
+    """Early predicate-match returns must not leave a pending Future behind.
+
+    A Future that is registered but never awaited would otherwise be GC'd
+    in pending state and emit a ``Future was destroyed but it is pending!``
+    message via the loop's exception handler.
+    """
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00010")  # status == 'running' already matches
+
+    loop = asyncio.get_running_loop()
+    original_create_future = loop.create_future
+    created: list[asyncio.Future[None]] = []
+
+    def capturing_create_future() -> asyncio.Future[None]:
+        fut = original_create_future()
+        created.append(fut)
+        return fut
+
+    loop.create_future = capturing_create_future  # type: ignore[method-assign]
+    try:
+        view = await manager.wait_for_status("wfs00010", "running", timeout_s=1)
+    finally:
+        loop.create_future = original_create_future  # type: ignore[method-assign]
+
+    assert view.runtime.status == "running"
+    assert created, "wait_for_status should have created at least one Future"
+    for fut in created:
+        assert fut.done(), f"Future {fut!r} left pending after early return"
+
+
+async def test_wait_for_status_no_lost_wakeup_between_read_and_register(runtime):
+    """A notification that fires between the store read and future registration
+    must not be lost. The waiter registers before reading, so either the
+    post-registration read returns the new status, or the pending future is
+    resolved by the notification.
+    """
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00008")
+
+    original_merged_view = manager._store.merged_view
+    fired = {"done": False}
+
+    def racing_merged_view(task_id: str):
+        view = original_merged_view(task_id)
+        # Simulate a concurrent transition happening after this read but before
+        # the waiter gets a chance to await the future. With the pre-registration
+        # design, the NEXT loop iteration's merged_view will observe the new
+        # status (because we ran _mark_task_* synchronously here).
+        if task_id == "wfs00008" and not fired["done"]:
+            fired["done"] = True
+            manager._mark_task_awaiting_approval("wfs00008", "raced")
+        return view
+
+    manager._store.merged_view = racing_merged_view  # type: ignore[method-assign]
+    try:
+        view = await manager.wait_for_status("wfs00008", "awaiting_approval", timeout_s=2)
+    finally:
+        manager._store.merged_view = original_merged_view  # type: ignore[method-assign]
+
+    assert view.runtime.status == "awaiting_approval"
+    assert fired["done"]
+
+
+async def test_wait_for_status_cleans_up_future_on_timeout(runtime):
+    """Timed-out waits must not leak futures into _status_waiters."""
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00006")
+
+    for _ in range(3):
+        with pytest.raises(TimeoutError):
+            await manager.wait_for_status("wfs00006", "awaiting_approval", timeout_s=0.02)
+
+    assert "wfs00006" not in manager._status_waiters
+
+
+async def test_wait_for_status_cleans_up_future_on_cancellation(runtime):
+    """Cancelled waits must also remove their future from _status_waiters."""
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00007")
+
+    waiter = asyncio.create_task(
+        manager.wait_for_status("wfs00007", "awaiting_approval", timeout_s=5)
+    )
+
+    # Deterministically wait for the waiter task to register its future
+    # instead of sleeping for a fixed duration (which can race on slow CI).
+    async def _await_registration() -> None:
+        while not manager._status_waiters.get("wfs00007"):
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_await_registration(), timeout=2)
+    assert manager._status_waiters.get("wfs00007")  # registered
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert "wfs00007" not in manager._status_waiters
+
+
+async def test_notify_status_changed_is_noop_when_loop_is_closed(runtime):
+    """A background thread notifying after loop shutdown must not raise.
+
+    Simulates the agent_runner thread path: we capture the loop (as
+    wait_for_status would), close it, then invoke _notify_status_changed
+    from a non-loop thread. With a closed loop, the notification must be
+    a best-effort no-op even if call_soon_threadsafe would otherwise raise.
+
+    The test seeds _status_waiters with a real pending future so the early
+    ``not _status_waiters`` short-circuit doesn't fire; the function must
+    actually reach the loop.is_closed() guard in the thread-path branch.
+    """
+    import threading
+
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00009")
+
+    # Create the future on the fake loop BEFORE closing it (create_future
+    # on a closed loop would itself raise).
+    fake_loop = asyncio.new_event_loop()
+    fut: asyncio.Future[None] = fake_loop.create_future()
+    fake_loop.close()
+
+    original_loop = manager._loop
+    manager._loop = fake_loop
+    manager._status_waiters["wfs00009"] = [fut]
+
+    error: list[BaseException] = []
+
+    def _notify() -> None:
+        try:
+            manager._notify_status_changed("wfs00009")
+        except BaseException as exc:  # noqa: BLE001
+            error.append(exc)
+
+    try:
+        thread = threading.Thread(target=_notify)
+        thread.start()
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+        assert not error, f"_notify_status_changed raised: {error!r}"
+        # Future is left unresolved because the loop is closed; that's the
+        # best-effort semantics we're asserting.
+        assert not fut.done()
+    finally:
+        # Restore the manager to a clean state so later tests on the same
+        # fixture instance don't inherit our closed fake loop or leftover
+        # waiter registration.
+        manager._loop = original_loop
+        manager._status_waiters.pop("wfs00009", None)
+
+
+async def test_wait_for_status_accepts_predicate(runtime):
+    """Predicate form supports awaiting any of multiple target statuses."""
+    manager = runtime.background_tasks
+    _seed_running_task(manager, "wfs00005")
+
+    async def _complete_later() -> None:
+        await asyncio.sleep(0.01)
+        manager._mark_task_completed("wfs00005")
+
+    flipper = asyncio.create_task(_complete_later())
+    try:
+        view = await manager.wait_for_status(
+            "wfs00005",
+            lambda s: s in ("awaiting_approval", "completed"),
+            timeout_s=2,
+        )
+    finally:
+        await flipper
+
+    assert view.runtime.status == "completed"

--- a/tests/tools/test_agent_tool.py
+++ b/tests/tools/test_agent_tool.py
@@ -978,16 +978,9 @@ async def test_agent_tool_background_agent_waits_for_approval(agent_tool, runtim
         assert msg.source_kind == "background_agent"
         assert msg.source_id == task_id
 
-        view = None
-        for _ in range(20):
-            view = runtime.background_tasks.get_task(task_id)
-            assert view is not None
-            if view.runtime.status == "awaiting_approval":
-                break
-            import asyncio
-
-            await asyncio.sleep(0.01)
-        assert view is not None
+        view = await runtime.background_tasks.wait_for_status(
+            task_id, "awaiting_approval", timeout_s=2
+        )
         assert view.runtime.status == "awaiting_approval"
 
         assert runtime.approval_runtime is not None
@@ -1050,16 +1043,7 @@ async def test_task_stop_kills_background_agent_waiting_for_approval(
     assert not result.is_error
     task_id = _extract_task_id(result.output)
 
-    import asyncio
-
-    view = None
-    for _ in range(20):
-        view = runtime.background_tasks.get_task(task_id)
-        assert view is not None
-        if view.runtime.status == "awaiting_approval":
-            break
-        await asyncio.sleep(0.01)
-    assert view is not None
+    view = await runtime.background_tasks.wait_for_status(task_id, "awaiting_approval", timeout_s=2)
     assert view.runtime.status == "awaiting_approval"
 
     stop_result = await task_stop_tool(task_stop_tool.params(task_id=task_id))


### PR DESCRIPTION
## Related Issue

N/A

## Description

Two tests in test_agent_tool.py polled task status with tight 200ms budgets (20 iterations of 10ms sleeps), which flake on slow runners. The status transition goes through an asyncio.create_task + asyncio.to_thread hop in BackgroundAgentRunner._apply_approval_runtime_event, so the wire-visible tool-call publication can race ahead of the on-disk status flip.

Add an event-driven wait_for_status primitive on BackgroundTaskManager: each _mark_task_* writer now calls _notify_status_changed, which resolves any futures registered by concurrent wait_for_status calls. This avoids changing production behavior while giving tests a deterministic observation point for non-terminal transitions (e.g. 'awaiting_approval').

Replace the polling loops in:
  - test_agent_tool_background_agent_waits_for_approval
  - test_task_stop_kills_background_agent_waiting_for_approval with wait_for_status(task_id, 'awaiting_approval', timeout_s=2).

Add unit tests covering the new primitive: immediate return, transition event wake-up, timeout, thread-boundary notification, and predicate form.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
