### PR TITLE
fix(agentspec): replace assert with proper AgentSpecError exception

### DIFF
--- a/src/kimi_cli/agentspec.py
+++ b/src/kimi_cli/agentspec.py
@@ -82,7 +82,8 @@ def load_agent_spec(agent_file: Path) -> ResolvedAgentSpec:
         AgentSpecError: If the agent spec is not valid.
     """
     agent_spec = _load_agent_spec(agent_file)
-    assert agent_spec.extend is None, "agent extension should be recursively resolved"
+    if agent_spec.extend is not None:
+        raise AgentSpecError("Agent extension should be recursively resolved")
     if isinstance(agent_spec.name, Inherit):
         raise AgentSpecError("Agent name is required")
     if isinstance(agent_spec.system_prompt_path, Inherit):


### PR DESCRIPTION
## Summary
- Replace `assert agent_spec.extend is None` with a proper `AgentSpecError` exception in `agentspec.py`

## Why
Using `assert` for production control flow is unsafe because Python's `-O` (optimize) flag strips all assertions, silently disabling this safety check. The assertion guards that recursive agent spec inheritance is fully resolved — if skipped, an unresolved `extend` could propagate and cause confusing downstream errors.

The fix replaces the assert with a `raise AgentSpecError(...)`, which is always enforced regardless of optimization flags.

## Test plan
- [ ] Existing tests in `tests/` related to agent spec loading should continue to pass
- [ ] Verify that running `python -O` no longer silently skips this check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
