### PR TITLE
fix(cli): silence authlib.jose deprecation warning from fastmcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- CLI: Silence `authlib.jose` deprecation warning from `fastmcp` — the warning is now suppressed at startup so it no longer pollutes the terminal or log output
 - Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
 
 ## 1.37.0 (2026-04-20)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- CLI: Silence `authlib.jose` deprecation warning from `fastmcp` — the warning is now suppressed at startup so it no longer pollutes the terminal or log output
 - Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
 
 ## 1.37.0 (2026-04-20)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,7 @@
 
 ## 未发布
 
+- CLI：屏蔽来自 `fastmcp` 的 `authlib.jose` 弃用警告——启动时自动忽略该警告，避免其污染终端或日志输出
 - Kosong：修复 Anthropic 供应商将并行工具结果拆分到多个 user message 的问题——现在会将仅包含工具结果的连续 user message 合并为单条消息，以符合 Anthropic Messages API 规范（assistant 一轮中的所有 `tool_use` 必须在同一条 user message 内回答）；修复了严格兼容后端（如 DeepSeek `/anthropic` 接口）返回 400 错误的问题，并避免官方后端静默地引导模型放弃并行工具调用
 
 ## 1.37.0 (2026-04-20)

--- a/src/kimi_cli/__main__.py
+++ b/src/kimi_cli/__main__.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from collections.abc import Sequence
 from pathlib import Path
+
+warnings.filterwarnings("ignore", message=r"authlib\.jose module is deprecated.*")
 
 
 def _prog_name() -> str:


### PR DESCRIPTION
## Related Issue

N/A — trivial startup noise cleanup.

## Description

`authlib` 1.7.0 (2026-04-18) added an import-time `AuthlibDeprecationWarning` on `authlib.jose`, which `fastmcp`'s JWT auth provider imports unconditionally:

```
.../fastmcp/server/auth/providers/jwt.py:10: AuthlibDeprecationWarning: authlib.jose module is deprecated, please use joserfc instead. It will be compatible before version 2.0.0.
  from authlib.jose import JsonWebKey, JsonWebToken
```

Users see this on every `kimi` startup.

### Why we can't root-cause fix this

- The warning is emitted from a third-party library (`fastmcp`), not our code.
- `fastmcp` — including the latest 3.x — still imports `authlib.jose` directly; there is no upstream migration to `joserfc` in flight.
- Pinning `authlib<1.7` in our `pyproject.toml` would constrain a transitive dependency we don't directly use, block us from future `authlib` 1.7+ fixes, and could collide if `fastmcp` later tightens its own bound.
- `authlib` keeps the module functional until 2.0.0, so this is purely cosmetic noise during the transition.

### What this PR does

Add a narrow, message-specific `warnings.filterwarnings` at the top of `src/kimi_cli/__main__.py` (before any import chain that pulls in `fastmcp`), matching only this exact deprecation text. Unlike the existing broad `DeprecationWarning` filter in `app.py`, this one won't hide unrelated warnings. When `fastmcp` migrates off `authlib.jose`, the filter becomes a no-op and can be removed.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
