### PR TITLE
feat(kimi): add KIMI_MODEL_THINKING_KEEP env for preserved thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Kimi: Add `KIMI_MODEL_THINKING_KEEP` environment variable that forwards its value verbatim to the Moonshot API as `thinking.keep`, enabling Preserved Thinking (e.g. `export KIMI_MODEL_THINKING_KEEP=all` to retain historical `reasoning_content` across turns); effective only for Moonshot models supporting Preserved Thinking (e.g. `kimi-k2.6` / `kimi-k2-thinking`), unset or empty string preserves the previous behavior and omits the field, and the override only applies when the current model is actually in thinking mode so the API never receives a `thinking.keep` without the companion `thinking.type`. Note that `keep=all` increases input tokens and API cost because history reasoning is resent
+- Kosong: Fix `Kimi.with_extra_body` silently dropping previously set `thinking.type` when a later call added another `thinking.*` field — the `thinking` sub-dict is now merged field-by-field instead of shallow-replaced, so composing `with_thinking(...)` with `with_extra_body({"thinking": {...}})` preserves both contributions
+
 ## 1.38.0 (2026-04-22)
 
 - Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -18,6 +18,7 @@ The following environment variables take effect when using `kimi` type providers
 | `KIMI_MODEL_TEMPERATURE` | Generation parameter `temperature` |
 | `KIMI_MODEL_TOP_P` | Generation parameter `top_p` |
 | `KIMI_MODEL_MAX_TOKENS` | Generation parameter `max_tokens` |
+| `KIMI_MODEL_THINKING_KEEP` | Moonshot `thinking.keep` switch for preserved thinking (only applied when thinking mode is active) |
 
 ### `KIMI_BASE_URL`
 
@@ -82,6 +83,22 @@ Sets the generation parameter `max_tokens`, limiting the maximum tokens per resp
 ```sh
 export KIMI_MODEL_MAX_TOKENS="4096"
 ```
+
+### `KIMI_MODEL_THINKING_KEEP`
+
+Forwards the value verbatim to the Moonshot API as `thinking.keep`, enabling Preserved Thinking (see the [Moonshot docs](https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model#preserved-thinking)). Setting it to `all` causes the provider to preserve the reasoning content of previous assistant turns across requests. The value is passed through unchanged, no validation or case normalization is performed.
+
+```sh
+export KIMI_MODEL_THINKING_KEEP="all"
+```
+
+Empty string or unset means the field is omitted from the request (current default behavior). The override only applies when the model is actually in thinking mode; it is ignored for non-thinking runs so the API never receives a `thinking.keep` without the companion `thinking.type`.
+
+This parameter only takes effect on Moonshot models that support Preserved Thinking (e.g., `kimi-k2.6` / `kimi-k2-thinking`). Passing it to other models has no effect or may be rejected by the API; the CLI does not validate the model.
+
+::: warning Cost
+`thinking.keep=all` instructs the API to retain historical reasoning content across turns, which increases input tokens and therefore API cost. Only enable it when the preserved thinking behavior is required.
+:::
 
 ## OpenAI-compatible environment variables
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,9 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Kimi: Add `KIMI_MODEL_THINKING_KEEP` environment variable that forwards its value verbatim to the Moonshot API as `thinking.keep`, enabling Preserved Thinking (e.g. `export KIMI_MODEL_THINKING_KEEP=all` to retain historical `reasoning_content` across turns); effective only for Moonshot models supporting Preserved Thinking (e.g. `kimi-k2.6` / `kimi-k2-thinking`), unset or empty string preserves the previous behavior and omits the field, and the override only applies when the current model is actually in thinking mode so the API never receives a `thinking.keep` without the companion `thinking.type`. Note that `keep=all` increases input tokens and API cost because history reasoning is resent
+- Kosong: Fix `Kimi.with_extra_body` silently dropping previously set `thinking.type` when a later call added another `thinking.*` field — the `thinking` sub-dict is now merged field-by-field instead of shallow-replaced, so composing `with_thinking(...)` with `with_extra_body({"thinking": {...}})` preserves both contributions
+
 ## 1.38.0 (2026-04-22)
 
 - Shell: Fix `Rejected by user` misleading message when an approval modal times out — after the 300s safety timeout, the tool call now rejects with `Rejected: approval timed out`, so users returning to their session after stepping away can tell the rejection was a timeout rather than a manual rejection. Pass `--yolo`/`-y` to auto-approve tool calls if you regularly leave sessions unattended

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -18,6 +18,7 @@ Kimi Code CLI 支持通过环境变量覆盖配置或控制运行行为。本页
 | `KIMI_MODEL_TEMPERATURE` | 生成参数 `temperature` |
 | `KIMI_MODEL_TOP_P` | 生成参数 `top_p` |
 | `KIMI_MODEL_MAX_TOKENS` | 生成参数 `max_tokens` |
+| `KIMI_MODEL_THINKING_KEEP` | Moonshot `thinking.keep` 开关（Preserved Thinking），仅在 Thinking 模式下生效 |
 
 ### `KIMI_BASE_URL`
 
@@ -82,6 +83,22 @@ export KIMI_MODEL_TOP_P="0.9"
 ```sh
 export KIMI_MODEL_MAX_TOKENS="4096"
 ```
+
+### `KIMI_MODEL_THINKING_KEEP`
+
+将 env 值原样作为 `thinking.keep` 字段发送给 Moonshot API，用于开启 Preserved Thinking（参考 [Moonshot 官方文档](https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model#preserved-thinking)）。设为 `all` 可让模型在多轮之间保留历史 reasoning_content。值不做任何校验、不做大小写归一化，透传给 API 自己判断。
+
+```sh
+export KIMI_MODEL_THINKING_KEEP="all"
+```
+
+未设置或设为空字符串时，请求体不携带此字段（等同当前默认行为）。该覆盖仅在当前模型真正处于 Thinking 模式时生效；对非 Thinking 模式的调用会被忽略，以避免发出只有 `thinking.keep` 而缺少 `thinking.type` 的无效请求体。
+
+此参数仅在支持 Preserved Thinking 的 Moonshot 模型（例如 `kimi-k2.6` / `kimi-k2-thinking`）上生效。传给其它模型时，Moonshot API 会忽略或拒绝该字段，CLI 本身不做校验。
+
+::: warning 注意成本
+`thinking.keep=all` 会让 API 在多轮之间保留历史 reasoning_content，input tokens 与 API 费用都会显著增加。请在确实需要 Preserved Thinking 时再开启。
+:::
 
 ## OpenAI 兼容环境变量
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,9 @@
 
 ## 未发布
 
+- Kimi：新增环境变量 `KIMI_MODEL_THINKING_KEEP`，将其值原样作为 `thinking.keep` 字段发送给 Moonshot API，用于启用 Preserved Thinking（例如 `export KIMI_MODEL_THINKING_KEEP=all` 可让模型在多轮之间保留历史 `reasoning_content`）；仅对支持 Preserved Thinking 的 Moonshot 模型（如 `kimi-k2.6` / `kimi-k2-thinking`）生效，未设置或空字符串时请求体不携带该字段、等同当前默认行为，且仅在当前模型真正处于 Thinking 模式时才注入，以避免 API 收到只有 `thinking.keep` 而缺少 `thinking.type` 的无效请求体。注意 `keep=all` 会因为重新发送历史推理内容而显著增加输入 token 与 API 费用
+- Kosong：修复 `Kimi.with_extra_body` 在后续调用新增其它 `thinking.*` 字段时静默丢掉已有 `thinking.type` 的问题——`thinking` 子对象现在按字段合并，而不是被整体浅覆盖，使得 `with_thinking(...)` 与 `with_extra_body({"thinking": {...}})` 组合使用时两次设置的字段都能保留
+
 ## 1.38.0 (2026-04-22)
 
 - Shell：修复 approval 弹窗超时后被误报为 `Rejected by user` 的问题——300 秒安全超时后，工具调用会以 `Rejected: approval timed out` 拒绝，让离开电脑一段时间后回来的用户能分辨出这是超时而非自己的手动拒绝。经常长时间离开的话可以加 `--yolo`/`-y` 自动批准工具调用

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Kimi: Add `keep` to `ThinkingConfig` (Moonshot `thinking.keep` passthrough for Preserved Thinking); value is typed as `Any` and forwarded unchanged, with case-preservation and no validation — callers choose a value the server accepts (e.g. `"all"`)
+- Kimi: Fix `with_extra_body` silently dropping earlier `thinking.*` fields on subsequent calls — the `thinking` sub-dict is now merged field-by-field so composing `with_thinking(...)` with `with_extra_body({"thinking": {...}})` preserves both contributions; other top-level keys retain last-writer-wins semantics
+
 ## 0.51.0 (2026-04-22)
 
 - Anthropic: Fix parallel tool results being split into multiple user messages — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls

--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -50,8 +50,12 @@ if TYPE_CHECKING:
         _: RetryableChatProvider = kimi
 
 
-class ThinkingConfig(TypedDict, total=True):
+class ThinkingConfig(TypedDict, total=False):
     type: Literal["enabled", "disabled"]
+    keep: Any
+    """Moonshot-specific ``thinking.keep`` switch for preserved thinking.
+    Forwarded verbatim to the API; callers are responsible for choosing a value
+    the server accepts (e.g. ``"all"``)."""
 
 
 class ExtraBody(TypedDict, total=False, extra_items=Any):
@@ -219,6 +223,11 @@ class Kimi:
         """
         Copy the chat provider, updating the extra_body in generation kwargs.
 
+        Top-level keys follow last-writer-wins semantics, except for the
+        ``thinking`` key: its sub-dict is merged field-by-field so that a
+        later call adding ``thinking.keep`` does not erase a ``thinking.type``
+        installed by an earlier ``with_thinking`` call.
+
         Returns:
             Self: A new instance of the chat provider with updated extra_body.
         """
@@ -226,6 +235,10 @@ class Kimi:
         new_self._generation_kwargs = copy.deepcopy(self._generation_kwargs)
         old_extra_body = new_self._generation_kwargs.get("extra_body") or {}
         new_extra_body: ExtraBody = {**old_extra_body, **extra_body}
+        old_thinking = old_extra_body.get("thinking")
+        new_thinking = extra_body.get("thinking")
+        if old_thinking is not None and new_thinking is not None:
+            new_extra_body["thinking"] = {**old_thinking, **new_thinking}
         new_self._generation_kwargs["extra_body"] = new_extra_body
         return new_self
 

--- a/packages/kosong/tests/api_snapshot_tests/test_kimi.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_kimi.py
@@ -317,3 +317,82 @@ async def test_kimi_with_thinking():
             pass
         body = json.loads(mock.calls.last.request.content.decode())
         assert body["reasoning_effort"] == snapshot("high")
+
+
+async def test_kimi_with_extra_body_thinking_deep_merge():
+    """with_extra_body must deep-merge the ``thinking`` sub-dict so that
+    a later call adding ``thinking.keep`` does not erase ``thinking.type``
+    set by an earlier ``with_thinking`` call."""
+    with respx.mock(base_url="https://api.moonshot.ai") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        provider = (
+            Kimi(model="kimi-k2-turbo-preview", api_key="test-key", stream=False)
+            .with_thinking("high")
+            .with_extra_body({"thinking": {"keep": "all"}})
+        )
+        stream = await provider.generate("", [], [Message(role="user", content="Think")])
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert body["thinking"] == snapshot({"type": "enabled", "keep": "all"})
+
+
+async def test_kimi_with_extra_body_thinking_empty_dict_is_noop():
+    """Passing ``{"thinking": {}}`` must leave an earlier ``thinking.type``
+    intact. An empty ``thinking`` patch is a no-op, not a clearing signal."""
+    with respx.mock(base_url="https://api.moonshot.ai") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        provider = (
+            Kimi(model="kimi-k2-turbo-preview", api_key="test-key", stream=False)
+            .with_thinking("high")
+            .with_extra_body({"thinking": {}})
+        )
+        stream = await provider.generate("", [], [Message(role="user", content="Think")])
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert body["thinking"] == snapshot({"type": "enabled"})
+
+
+async def test_kimi_with_extra_body_thinking_starts_from_empty_dict():
+    """Seeding ``thinking`` with ``{}`` first, then populating it via
+    ``with_thinking`` must produce the populated config — the empty seed
+    must not block subsequent field additions."""
+    with respx.mock(base_url="https://api.moonshot.ai") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        provider = (
+            Kimi(model="kimi-k2-turbo-preview", api_key="test-key", stream=False)
+            .with_extra_body({"thinking": {}})
+            .with_thinking("high")
+        )
+        stream = await provider.generate("", [], [Message(role="user", content="Think")])
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert body["thinking"] == snapshot({"type": "enabled"})
+
+
+async def test_kimi_with_extra_body_non_thinking_key_shallow_merge():
+    """Only the ``thinking`` key gets deep-merge special-casing; other
+    top-level extra_body keys still follow the previous shallow-merge
+    semantics (last writer wins)."""
+    with respx.mock(base_url="https://api.moonshot.ai") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        provider = (
+            Kimi(model="kimi-k2-turbo-preview", api_key="test-key", stream=False)
+            .with_extra_body({"custom": {"a": 1}})  # pyright: ignore[reportArgumentType]
+            .with_extra_body({"custom": {"b": 2}})  # pyright: ignore[reportArgumentType]
+        )
+        stream = await provider.generate("", [], [Message(role="user", content="Hi")])
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert body["custom"] == snapshot({"b": 2})

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -234,11 +234,25 @@ def create_llm(
     capabilities = derive_model_capabilities(model)
 
     # Apply thinking if specified or if model always requires thinking
-    if "always_thinking" in capabilities or (thinking is True and "thinking" in capabilities):
+    thinking_on = "always_thinking" in capabilities or (
+        thinking is True and "thinking" in capabilities
+    )
+    if thinking_on:
         chat_provider = chat_provider.with_thinking("high")
     elif thinking is False:
         chat_provider = chat_provider.with_thinking("off")
     # If thinking is None and model doesn't always think, leave as-is (default behavior)
+
+    # Apply Moonshot-specific ``thinking.keep`` (preserved thinking) only when
+    # the model is actually in thinking mode; otherwise the API would see a
+    # ``thinking.keep`` without an accompanying ``thinking.type`` it honors.
+    if thinking_on and provider.type == "kimi":
+        from kosong.chat_provider.kimi import Kimi
+
+        if isinstance(chat_provider, Kimi) and (
+            thinking_keep := os.getenv("KIMI_MODEL_THINKING_KEEP")
+        ):
+            chat_provider = chat_provider.with_extra_body({"thinking": {"keep": thinking_keep}})
 
     return LLM(
         chat_provider=chat_provider,

--- a/tests/core/test_create_llm.py
+++ b/tests/core/test_create_llm.py
@@ -413,7 +413,7 @@ def test_create_llm_kimi_thinking_keep_all_injects_field(monkeypatch):
 def test_create_llm_kimi_thinking_keep_arbitrary_value_passes_through(monkeypatch):
     """Non-'all' values must be forwarded unchanged — no casing normalization,
     no validation. The Moonshot API is the source of truth."""
-    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "FoO")
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "xYz")
     provider, model = _make_kimi_thinking_model()
 
     llm = create_llm(provider, model)
@@ -421,7 +421,7 @@ def test_create_llm_kimi_thinking_keep_arbitrary_value_passes_through(monkeypatc
     assert isinstance(llm.chat_provider, Kimi)
 
     extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
-    assert extra_body.get("thinking", {}).get("keep") == "FoO"
+    assert extra_body.get("thinking", {}).get("keep") == "xYz"
 
 
 def test_create_llm_kimi_thinking_keep_skipped_when_thinking_off(monkeypatch):

--- a/tests/core/test_create_llm.py
+++ b/tests/core/test_create_llm.py
@@ -329,3 +329,154 @@ def test_create_llm_openai_responses_thinking_false_no_reasoning_in_params():
             "reasoning_effort": None,
         }
     )
+
+
+def _make_kimi_thinking_model() -> tuple[LLMProvider, LLMModel]:
+    """Helper: build a kimi provider + always-thinking model pair."""
+    provider = LLMProvider(
+        type="kimi",
+        base_url="https://api.test/v1",
+        api_key=SecretStr("test-key"),
+    )
+    model = LLMModel(
+        provider="kimi",
+        model="kimi-k2-thinking-turbo",
+        max_context_size=4096,
+        capabilities=None,
+    )
+    return provider, model
+
+
+def _make_kimi_plain_model() -> tuple[LLMProvider, LLMModel]:
+    """Helper: build a kimi provider + non-thinking model pair."""
+    provider = LLMProvider(
+        type="kimi",
+        base_url="https://api.test/v1",
+        api_key=SecretStr("test-key"),
+    )
+    model = LLMModel(
+        provider="kimi",
+        model="kimi-k2-turbo-preview",
+        max_context_size=4096,
+        capabilities=None,
+    )
+    return provider, model
+
+
+def test_create_llm_kimi_thinking_keep_not_set_omits_field(monkeypatch):
+    """When KIMI_MODEL_THINKING_KEEP is unset, extra_body.thinking must not
+    contain a ``keep`` key, even for always-thinking models."""
+    monkeypatch.delenv("KIMI_MODEL_THINKING_KEEP", raising=False)
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    thinking = extra_body.get("thinking") or {}
+    assert "keep" not in thinking
+    assert thinking.get("type") == "enabled"
+
+
+def test_create_llm_kimi_thinking_keep_empty_string_omits_field(monkeypatch):
+    """An empty-string env value must be treated as unset (consistent with
+    other KIMI_MODEL_* envs that use walrus-truthy reads)."""
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "")
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    thinking = extra_body.get("thinking") or {}
+    assert "keep" not in thinking
+
+
+def test_create_llm_kimi_thinking_keep_all_injects_field(monkeypatch):
+    """With a thinking-capable model and KIMI_MODEL_THINKING_KEEP=all, the
+    provider's extra_body.thinking must carry both ``type`` (set by
+    with_thinking) and ``keep`` (set by the env)."""
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "all")
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.model_parameters.get("extra_body") == snapshot(
+        {"thinking": {"type": "enabled", "keep": "all"}}
+    )
+
+
+def test_create_llm_kimi_thinking_keep_arbitrary_value_passes_through(monkeypatch):
+    """Non-'all' values must be forwarded unchanged — no casing normalization,
+    no validation. The Moonshot API is the source of truth."""
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "FoO")
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    assert extra_body.get("thinking", {}).get("keep") == "FoO"
+
+
+def test_create_llm_kimi_thinking_keep_skipped_when_thinking_off(monkeypatch):
+    """When thinking=False (with_thinking("off")), keep must NOT be injected,
+    even if the env is set. Avoids sending a `thinking.keep` without an
+    accompanying `thinking.type` that the API actually honors."""
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "all")
+    provider, model = _make_kimi_plain_model()
+    # capabilities is None and model name has no "thinking"/"reason" marker, so
+    # derive_model_capabilities returns an empty set. thinking=False then drives
+    # with_thinking("off").
+    llm = create_llm(provider, model, thinking=False)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    thinking = extra_body.get("thinking") or {}
+    assert "keep" not in thinking
+
+
+def test_create_llm_kimi_thinking_keep_skipped_when_no_thinking_branch(monkeypatch):
+    """When the model has no thinking capability and thinking is None, neither
+    with_thinking branch runs — keep must also NOT be injected."""
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "all")
+    provider, model = _make_kimi_plain_model()
+
+    llm = create_llm(provider, model, thinking=None)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    # extra_body might be missing entirely (no thinking branch ran), or present
+    # with no thinking key. Both are acceptable; what must hold is "no keep".
+    thinking = extra_body.get("thinking") or {}
+    assert "keep" not in thinking
+
+
+def test_create_llm_kimi_thinking_keep_injected_on_explicit_thinking_true(monkeypatch):
+    """Covers the second half of the ``thinking_on`` condition: a
+    thinking-capable (but not always_thinking) model with explicit
+    ``thinking=True``. This exercises a different branch of
+    ``"always_thinking" in capabilities or (thinking is True and "thinking" in capabilities)``
+    than the always-thinking-name-based tests above."""
+    monkeypatch.setenv("KIMI_MODEL_THINKING_KEEP", "all")
+    provider, model = _make_kimi_plain_model()
+    # Model name has no "thinking"/"reason" marker, so derive_model_capabilities
+    # returns an empty set; manually granting only the "thinking" capability
+    # means always_thinking is NOT in capabilities — thinking_on is driven
+    # solely by the explicit thinking=True argument.
+    model.capabilities = {"thinking"}
+
+    llm = create_llm(provider, model, thinking=True)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.model_parameters.get("extra_body") == snapshot(
+        {"thinking": {"type": "enabled", "keep": "all"}}
+    )


### PR DESCRIPTION
## Summary

- Add a new `KIMI_MODEL_THINKING_KEEP` env var that forwards its value verbatim to the Moonshot API as `thinking.keep`, enabling Preserved Thinking on models that support it (e.g. `kimi-k2.6` / `kimi-k2-thinking`).
- Fix a latent bug in `Kimi.with_extra_body` that silently erased previously set `thinking.type` when a later call added another `thinking.*` field; the sub-dict is now merged field-by-field.
- Update docs (en + zh) and CHANGELOG.

## Key behavior

- Unset or empty string: `thinking.keep` is omitted from the request — matches current default.
- Non-empty value: forwarded verbatim, no validation, no case normalization (API is the source of truth).
- Override is only applied when the model is actually in thinking mode; for non-thinking runs it is silently ignored so the API never sees a `thinking.keep` without its companion `thinking.type`.
- Only effective for Moonshot models that support Preserved Thinking — the CLI does not validate this; other models either ignore the field or have the API reject it.
- `keep=all` preserves historical reasoning content across turns, which increases input tokens and API cost; documented.

## Kosong-level change

`Kimi.with_extra_body` previously shallow-merged the entire dict, so composing `with_thinking("high")` with `with_extra_body({"thinking": {"keep": "all"}})` overwrote `thinking.type`. The `thinking` key is now deep-merged at field level (other top-level keys keep last-writer-wins). Empty-dict patches (`{"thinking": {}}`) are treated as no-ops instead of clearing signals.

`ThinkingConfig` is now `total=False` with `type` and the new `keep: Any` both optional, matching the "fragment patch" nature of the value that flows through `with_extra_body`.

## Testing

- [x] `packages/kosong`: 260 tests pass (`pytest --doctest-modules`), including 4 new wire-level assertions covering deep merge, empty-dict no-op (both directions), and non-thinking key shallow merge.
- [x] `tests/`: 2547 tests pass, including 7 new `test_create_llm_kimi_thinking_keep_*` snapshot tests covering unset / empty / `all` / arbitrary value / thinking off / no-thinking-branch / explicit-thinking-true.
- [x] `ruff check`, `ruff format --check`, `pyright` all clean on both packages.

## Docs

- `docs/en/configuration/env-vars.md` and `docs/zh/configuration/env-vars.md`: new `KIMI_MODEL_THINKING_KEEP` section with model applicability note and cost warning.
- Root `CHANGELOG.md` and `packages/kosong/CHANGELOG.md`: entries added under `## Unreleased`.

## Breaking changes

None. Default behavior (env unset) matches existing requests exactly. The `with_extra_body` fix is strictly additive — any prior call sequence that got away with a single `with_extra_body({"thinking": ...})` call produces identical output; only previously-broken chained compositions now behave correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
