### PR TITLE
fix(shell): handle undecodable git output in @ file mention

### DIFF
--- a/src/kimi_cli/utils/file_filter.py
+++ b/src/kimi_cli/utils/file_filter.py
@@ -145,7 +145,16 @@ def git_index_mtime(root: Path) -> float | None:
         return None
 
 
-def _parse_ls_files_output(stdout: str, *, filter_ignored: bool = True) -> list[str]:
+def _decode_git_output(stdout: bytes | str | None) -> str:
+    """Decode git subprocess output without relying on the OS locale."""
+    if stdout is None:
+        return ""
+    if isinstance(stdout, bytes):
+        return stdout.decode("utf-8", errors="surrogateescape")
+    return stdout
+
+
+def _parse_ls_files_output(stdout: bytes | str | None, *, filter_ignored: bool = True) -> list[str]:
     """Parse NUL-delimited ``git ls-files -z`` output into paths with synthesised dirs.
 
     When *filter_ignored* is *True*, paths whose segments match
@@ -155,7 +164,8 @@ def _parse_ls_files_output(stdout: str, *, filter_ignored: bool = True) -> list[
     paths: list[str] = []
     seen_dirs: set[str] = set()
     ignored_prefixes: set[str] = set()
-    for entry in stdout.split("\0"):
+    decoded = _decode_git_output(stdout)
+    for entry in decoded.split("\0"):
         if not entry:
             continue
 
@@ -192,11 +202,10 @@ def _git_deleted_files(root: Path, scope: str | None = None) -> set[str]:
             cmd,
             cwd=root,
             capture_output=True,
-            text=True,
             timeout=_GIT_LS_FILES_TIMEOUT,
         )
         if result.returncode == 0:
-            return {e for e in result.stdout.split("\0") if e}
+            return {e for e in _decode_git_output(result.stdout).split("\0") if e}
     except Exception:
         pass
     return set()
@@ -235,7 +244,6 @@ def list_files_git(
             cmd,
             cwd=root,
             capture_output=True,
-            text=True,
             timeout=_GIT_LS_FILES_TIMEOUT,
         )
         if result.returncode != 0:
@@ -264,7 +272,6 @@ def list_files_git(
                 others_cmd,
                 cwd=root,
                 capture_output=True,
-                text=True,
                 timeout=_GIT_LS_FILES_TIMEOUT,
             )
             if others.returncode == 0:

--- a/tests/utils/test_file_filter.py
+++ b/tests/utils/test_file_filter.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from kimi_cli.utils.file_filter import (
+    _parse_ls_files_output,
     is_ignored,
     list_files_git,
     list_files_walk,
@@ -359,22 +360,17 @@ class TestFallback:
         result = list_files_walk(tmp_path)
         assert "a.py" in result
 
-    def test_git_output_decode_failure_does_not_crash(self, tmp_path: Path, monkeypatch) -> None:
+    def test_undecodable_git_output_does_not_crash(self, tmp_path: Path, monkeypatch) -> None:
         """Undecodable git output must not crash file discovery on Windows."""
 
         def fake_run(cmd, **kwargs):
-            text = kwargs.get("text", False)
             if "--deleted" in cmd or "--others" in cmd:
                 return subprocess.CompletedProcess(
                     cmd,
                     0,
-                    stdout="" if text else b"",
-                    stderr="" if text else b"",
+                    stdout=b"",
+                    stderr=b"",
                 )
-            if text:
-                # Simulate Windows text-mode subprocess decoding failure, where
-                # stdout ends up as None after the reader thread dies.
-                return subprocess.CompletedProcess(cmd, 0, stdout=None, stderr="")
             return subprocess.CompletedProcess(
                 cmd,
                 0,
@@ -389,3 +385,7 @@ class TestFallback:
         assert result is not None
         assert "src/" in result
         assert any(path.endswith("bad.py") for path in result)
+
+    def test_parse_ls_files_output_tolerates_none_stdout(self) -> None:
+        """Missing stdout must be treated as empty output instead of crashing."""
+        assert _parse_ls_files_output(None) == []

--- a/tests/utils/test_file_filter.py
+++ b/tests/utils/test_file_filter.py
@@ -358,3 +358,34 @@ class TestFallback:
         (tmp_path / "a.py").write_text("")
         result = list_files_walk(tmp_path)
         assert "a.py" in result
+
+    def test_git_output_decode_failure_does_not_crash(self, tmp_path: Path, monkeypatch) -> None:
+        """Undecodable git output must not crash file discovery on Windows."""
+
+        def fake_run(cmd, **kwargs):
+            text = kwargs.get("text", False)
+            if "--deleted" in cmd or "--others" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="" if text else b"",
+                    stderr="" if text else b"",
+                )
+            if text:
+                # Simulate Windows text-mode subprocess decoding failure, where
+                # stdout ends up as None after the reader thread dies.
+                return subprocess.CompletedProcess(cmd, 0, stdout=None, stderr="")
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=b"src/\xadbad.py\0",
+                stderr=b"",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = list_files_git(tmp_path)
+
+        assert result is not None
+        assert "src/" in result
+        assert any(path.endswith("bad.py") for path in result)


### PR DESCRIPTION
## Related Issue

Resolve #2015

## Description

This fixes a Windows-only crash in `@` file mention completion.

Root cause:
- entering the third character switches completion from top-level listing to the git-backed deep file scan
- `git ls-files -z` output was read with locale-dependent `subprocess` text decoding
- on Windows, undecodable path bytes could trigger a `UnicodeDecodeError`, then cascade into a `NoneType.split` crash

Changes:
- read `git ls-files` output as raw bytes instead of locale-decoded text
- decode in `file_filter.py` with `utf-8` and `surrogateescape`
- handle missing stdout defensively in the parser
- add a regression test for the Windows decode-failure path

Validation:
- `uv run pytest tests/utils/test_file_filter.py tests/ui_and_conv/test_file_completer.py`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
