### PR TITLE
feat: add Alt+V paste support for Windows Terminal

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1155,7 +1155,7 @@ def _build_toolbar_tips(clipboard_available: bool) -> list[str]:
         "/theme: switch dark/light",
     ]
     if clipboard_available:
-        tips.append("ctrl-v: paste clipboard")
+        tips.append("ctrl-v/alt-v: paste clipboard")
     tips.append("@: mention files")
     return tips
 
@@ -1476,6 +1476,19 @@ class CustomPromptSession:
                 from kimi_cli.telemetry import track
 
                 track("shortcut_paste")
+                if self._try_paste_media(event):
+                    return
+                clipboard_data = event.app.clipboard.get_data()
+                if clipboard_data is None:  # type: ignore[reportUnnecessaryComparison]
+                    return
+                self._insert_pasted_text(event.current_buffer, clipboard_data.text)
+                event.app.invalidate()
+
+            @_kb.add("escape", "v", eager=True)
+            def _(event: KeyPressEvent) -> None:
+                from kimi_cli.telemetry import track
+
+                track("shortcut_paste_alt")
                 if self._try_paste_media(event):
                     return
                 clipboard_data = event.app.clipboard.get_data()


### PR DESCRIPTION
Windows Terminal intercepts Ctrl+V for its own text paste, so prompt_toolkit never receives the event. This PR adds Alt+V as a fallback key binding with identical media paste logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
