### PR TITLE
fix: use per-process log filenames to prevent rotation lock on Windows

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import os
 import sys
 import time
 import warnings
@@ -58,7 +59,7 @@ def enable_logging(debug: bool = False, *, redirect_stderr: bool = True) -> None
     if debug:
         logger.enable("kosong")
     logger.add(
-        get_share_dir() / "logs" / "kimi.log",
+        get_share_dir() / "logs" / f"kimi.{os.getpid()}.log",
         # FIXME: configure level for different modules
         level="TRACE" if debug else "INFO",
         format=(


### PR DESCRIPTION
When multiple kimi processes run concurrently, loguru's rotation fails with PermissionError [WinError 32] be
  cause another process holds kimi.log open. Using kimi.{pid}.log eliminates the contention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
