### PR TITLE
chore(release): bump kimi-cli to 1.38.0 and kosong to 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.38.0 (2026-04-22)
+
 - Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended
 - Auth: Fix OAuth users being forced to `/login` again after an unrelated refresh-token rotation race — when a concurrently-running kimi-cli instance (terminal, VS Code extension, or `kimi -p` one-shot) legitimately rotated the refresh token, the current instance's now-stale refresh request would come back with a 401, and a TOCTOU window between the "did another instance rotate?" disk check and the `delete_tokens` call could wipe the credentials file even though a valid rotated token was about to be written to it; the in-memory cache is still cleared so truly revoked tokens surface on the next request, but the file is preserved so a concurrent instance's freshly-rotated token can be recovered, and an eventual `/login` still overwrites it atomically
 - Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+## 1.38.0 (2026-04-22)
+
 - Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended
 - Auth: Fix OAuth users being forced to `/login` again after an unrelated refresh-token rotation race — when a concurrently-running kimi-cli instance (terminal, VS Code extension, or `kimi -p` one-shot) legitimately rotated the refresh token, the current instance's now-stale refresh request would come back with a 401, and a TOCTOU window between the "did another instance rotate?" disk check and the `delete_tokens` call could wipe the credentials file even though a valid rotated token was about to be written to it; the in-memory cache is still cleared so truly revoked tokens surface on the next request, but the file is preserved so a concurrent instance's freshly-rotated token can be recovered, and an eventual `/login` still overwrites it atomically
 - Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 1.38.0 (2026-04-22)
+
 - Shell：修复 approval 弹窗超时后被误报为 `Rejected by user` 的问题——300 秒安全超时后，工具调用会以 `Rejected: approval timed out` 拒绝，让离开电脑一段时间后回来的用户能分辨出这是超时而非自己的手动拒绝。经常长时间离开的话可以加 `--yolo`/`-y` 自动批准工具调用
 - Auth：修复 OAuth 用户因并发实例的 refresh token 轮换竞态被反复要求 `/login` 的问题——当另一个并发运行的 kimi-cli 实例（终端、VS Code 插件或 `kimi -p` 一次性命令）合法地轮换了 refresh token，当前实例手里过期的 refresh 请求会从服务端拿回 401，“别的实例是否刚轮换过”的磁盘检查与 `delete_tokens` 调用之间存在 TOCTOU 竞态，即使磁盘上马上会被写入一份有效的新 token，凭证文件也会被误删，迫使用户重新登录；现在依旧清理内存缓存（真正失效的 token 会在下一次请求时浮现），但保留文件，让并发实例刚写入的新 token 有机会被恢复，最终的 `/login` 仍会原子覆盖该文件
 - Kosong：修复 Anthropic 供应商将并行工具结果拆分到多个 user message 的问题——现在会将仅包含工具结果的连续 user message 合并为单条消息，以符合 Anthropic Messages API 规范（assistant 一轮中的所有 `tool_use` 必须在同一条 user message 内回答）；修复了严格兼容后端（如 DeepSeek `/anthropic` 接口）返回 400 错误的问题，并避免官方后端静默地引导模型放弃并行工具调用

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.37.0"
+version = "1.38.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.37.0"]
+dependencies = ["kimi-cli==1.38.0"]
 
 [project.scripts]
 kimi-code = "kimi_cli.__main__:main"

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.51.0 (2026-04-22)
+
 - Anthropic: Fix parallel tool results being split into multiple user messages — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
 
 ## 0.50.0 (2026-04-17)

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kosong"
-version = "0.50.0"
+version = "0.51.0"
 description = "The LLM abstraction layer for modern AI agent applications."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.37.0"
+version = "1.38.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -9,7 +9,7 @@ dependencies = [
     "aiofiles>=24.0,<26.0",
     "aiohttp==3.13.3",
     "typer==0.21.1",
-    "kosong[contrib]==0.50.0",
+    "kosong[contrib]==0.51.0",
     # loguru stays >=0.6.0 because notify-py (via batrachian-toad) caps it at <=0.6.0 on 3.14+.
     "loguru>=0.6.0,<0.8",
     "prompt-toolkit==3.0.52",

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.37.0"
+version = "1.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1300,7 +1300,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.37.0"
+version = "1.38.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },
@@ -1346,7 +1346,7 @@ dev = [
 
 [[package]]
 name = "kosong"
-version = "0.50.0"
+version = "0.51.0"
 source = { editable = "packages/kosong" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump **kimi-cli** and **kimi-code** from `1.37.0` to `1.38.0`
- Bump **kosong** from `0.50.0` to `0.51.0` (root `kosong[contrib]==0.51.0` pin updated)
- Promote CHANGELOG `Unreleased` entries under dated version headers in both the root and `packages/kosong`
- Sync `docs/en/release-notes/changelog.md` via `sync-changelog.mjs` and align `docs/zh/release-notes/changelog.md`
- Refresh `uv.lock`

### Release contents

**kimi-cli 1.38.0**
- Shell: Fix `Rejected by user` misleading message when an approval modal times out
- Auth: Fix OAuth users being forced to `/login` after an unrelated refresh-token rotation race
- Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider

**kosong 0.51.0**
- Anthropic: Fix parallel tool results being split into multiple user messages (see above)

No changes in `packages/kaos` or `sdks/kimi-sdk`, so those packages are not released this round.

## Test plan

- [ ] CI passes (version tag checks, dependency pin checks, lint/type/tests)
- [ ] After merge, tag `1.38.0` for kimi-cli + kimi-code and `kosong-0.51.0` for kosong; push tags to trigger release workflows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
