### PR TITLE
fix(utils): detect virtual interface IPs in get_network_addresses

### DIFF
--- a/src/kimi_cli/utils/server.py
+++ b/src/kimi_cli/utils/server.py
@@ -49,6 +49,39 @@ def find_available_port(host: str, start_port: int, max_attempts: int = 10) -> i
     )
 
 
+def _get_interface_addrs_ioctl() -> list[str]:
+    """Enumerate IPv4 addresses via socket.if_nameindex + ioctl (Linux).
+
+    This fallback covers virtual interfaces (e.g. Tailscale, WireGuard,
+    Docker bridges) that ``getaddrinfo`` and the default-route heuristic
+    often miss.
+    """
+    addresses: list[str] = []
+    try:
+        import fcntl
+        import struct
+
+        SIOCGIFADDR = 0x8915
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            for _, ifname in socket.if_nameindex():
+                try:
+                    ifreq = struct.pack(
+                        "16sH14s",
+                        ifname[:15].encode("utf-8"),
+                        socket.AF_INET,
+                        b"\x00" * 14,
+                    )
+                    res = fcntl.ioctl(s.fileno(), SIOCGIFADDR, ifreq)
+                    ip = socket.inet_ntoa(res[20:24])
+                    if ip and not ip.startswith("127.") and ip not in addresses:
+                        addresses.append(ip)
+                except OSError:
+                    continue
+    except Exception:
+        pass
+    return addresses
+
+
 def get_network_addresses() -> list[str]:
     """Get non-loopback IPv4 addresses for this machine."""
     addresses: list[str] = []
@@ -82,6 +115,12 @@ def get_network_addresses() -> list[str]:
                         addresses.append(addr)
     except (ImportError, Exception):
         pass
+
+    # Fallback: ioctl enumeration covers virtual interfaces (Tailscale,
+    # WireGuard, etc.) that the methods above may miss.
+    for addr in _get_interface_addrs_ioctl():
+        if addr not in addresses:
+            addresses.append(addr)
 
     return addresses
 


### PR DESCRIPTION
## Problem

When running \`kimi web --host 0.0.0.0 --public\`, the WebSocket connection was rejected with 403 Forbidden when accessing via Tailscale (or other virtual interfaces like WireGuard, Docker bridges).

Root cause: \`get_network_addresses()\` only used \`socket.gethostname()\` and the default-route heuristic, which miss virtual network interfaces (e.g. \`tailscale0\`). This caused the actual Origin to be absent from \`allowed_origins\`, triggering the WebSocket origin check failure.

## Fix

Add an ioctl-based fallback (\`SIOCGIFADDR\`) that enumerates all network interfaces via \`socket.if_nameindex()\`. This covers Tailscale, WireGuard, Docker bridges, and other virtual interfaces without requiring external dependencies like \`netifaces\`.

## Verification

- ruff check / format: passed
- ty check: passed
- tests/utils/test_server.py: 20 passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
