### PR TITLE
fix(cli): clear tombstone when disk token was rotated by another process

### DIFF
--- a/src/kimi_cli/auth/oauth.py
+++ b/src/kimi_cli/auth/oauth.py
@@ -815,7 +815,19 @@ class OAuthManager:
         return state
 
     def _should_suppress_persisted_token(self, ref: OAuthRef, token: OAuthToken) -> bool:
-        return self._rejected_refresh_state(ref, token.refresh_token) is not None
+        state = self._rejected_refresh_state(ref, token.refresh_token)
+        if state is None:
+            return False
+        # Critical fix: check if another process has rotated the token on disk.
+        # The in-memory `token` may be stale; comparing only against it misses
+        # concurrent rotations. If the on-disk refresh_token differs from the
+        # tombstoned one, another instance successfully rotated — clear the tombstone
+        # and allow loading the fresh token.
+        disk_token = load_tokens(ref)
+        if disk_token and disk_token.refresh_token != state.refresh_token:
+            self._clear_rejected_refresh_token(ref)
+            return False
+        return True
 
     def _can_retry_rejected_refresh_token(self, ref: OAuthRef, refresh_token: str | None) -> bool:
         state = self._rejected_refresh_state(ref, refresh_token)

--- a/tests/auth/test_oauth_refresh.py
+++ b/tests/auth/test_oauth_refresh.py
@@ -570,3 +570,113 @@ def test_refresh_threshold_uses_minimum_when_small():
 def test_refresh_threshold_zero_expires_in():
     """When expires_in is 0, fall back to the minimum."""
     assert _refresh_threshold(0) == 300.0
+
+
+def test_should_suppress_persisted_token_detects_disk_rotation(tmp_path, monkeypatch):
+    """If the tombstone exists but the on-disk token has a different refresh_token
+    (another process rotated), _should_suppress_persisted_token must return False
+    and clear the tombstone so the fresh token can be loaded.
+
+    This is a regression test for the case where a concurrent manager rotates
+    the token while this process holds the old refresh_token in memory. Without
+    the disk check, the in-memory comparison would never clear the tombstone
+    because the memory token is stale.
+    """
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+
+    # Step 1: write initial token R1 to disk
+    _save_to_file("oauth/kimi-code", _make_token(refresh="R1", expires_in=900))
+    manager = OAuthManager(_make_config())
+
+    # Step 2: simulate a previous 401 that tombstoned R1
+    manager._mark_refresh_token_rejected(
+        OAuthRef(storage="file", key="oauth/kimi-code"), "R1"
+    )
+    assert _REJECTED_REFRESH_TOKENS.get("oauth/kimi-code") is not None
+
+    # Step 3: simulate concurrent instance writing R2 to disk
+    _save_to_file(
+        "oauth/kimi-code",
+        _make_token(access="access-R2", refresh="R2", expires_in=900),
+    )
+
+    # Step 4: create a new manager (triggers _load_initial_tokens) —
+    # this is the startup path where the bug manifests
+    fresh_manager = OAuthManager(_make_config())
+
+    # The tombstone should be cleared and the new token loaded
+    assert _REJECTED_REFRESH_TOKENS.get("oauth/kimi-code") is None, (
+        "tombstone must be cleared when disk token was rotated by another process"
+    )
+    assert fresh_manager._access_tokens.get("oauth/kimi-code") == "access-R2", (
+        "the rotated access token from disk must be cached at startup"
+    )
+
+
+def test_should_suppress_persisted_token_true_when_disk_token_matches_tombstone(
+    tmp_path, monkeypatch
+):
+    """If the on-disk refresh_token is identical to the tombstoned one,
+    suppression must remain True — the token has not been rotated yet.
+    """
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+
+    _save_to_file("oauth/kimi-code", _make_token(refresh="R1", expires_in=900))
+    manager = OAuthManager(_make_config())
+    manager._mark_refresh_token_rejected(
+        OAuthRef(storage="file", key="oauth/kimi-code"), "R1"
+    )
+    assert _REJECTED_REFRESH_TOKENS.get("oauth/kimi-code") is not None
+
+    # Disk still has R1, so suppression should remain True
+    token = _make_token(refresh="R1", expires_in=900)
+    assert manager._should_suppress_persisted_token(
+        OAuthRef(storage="file", key="oauth/kimi-code"), token
+    )
+    assert _REJECTED_REFRESH_TOKENS.get("oauth/kimi-code") is not None, (
+        "tombstone must stay when disk token matches"
+    )
+
+
+def test_should_suppress_persisted_token_true_when_disk_token_missing(
+    tmp_path, monkeypatch
+):
+    """If the credentials file has been deleted but the tombstone remains,
+    suppression should still be True (there is nothing fresh to load).
+    """
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+
+    _save_to_file("oauth/kimi-code", _make_token(refresh="R1", expires_in=900))
+    manager = OAuthManager(_make_config())
+    manager._mark_refresh_token_rejected(
+        OAuthRef(storage="file", key="oauth/kimi-code"), "R1"
+    )
+    assert _REJECTED_REFRESH_TOKENS.get("oauth/kimi-code") is not None
+
+    # Delete the credentials file
+    cred = tmp_path / "credentials" / "kimi-code.json"
+    cred.unlink()
+    assert not cred.exists()
+
+    token = _make_token(refresh="R1", expires_in=900)
+    assert manager._should_suppress_persisted_token(
+        OAuthRef(storage="file", key="oauth/kimi-code"), token
+    )
+    assert _REJECTED_REFRESH_TOKENS.get("oauth/kimi-code") is not None, (
+        "tombstone must stay when disk token is missing"
+    )
+
+
+def test_should_suppress_persisted_token_false_when_no_tombstone(
+    tmp_path, monkeypatch
+):
+    """When there is no rejected-refresh tombstone, suppression must be False."""
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+
+    _save_to_file("oauth/kimi-code", _make_token(refresh="R1", expires_in=900))
+    manager = OAuthManager(_make_config())
+
+    token = _make_token(refresh="R1", expires_in=900)
+    assert not manager._should_suppress_persisted_token(
+        OAuthRef(storage="file", key="oauth/kimi-code"), token
+    )


### PR DESCRIPTION


The _should_suppress_persisted_token() check only compared the in-memory token's refresh_token against the tombstone. When a concurrent process (another VS Code window, terminal, etc.) had legitimately rotated the refresh token and written a new one to disk, the current process could still hold the old refresh_token in memory and therefore never clear its own tombstone. This left the process with an empty API key and caused every request to 401.

Fix: before deciding to suppress, re-read the token from disk. If the on-disk refresh_token differs from the tombstoned one, another instance successfully rotated — clear the tombstone and load the fresh token.

Refs: PR #1996 follow-up

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

xref: https://github.com/MoonshotAI/kimi-cli/pull/1996
<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
