### PR TITLE
feat(tools): enable strict mode for specific tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
+- Core: Enable strict parameter validation for built-in tools (`Grep`, `ReadFile`, `StrReplaceFile`, `WriteFile`, `Shell`, `SetTodoList`) — API requests now include `strict: true`, enforcing exact parameter schema compliance and reducing invalid tool call errors from model hallucinations
+- Kosong: Add `strict` field to `Tool` and `CallableTool2` definitions, and propagate it through OpenAI, OpenAI Responses, and Anthropic providers
 
 ## 1.37.0 (2026-04-20)
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -5,6 +5,8 @@ This page documents the changes in each Kimi Code CLI release.
 ## Unreleased
 
 - Kosong: Fix parallel tool results being split into multiple user messages in Anthropic provider — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
+- Core: Enable strict parameter validation for built-in tools (`Grep`, `ReadFile`, `StrReplaceFile`, `WriteFile`, `Shell`, `SetTodoList`) — API requests now include `strict: true`, enforcing exact parameter schema compliance and reducing invalid tool call errors from model hallucinations
+- Kosong: Add `strict` field to `Tool` and `CallableTool2` definitions, and propagate it through OpenAI, OpenAI Responses, and Anthropic providers
 
 ## 1.37.0 (2026-04-20)
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -5,6 +5,8 @@
 ## 未发布
 
 - Kosong：修复 Anthropic 供应商将并行工具结果拆分到多个 user message 的问题——现在会将仅包含工具结果的连续 user message 合并为单条消息，以符合 Anthropic Messages API 规范（assistant 一轮中的所有 `tool_use` 必须在同一条 user message 内回答）；修复了严格兼容后端（如 DeepSeek `/anthropic` 接口）返回 400 错误的问题，并避免官方后端静默地引导模型放弃并行工具调用
+- Core：为内置工具（`Grep`、`ReadFile`、`StrReplaceFile`、`WriteFile`、`Shell`、`SetTodoList`）启用严格参数校验——API 请求现在携带 `strict: true`，强制要求参数完全符合 schema，减少模型幻觉导致的无效工具调用错误
+- Kosong：为 `Tool` 和 `CallableTool2` 定义新增 `strict` 字段，并透传至 OpenAI、OpenAI Responses 和 Anthropic 供应商
 
 ## 1.37.0 (2026-04-20)
 

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Anthropic: Fix parallel tool results being split into multiple user messages — consecutive tool-result-only user messages are now merged into a single message, complying with the Anthropic Messages API spec that all `tool_use` blocks in an assistant turn must be answered within one user message; this fixes 400 errors on strict Anthropic-compatible backends (e.g. DeepSeek `/anthropic` endpoint) and prevents the official backend from silently teaching the model to avoid parallel tool calls
+- Core: Add `strict` field to `Tool` and `CallableTool2` definitions, and propagate it through OpenAI, OpenAI Responses, and Anthropic providers
 
 ## 0.50.0 (2026-04-17)
 

--- a/packages/kosong/src/kosong/chat_provider/openai_common.py
+++ b/packages/kosong/src/kosong/chat_provider/openai_common.py
@@ -158,5 +158,6 @@ def tool_to_openai(tool: Tool) -> ChatCompletionToolParam:
             "name": tool.name,
             "description": tool.description,
             "parameters": tool.parameters,
+            "strict": tool.strict,
         },
     }

--- a/packages/kosong/src/kosong/chat_provider/openai_common.py
+++ b/packages/kosong/src/kosong/chat_provider/openai_common.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import inspect
 import re
 from collections.abc import Awaitable, Mapping
@@ -7,6 +8,7 @@ from typing import Any, cast
 import httpx
 import openai
 from openai import AsyncOpenAI, OpenAIError
+from openai.lib._pydantic import _ensure_strict_json_schema  # type: ignore[reportPrivateUsage]
 from openai.types import ReasoningEffort
 from openai.types.chat import ChatCompletionToolParam
 
@@ -149,15 +151,26 @@ def reasoning_effort_to_thinking_effort(effort: ReasoningEffort) -> ThinkingEffo
             return "off"
 
 
+def ensure_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Make a JSON schema compliant with OpenAI strict mode.
+
+    Mutates a deep copy so the original schema is preserved.
+    """
+    schema_copy = copy.deepcopy(schema)
+    return _ensure_strict_json_schema(schema_copy, path=(), root=schema_copy)
+
+
 def tool_to_openai(tool: Tool) -> ChatCompletionToolParam:
     """Convert a single tool to OpenAI tool format."""
-    # simply `model_dump` because the `Tool` type is OpenAI-compatible
+    parameters = tool.parameters
+    if tool.strict:
+        parameters = ensure_strict_json_schema(parameters)
     return {
         "type": "function",
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": tool.parameters,
+            "parameters": parameters,
             "strict": tool.strict,
         },
     }

--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -627,6 +627,7 @@ def _convert_tool(tool: Tool) -> ToolParam:
         "name": tool.name,
         "description": tool.description,
         "input_schema": tool.parameters,
+        "strict": tool.strict,
     }
 
 

--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -37,6 +37,7 @@ from anthropic import (
 from anthropic import (
     RateLimitError as AnthropicRateLimitError,
 )
+from anthropic import transform_schema as _anthropic_transform_schema
 from anthropic.lib.streaming import MessageStopEvent
 from anthropic.types import (
     Base64ImageSourceParam,
@@ -622,11 +623,26 @@ class AnthropicStreamedMessage:
             raise _convert_error(exc) from exc
 
 
+def ensure_anthropic_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Make a JSON schema compliant with Anthropic strict tool use.
+
+    Anthropic's strict subset rejects ``minimum``/``maximum``/``minLength``/
+    ``maxLength``/``multipleOf``/``maxItems`` and requires ``additionalProperties:
+    false`` on objects. The official SDK helper strips those keywords and
+    appends them to ``description`` so the model still sees the constraints.
+    Mutates a deep copy so the original schema is preserved.
+    """
+    return _anthropic_transform_schema(copy.deepcopy(schema))
+
+
 def _convert_tool(tool: Tool) -> ToolParam:
+    schema = tool.parameters
+    if tool.strict:
+        schema = ensure_anthropic_strict_json_schema(schema)
     return {
         "name": tool.name,
         "description": tool.description,
-        "input_schema": tool.parameters,
+        "input_schema": schema,
         "strict": tool.strict,
     }
 

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
@@ -41,6 +41,7 @@ from kosong.chat_provider.openai_common import (
     close_replaced_openai_client,
     convert_error,
     create_openai_client,
+    ensure_strict_json_schema,
     reasoning_effort_to_thinking_effort,
     thinking_effort_to_reasoning_effort,
 )
@@ -342,11 +343,14 @@ class OpenAIResponses:
 
 def _convert_tool(tool: Tool) -> ToolParam:
     """Convert a Kosong tool to an OpenAI Responses tool."""
+    parameters = tool.parameters
+    if tool.strict:
+        parameters = ensure_strict_json_schema(parameters)
     return {
         "type": "function",
         "name": tool.name,
         "description": tool.description,
-        "parameters": tool.parameters,
+        "parameters": parameters,
         "strict": tool.strict,
     }
 

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
@@ -347,7 +347,7 @@ def _convert_tool(tool: Tool) -> ToolParam:
         "name": tool.name,
         "description": tool.description,
         "parameters": tool.parameters,
-        "strict": False,
+        "strict": tool.strict,
     }
 
 

--- a/packages/kosong/src/kosong/tooling/__init__.py
+++ b/packages/kosong/src/kosong/tooling/__init__.py
@@ -27,6 +27,9 @@ class Tool(BaseModel):
     parameters: ParametersType
     """The parameters of the tool, in JSON Schema format."""
 
+    strict: bool = False
+    """Whether to enforce strict parameter validation when calling the tool via API."""
+
     @model_validator(mode="after")
     def _validate_parameters(self) -> Self:
         jsonschema.validate(self.parameters, jsonschema.Draft202012Validator.META_SCHEMA)
@@ -243,6 +246,8 @@ class CallableTool2[Params: BaseModel](ABC):
     """The description of the tool."""
     params: type[Params]
     """The Pydantic model type of the tool parameters."""
+    strict: bool = False
+    """Whether to enforce strict parameter validation when calling the tool via API."""
 
     def __init__(
         self,
@@ -276,12 +281,17 @@ class CallableTool2[Params: BaseModel](ABC):
         if not isinstance(self.params, type) or not issubclass(self.params, BaseModel):  # type: ignore[reportUnnecessaryIsInstance]
             raise ValueError("Tool params must be a subclass of pydantic.BaseModel")
 
+        strict = getattr(cls, "strict", False)
+        if not isinstance(strict, bool):  # type: ignore[reportUnnecessaryIsInstance]
+            strict = False
+
         self._base = Tool(
             name=self.name,
             description=self.description,
             parameters=deref_json_schema(
                 self.params.model_json_schema(schema_generator=_GenerateJsonSchemaNoTitles)
             ),
+            strict=strict,
         )
 
     @property

--- a/packages/kosong/tests/api_snapshot_tests/test_anthropic.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_anthropic.py
@@ -193,6 +193,7 @@ async def test_anthropic_message_conversion():
                                 },
                                 "required": ["a", "b"],
                             },
+                            "strict": False,
                         },
                         {
                             "name": "multiply",
@@ -205,6 +206,7 @@ async def test_anthropic_message_conversion():
                                 },
                                 "required": ["a", "b"],
                             },
+                            "strict": False,
                             "cache_control": {"type": "ephemeral"},
                         },
                     ],
@@ -343,6 +345,7 @@ async def test_anthropic_message_conversion():
                                 },
                                 "required": ["a", "b"],
                             },
+                            "strict": False,
                         },
                         {
                             "name": "multiply",
@@ -355,6 +358,7 @@ async def test_anthropic_message_conversion():
                                 },
                                 "required": ["a", "b"],
                             },
+                            "strict": False,
                             "cache_control": {"type": "ephemeral"},
                         },
                     ],

--- a/packages/kosong/tests/api_snapshot_tests/test_kimi.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_kimi.py
@@ -113,6 +113,7 @@ async def test_kimi_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                         {
@@ -128,6 +129,7 @@ async def test_kimi_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                     ],
@@ -245,6 +247,7 @@ async def test_kimi_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                         {
@@ -260,6 +263,7 @@ async def test_kimi_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                     ],

--- a/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
@@ -87,6 +87,7 @@ async def test_openai_legacy_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                         {
@@ -102,6 +103,7 @@ async def test_openai_legacy_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                     ],
@@ -219,6 +221,7 @@ async def test_openai_legacy_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                         {
@@ -234,6 +237,7 @@ async def test_openai_legacy_message_conversion():
                                     },
                                     "required": ["a", "b"],
                                 },
+                                "strict": False,
                             },
                         },
                     ],

--- a/src/kimi_cli/tools/file/grep_local.py
+++ b/src/kimi_cli/tools/file/grep_local.py
@@ -383,6 +383,7 @@ def _strip_path_prefix(output: str, search_base: str) -> str:
 
 class Grep(CallableTool2[Params]):
     name: str = "Grep"
+    strict: bool = True
     description: str = load_desc(Path(__file__).parent / "grep.md")
     params: type[Params] = Params
 

--- a/src/kimi_cli/tools/file/read.py
+++ b/src/kimi_cli/tools/file/read.py
@@ -62,6 +62,7 @@ class Params(BaseModel):
 
 class ReadFile(CallableTool2[Params]):
     name: str = "ReadFile"
+    strict: bool = True
     params: type[Params] = Params
 
     def __init__(self, runtime: Runtime) -> None:

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -42,6 +42,7 @@ class Params(BaseModel):
 
 class StrReplaceFile(CallableTool2[Params]):
     name: str = "StrReplaceFile"
+    strict: bool = True
     description: str = _BASE_DESCRIPTION
     params: type[Params] = Params
 

--- a/src/kimi_cli/tools/file/write.py
+++ b/src/kimi_cli/tools/file/write.py
@@ -39,6 +39,7 @@ class Params(BaseModel):
 
 class WriteFile(CallableTool2[Params]):
     name: str = "WriteFile"
+    strict: bool = True
     description: str = _BASE_DESCRIPTION
     params: type[Params] = Params
 

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -58,6 +58,7 @@ class Params(BaseModel):
 
 class Shell(CallableTool2[Params]):
     name: str = "Shell"
+    strict: bool = True
     params: type[Params] = Params
 
     def __init__(self, approval: Approval, environment: Environment, runtime: Runtime):

--- a/src/kimi_cli/tools/todo/__init__.py
+++ b/src/kimi_cli/tools/todo/__init__.py
@@ -29,6 +29,7 @@ class Params(BaseModel):
 
 class SetTodoList(CallableTool2[Params]):
     name: str = "SetTodoList"
+    strict: bool = True
     description: str = load_desc(Path(__file__).parent / "set_todo_list.md")
     params: type[Params] = Params
 


### PR DESCRIPTION
## Related Issue

N/A

## Description

Enable OpenAI/Anthropic strict schema validation for a subset of core tools to improve reliability:

- `Shell` (Bash/PowerShell)
- `ReadFile`
- `Grep`
- `WriteFile`
- `StrReplaceFile`
- `SetTodoList`

Changes:
1. Added `strict: bool = False` to the `Tool` base model (`kosong`).
2. Updated `CallableTool2` to read the `strict` class attribute and pass it to `Tool`.
3. Updated OpenAI Responses, OpenAI Legacy, and Anthropic tool converters to emit `tool.strict`.
4. Added `strict: bool = True` to each of the 6 tool classes above.

Other tools remain `strict=False` by default.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run \`make gen-changelog\` to update the changelog.
- [ ] I have run \`make gen-docs\` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
