### PR TITLE
fix(ui): flip /usage gauge color thresholds

### DIFF
--- a/src/kimi_cli/ui/shell/usage.py
+++ b/src/kimi_cli/ui/shell/usage.py
@@ -274,8 +274,10 @@ def _format_row(row: UsageRow, label_width: int) -> RenderableType:
 
 
 def _ratio_color(ratio: float) -> str:
-    if ratio >= 0.9:
+    # ratio is the remaining fraction (1.0 = full, 0.0 = exhausted),
+    # so the thresholds are flipped from a "used" gauge.
+    if ratio <= 0.1:
         return "red"
-    if ratio >= 0.7:
+    if ratio <= 0.3:
         return "yellow"
     return "green"


### PR DESCRIPTION
Fixes #2019.

`_format_row` in `src/kimi_cli/ui/shell/usage.py` computes

```python
ratio = (row.limit - row.used) / row.limit if row.limit > 0 else 0
```

i.e. the **remaining** fraction (and the caller renders it as `{percent:.0f}% left`). The color helper below reads `ratio` as if it were a "used" gauge:

```python
def _ratio_color(ratio: float) -> str:
    if ratio >= 0.9:
        return "red"      # actually: 90%+ remaining, should be green
    if ratio >= 0.7:
        return "yellow"   # 70%+ remaining, should be green too
    return "green"        # < 70% remaining, gauge silently goes green as it drains
```

So the progress bar is green while usage is almost full and turns red right after a reset. This PR flips the thresholds so `red` kicks in when ≤10% remains and `yellow` when ≤30% remains, which matches the `% left` label.

Reporter (@sunmy2019) also gave the same fix in the issue. Added a short comment explaining the direction since the variable name alone doesn't make it obvious.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
