### PR TITLE
feat(config): add default_skills config for auto-activating skills on session start

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -23,6 +23,7 @@ from kimi_cli.constant import VERSION
 from kimi_cli.llm import augment_provider_with_env_vars, create_llm, model_display_name
 from kimi_cli.session import Session
 from kimi_cli.share import get_share_dir
+from kimi_cli.skill import normalize_skill_name, read_skill_text
 from kimi_cli.soul import run_soul
 from kimi_cli.soul.agent import Runtime, load_agent
 from kimi_cli.soul.context import Context
@@ -297,6 +298,25 @@ class KimiCLI:
             agent = dataclasses.replace(agent, system_prompt=context.system_prompt)
         else:
             await context.write_system_prompt(agent.system_prompt)
+            # Auto-activate default skills for new sessions
+            for skill_name in config.default_skills:
+                skill = runtime.skills.get(normalize_skill_name(skill_name))
+                if skill is None:
+                    logger.warning(
+                        "Default skill '{name}' not found; skipping",
+                        name=skill_name,
+                    )
+                    continue
+                skill_text = await read_skill_text(skill)
+                if skill_text is None:
+                    logger.warning(
+                        "Failed to read default skill '{name}'; skipping",
+                        name=skill_name,
+                    )
+                    continue
+                from kosong.message import Message
+
+                await context.append_message(Message(role="user", content=skill_text))
 
         soul = KimiSoul(agent, context=context)
 

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -259,6 +259,14 @@ class Config(BaseModel):
             "Missing paths are silently skipped."
         ),
     )
+    default_skills: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Skills to auto-activate at the start of every new session. "
+            "Each entry is a skill name (case-insensitive). Missing or unreadable "
+            "skills are logged and skipped."
+        ),
+    )
     telemetry: bool = Field(
         default=True,
         description="Enable anonymous telemetry to help improve kimi-cli. Set to false to disable.",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -58,6 +58,7 @@ def test_default_config_dump():
             "hooks": [],
             "merge_all_available_skills": True,
             "extra_skill_dirs": [],
+            "default_skills": [],
             "telemetry": True,
             "skip_yolo_prompt_injection": False,
         }

--- a/tests/core/test_startup_progress.py
+++ b/tests/core/test_startup_progress.py
@@ -170,3 +170,113 @@ async def test_kimi_cli_create_cleans_stale_running_foreground_subagents(
     await KimiCLI.create(session, config=config)
 
     update_instance.assert_called_once_with("afg1", status="failed")
+
+
+@pytest.mark.asyncio
+async def test_kimi_cli_create_injects_default_skills_on_new_session(session, config, monkeypatch) -> None:
+    """Default skills are appended as user messages for new sessions."""
+    config.default_skills = ["caveman", "missing-skill"]
+    append_message = AsyncMock()
+    write_system_prompt = AsyncMock()
+
+    fake_skill = SimpleNamespace(name="caveman")
+    fake_runtime = SimpleNamespace(
+        session=session,
+        config=config,
+        llm=None,
+        notifications=SimpleNamespace(recover=lambda: None),
+        background_tasks=SimpleNamespace(reconcile=lambda: None),
+        skills={"caveman": fake_skill},
+    )
+    fake_agent = SimpleNamespace(name="Test Agent", system_prompt="Test system prompt")
+    fake_context = SimpleNamespace(system_prompt=None)
+    fake_context.restore = AsyncMock()
+    fake_context.write_system_prompt = write_system_prompt
+    fake_context.append_message = append_message
+
+    async def fake_runtime_create(*args, **kwargs):
+        return fake_runtime
+
+    async def fake_load_agent(*args, **kwargs):
+        return fake_agent
+
+    monkeypatch.setattr(app_module, "load_config", lambda conf: conf)
+    monkeypatch.setattr(app_module, "augment_provider_with_env_vars", lambda provider, model: {})
+    monkeypatch.setattr(app_module, "create_llm", lambda *args, **kwargs: None)
+    monkeypatch.setattr(app_module.Runtime, "create", fake_runtime_create)
+    monkeypatch.setattr(app_module, "load_agent", fake_load_agent)
+    monkeypatch.setattr(app_module, "Context", lambda _path: fake_context)
+    monkeypatch.setattr(
+        app_module,
+        "read_skill_text",
+        AsyncMock(return_value="Speak like caveman."),
+    )
+
+    class _FakeSoul:
+        def __init__(self, agent, context):
+            pass
+
+        def set_hook_engine(self, engine):
+            pass
+
+    monkeypatch.setattr(app_module, "KimiSoul", _FakeSoul)
+
+    await KimiCLI.create(session, config=config)
+
+    write_system_prompt.assert_awaited_once_with("Test system prompt")
+    append_message.assert_awaited_once()
+    # Verify the message content contains the skill text
+    call_args = append_message.await_args[0][0]
+    assert call_args.role == "user"
+    assert call_args.content[0].text == "Speak like caveman."
+
+
+@pytest.mark.asyncio
+async def test_kimi_cli_create_skips_default_skills_on_restored_session(session, config, monkeypatch) -> None:
+    """Default skills are NOT injected when restoring an existing session."""
+    config.default_skills = ["caveman"]
+    append_message = AsyncMock()
+
+    fake_runtime = SimpleNamespace(
+        session=session,
+        config=config,
+        llm=None,
+        notifications=SimpleNamespace(recover=lambda: None),
+        background_tasks=SimpleNamespace(reconcile=lambda: None),
+        skills={},
+    )
+    from dataclasses import dataclass
+    @dataclass(frozen=True)
+    class FakeAgent:
+        name: str
+        system_prompt: str
+    fake_agent = FakeAgent(name="Test Agent", system_prompt="Test system prompt")
+    fake_context = SimpleNamespace(system_prompt="Existing prompt")
+    fake_context.restore = AsyncMock()
+    fake_context.append_message = append_message
+
+    async def fake_runtime_create(*args, **kwargs):
+        return fake_runtime
+
+    async def fake_load_agent(*args, **kwargs):
+        return fake_agent
+
+    monkeypatch.setattr(app_module, "load_config", lambda conf: conf)
+    monkeypatch.setattr(app_module, "augment_provider_with_env_vars", lambda provider, model: {})
+    monkeypatch.setattr(app_module, "create_llm", lambda *args, **kwargs: None)
+    monkeypatch.setattr(app_module.Runtime, "create", fake_runtime_create)
+    monkeypatch.setattr(app_module, "load_agent", fake_load_agent)
+    monkeypatch.setattr(app_module, "Context", lambda _path: fake_context)
+
+    class _FakeSoul:
+        def __init__(self, agent, context):
+            pass
+
+        def set_hook_engine(self, engine):
+            pass
+
+    monkeypatch.setattr(app_module, "KimiSoul", _FakeSoul)
+
+    await KimiCLI.create(session, config=config)
+
+    append_message.assert_not_awaited()


### PR DESCRIPTION
## Summary

Implements the feature requested in #2062: a  config key that automatically activates specified skills at the start of every new session.

## Changes

- **Config schema** (): adds  field, default .
- **Session startup** (): after writing the system prompt for a new session, iterate over , look each up in , and append the skill text as a user message to the context.
  - Missing skills are logged as a warning and skipped.
  - Unreadable skills are logged as a warning and skipped.
  - Restored sessions are unaffected (the injection only happens when ).
- **Tests**:
  - Updated config snapshot test to include .
  - Added test verifying default skills are injected on new sessions.
  - Added test verifying default skills are skipped on restored sessions.

## Usage



## Backward Compatibility

Fully backward compatible: the default value is an empty list, so existing configs behave identically.

Closes #2062
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
