### PR TITLE
fix(wire): eliminate TOCTOU race in WireFile.append_record

### DIFF
--- a/src/kimi_cli/wire/file.py
+++ b/src/kimi_cli/wire/file.py
@@ -123,7 +123,10 @@ class WireFile:
 
     async def append_record(self, record: WireMessageRecord) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        needs_header = not self.path.exists() or self.path.stat().st_size == 0
+        try:
+            needs_header = self.path.stat().st_size == 0
+        except FileNotFoundError:
+            needs_header = True
         async with aiofiles.open(self.path, mode="a", encoding="utf-8") as f:
             if needs_header:
                 metadata = WireFileMetadata(protocol_version=self.protocol_version)


### PR DESCRIPTION
## Summary
- Fix a time-of-check-to-time-of-use (TOCTOU) race condition in `WireFile.append_record`

## Problem
The previous code checked `self.path.exists()` before calling `self.path.stat().st_size`, creating a window where the file could be deleted between the two calls. This would cause an unhandled `FileNotFoundError` that crashes the append operation.

```python
# Before (TOCTOU race)
needs_header = not self.path.exists() or self.path.stat().st_size == 0
```

## Fix
Replaced the two-call pattern with a single `stat()` call wrapped in try-except:

```python
# After (atomic check)
try:
    needs_header = self.path.stat().st_size == 0
except FileNotFoundError:
    needs_header = True
```

## Test plan
- [ ] Existing wire file tests should continue to pass
- [ ] Verify append operations work correctly on fresh files (no file exists)
- [ ] Verify append operations work correctly on existing non-empty files (header not re-written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
