### PR TITLE
feat(soul): add inject_yolo_prompt config to suppress yolo mode prompt injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Add `skip_yolo_prompt_injection` config option to suppress the system reminder normally injected when yolo mode is active — useful when building custom applications on top of `KimiSoul` that do not need the non-interactive mode hint
+
 ## 1.38.0 (2026-04-22)
 
 - Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Add `skip_yolo_prompt_injection` config option to suppress the system reminder normally injected when yolo mode is active — useful when building custom applications on top of `KimiSoul` that do not need the non-interactive mode hint
+
 ## 1.38.0 (2026-04-22)
 
 - Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Core：新增 `skip_yolo_prompt_injection` 配置项，用于抑制 yolo 模式下注入的系统提示词——基于 `KimiSoul` 构建自定义应用且不需要该提示时很有用
+
 ## 1.38.0 (2026-04-22)
 
 - Shell：修复 approval 弹窗超时后被误报为 `Rejected by user` 的问题——300 秒安全超时后，工具调用会以 `Rejected: approval timed out` 拒绝，让离开电脑一段时间后回来的用户能分辨出这是超时而非自己的手动拒绝。经常长时间离开的话可以加 `--yolo`/`-y` 自动批准工具调用

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -195,6 +195,14 @@ class Config(BaseModel):
     default_model: str = Field(default="", description="Default model to use")
     default_thinking: bool = Field(default=False, description="Default thinking mode")
     default_yolo: bool = Field(default=False, description="Default yolo (auto-approve) mode")
+    inject_yolo_prompt: bool = Field(
+        default=True,
+        description=(
+            "If true, inject a system reminder when yolo mode is active to inform the model "
+            "it is running non-interactively. Set to false to suppress the injection when "
+            "building custom applications on top of KimiSoul."
+        ),
+    )
     default_plan_mode: bool = Field(default=False, description="Default plan mode for new sessions")
     default_editor: str = Field(
         default="",

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -195,12 +195,12 @@ class Config(BaseModel):
     default_model: str = Field(default="", description="Default model to use")
     default_thinking: bool = Field(default=False, description="Default thinking mode")
     default_yolo: bool = Field(default=False, description="Default yolo (auto-approve) mode")
-    inject_yolo_prompt: bool = Field(
-        default=True,
+    skip_yolo_prompt_injection: bool = Field(
+        default=False,
         description=(
-            "If true, inject a system reminder when yolo mode is active to inform the model "
-            "it is running non-interactively. Set to false to suppress the injection when "
-            "building custom applications on top of KimiSoul."
+            "If true, suppress the system reminder that is normally injected when yolo mode "
+            "is active. Useful when building custom applications on top of KimiSoul that do "
+            "not need the non-interactive mode hint."
         ),
     )
     default_plan_mode: bool = Field(default=False, description="Default plan mode for new sessions")

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -199,7 +199,11 @@ class KimiSoul:
             self._ensure_plan_session_id()
         self._injection_providers: list[DynamicInjectionProvider] = [
             PlanModeInjectionProvider(),
-            *([YoloModeInjectionProvider()] if self._runtime.config.inject_yolo_prompt else []),
+            *(
+                []
+                if self._runtime.config.skip_yolo_prompt_injection
+                else [YoloModeInjectionProvider()]
+            ),
         ]
         self._hook_engine: HookEngine = HookEngine()
         self._stop_hook_active: bool = False

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -199,7 +199,11 @@ class KimiSoul:
             self._ensure_plan_session_id()
         self._injection_providers: list[DynamicInjectionProvider] = [
             PlanModeInjectionProvider(),
-            YoloModeInjectionProvider(),
+            *(
+                [YoloModeInjectionProvider()]
+                if self._runtime.config.inject_yolo_prompt
+                else []
+            ),
         ]
         self._hook_engine: HookEngine = HookEngine()
         self._stop_hook_active: bool = False

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -199,11 +199,7 @@ class KimiSoul:
             self._ensure_plan_session_id()
         self._injection_providers: list[DynamicInjectionProvider] = [
             PlanModeInjectionProvider(),
-            *(
-                [YoloModeInjectionProvider()]
-                if self._runtime.config.inject_yolo_prompt
-                else []
-            ),
+            *([YoloModeInjectionProvider()] if self._runtime.config.inject_yolo_prompt else []),
         ]
         self._hook_engine: HookEngine = HookEngine()
         self._stop_hook_active: bool = False

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -58,7 +58,7 @@ def test_default_config_dump():
             "hooks": [],
             "merge_all_available_skills": False,
             "telemetry": True,
-            "inject_yolo_prompt": True,
+            "skip_yolo_prompt_injection": False,
         }
     )
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -58,6 +58,7 @@ def test_default_config_dump():
             "hooks": [],
             "merge_all_available_skills": False,
             "telemetry": True,
+            "inject_yolo_prompt": True,
         }
     )
 


### PR DESCRIPTION
## Summary

- Add `inject_yolo_prompt` field to `Config` (default `true`) to control whether the yolo mode system reminder is injected into the conversation
- Honour the config in `KimiSoul.__init__` when building the injection provider list
- Setting `inject_yolo_prompt=false` lets custom applications run in yolo mode (auto-approve all tools) without injecting the non-interactive prompt

## Test plan

- [ ] Default behaviour unchanged: yolo mode still injects the system reminder when `inject_yolo_prompt` is not set
- [ ] Setting `Config(inject_yolo_prompt=False)` suppresses the injection while yolo auto-approval still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
