### PR TITLE
fix(acp): replace assert statements with proper RuntimeError exceptions

### DIFF
--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -91,7 +91,8 @@ class _ToolCallState:
         # with the same tool call ID (on the LLM side). To avoid confusion of the
         # ACP client, we ensure the uniqueness by prefixing with the turn ID.
         turn_id = _current_turn_id.get()
-        assert turn_id is not None
+        if turn_id is None:
+            raise RuntimeError("acp_tool_call_id accessed outside of a turn")
         return f"{turn_id}/{self.tool_call.id}"
 
     def append_args_part(self, args_part: str) -> None:
@@ -286,7 +287,8 @@ class ACPSession:
 
     async def _send_tool_call(self, tool_call: ToolCall):
         """Send tool call to client."""
-        assert self._turn_state is not None
+        if self._turn_state is None:
+            raise RuntimeError("Tool call received outside of a turn")
         if not self._id or not self._conn:
             return
 
@@ -314,7 +316,8 @@ class ACPSession:
 
     async def _send_tool_call_part(self, part: ToolCallPart):
         """Send tool call part (streaming arguments)."""
-        assert self._turn_state is not None
+        if self._turn_state is None:
+            raise RuntimeError("Tool call part received outside of a turn")
         if (
             not self._id
             or not self._conn
@@ -347,7 +350,8 @@ class ACPSession:
 
     async def _send_tool_result(self, result: ToolResult):
         """Send tool result to client."""
-        assert self._turn_state is not None
+        if self._turn_state is None:
+            raise RuntimeError("Tool result received outside of a turn")
         if not self._id or not self._conn:
             return
 
@@ -381,7 +385,8 @@ class ACPSession:
 
     async def _handle_approval_request(self, request: ApprovalRequest):
         """Handle approval request by sending permission request to client."""
-        assert self._turn_state is not None
+        if self._turn_state is None:
+            raise RuntimeError("Approval request received outside of a turn")
         if not self._id or not self._conn:
             logger.warning("No session ID, auto-rejecting approval request")
             request.resolve("reject")


### PR DESCRIPTION
## Summary
- Replace 5 `assert` statements in `acp/session.py` with proper `RuntimeError` exceptions

## Why
Using `assert` for production invariant checks is unsafe because Python's `-O` (optimize) flag strips all assertions. In this file, the assertions guard critical invariants:

1. `_ToolCallState.acp_tool_call_id`: `turn_id` must be set before accessing the property
2. `ACPSession._send_tool_call`: turn state must exist when sending tool calls
3. `ACPSession._send_tool_call_part`: turn state must exist when streaming arguments
4. `ACPSession._send_tool_result`: turn state must exist when sending results
5. `ACPSession._handle_approval_request`: turn state must exist for approval handling

Each assert is replaced with an explicit `if ... is None: raise RuntimeError(...)` with a descriptive error message, ensuring the invariants are always enforced regardless of Python optimization flags.

## Test plan
- [ ] Existing ACP session tests should continue to pass
- [ ] Verify error messages are descriptive when invariants are violated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
