### PR TITLE
fix(plan): respect KIMI_SHARE_DIR for plan files

### DIFF
--- a/src/kimi_cli/tools/plan/heroes.py
+++ b/src/kimi_cli/tools/plan/heroes.py
@@ -2,10 +2,44 @@
 
 from __future__ import annotations
 
+import contextlib
 import secrets
 from pathlib import Path
 
-PLANS_DIR = Path.home() / ".kimi" / "plans"
+from kimi_cli.share import get_share_dir
+
+# Legacy plans dir for migration (hardcoded ~/.kimi/plans)
+_LEGACY_PLANS_DIR = Path.home() / ".kimi" / "plans"
+
+
+def _get_plans_dir() -> Path:
+    """Get the plans directory, migrating from legacy if needed."""
+    plans_dir = get_share_dir() / "plans"
+    plans_dir.mkdir(parents=True, exist_ok=True)
+
+    # Auto-migrate: if legacy dir exists and is different from new dir, migrate files
+    if _LEGACY_PLANS_DIR.exists() and plans_dir != _LEGACY_PLANS_DIR:
+        _migrate_legacy_plans(plans_dir)
+
+    return plans_dir
+
+
+def _migrate_legacy_plans(target_dir: Path) -> None:
+    """Migrate plan files from legacy ~/.kimi/plans to target_dir."""
+    try:
+        for old_file in _LEGACY_PLANS_DIR.glob("*.md"):
+            if old_file.is_file():
+                new_file = target_dir / old_file.name
+                if not new_file.exists():
+                    # Copy file to new location (don't remove old one for safety)
+                    new_file.write_text(old_file.read_text(encoding="utf-8"), encoding="utf-8")
+        # Only remove legacy dir if it's now empty (all files migrated or already existed)
+        with contextlib.suppress(OSError):
+            _LEGACY_PLANS_DIR.rmdir()  # Only succeeds if empty
+    except Exception:
+        # Migration failures should not block normal operation
+        pass
+
 
 HERO_NAMES: list[str] = [
     # --- Marvel ---
@@ -250,12 +284,12 @@ def get_or_create_slug(session_id: str) -> str:
     """Get or create a plan file slug for the given session."""
     if session_id in _slug_cache:
         return _slug_cache[session_id]
-    PLANS_DIR.mkdir(parents=True, exist_ok=True)
+    plans_dir = _get_plans_dir()
     slug = ""
     for _ in range(20):
         words = [secrets.choice(HERO_NAMES) for _ in range(3)]
         slug = "-".join(words)
-        if not (PLANS_DIR / f"{slug}.md").exists():
+        if not (plans_dir / f"{slug}.md").exists():
             break
     else:
         # All 20 attempts collided; append session prefix for uniqueness
@@ -266,7 +300,7 @@ def get_or_create_slug(session_id: str) -> str:
 
 def get_plan_file_path(session_id: str) -> Path:
     """Get the plan file path for the given session."""
-    return PLANS_DIR / f"{get_or_create_slug(session_id)}.md"
+    return _get_plans_dir() / f"{get_or_create_slug(session_id)}.md"
 
 
 def read_plan_file(session_id: str) -> str | None:

--- a/src/kimi_cli/tools/plan/heroes.py
+++ b/src/kimi_cli/tools/plan/heroes.py
@@ -15,6 +15,15 @@ _LEGACY_PLANS_DIR = Path.home() / ".kimi" / "plans"
 _migration_done = False
 
 
+def _is_same_directory(path1: Path, path2: Path) -> bool:
+    """Check if two paths point to the same directory (handles symlinks via inode comparison)."""
+    try:
+        return path1.samefile(path2)
+    except (OSError, ValueError):
+        # If either path doesn't exist, fall back to string comparison
+        return path1 == path2
+
+
 def _get_plans_dir() -> Path:
     """Get the plans directory, migrating from legacy if needed."""
     global _migration_done
@@ -22,7 +31,7 @@ def _get_plans_dir() -> Path:
     plans_dir.mkdir(parents=True, exist_ok=True)
 
     # Auto-migrate: if legacy dir exists and is different from new dir, migrate files
-    if not _migration_done and _LEGACY_PLANS_DIR.exists() and plans_dir != _LEGACY_PLANS_DIR:
+    if not _migration_done and _LEGACY_PLANS_DIR.exists() and not _is_same_directory(plans_dir, _LEGACY_PLANS_DIR):
         _migrate_legacy_plans(plans_dir)
         _migration_done = True
 

--- a/src/kimi_cli/tools/plan/heroes.py
+++ b/src/kimi_cli/tools/plan/heroes.py
@@ -11,15 +11,20 @@ from kimi_cli.share import get_share_dir
 # Legacy plans dir for migration (hardcoded ~/.kimi/plans)
 _LEGACY_PLANS_DIR = Path.home() / ".kimi" / "plans"
 
+# Module-level flag to ensure migration only runs once per process
+_migration_done = False
+
 
 def _get_plans_dir() -> Path:
     """Get the plans directory, migrating from legacy if needed."""
+    global _migration_done
     plans_dir = get_share_dir() / "plans"
     plans_dir.mkdir(parents=True, exist_ok=True)
 
     # Auto-migrate: if legacy dir exists and is different from new dir, migrate files
-    if _LEGACY_PLANS_DIR.exists() and plans_dir != _LEGACY_PLANS_DIR:
+    if not _migration_done and _LEGACY_PLANS_DIR.exists() and plans_dir != _LEGACY_PLANS_DIR:
         _migrate_legacy_plans(plans_dir)
+        _migration_done = True
 
     return plans_dir
 
@@ -31,9 +36,11 @@ def _migrate_legacy_plans(target_dir: Path) -> None:
             if old_file.is_file():
                 new_file = target_dir / old_file.name
                 if not new_file.exists():
-                    # Copy file to new location (don't remove old one for safety)
+                    # Copy file to new location, then remove original
                     new_file.write_text(old_file.read_text(encoding="utf-8"), encoding="utf-8")
-        # Only remove legacy dir if it's now empty (all files migrated or already existed)
+                # Remove original file after successful copy (or if target already exists)
+                old_file.unlink()
+        # Only remove legacy dir if it's now empty (all files migrated)
         with contextlib.suppress(OSError):
             _LEGACY_PLANS_DIR.rmdir()  # Only succeeds if empty
     except Exception:

--- a/tests/core/test_plan_flag.py
+++ b/tests/core/test_plan_flag.py
@@ -248,7 +248,7 @@ class TestSchedulePlanActivationReminder:
         from kimi_cli.soul.kimisoul import KimiSoul
 
         # Redirect PLANS_DIR to tmp_path to avoid filesystem side effects
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
 
         agent = Agent(
             name="Test",

--- a/tests/core/test_plan_mode.py
+++ b/tests/core/test_plan_mode.py
@@ -69,14 +69,14 @@ def _tool_output_text(result: ToolReturnValue) -> str:
 
 class TestGetOrCreateSlug:
     def test_returns_hero_name(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         slug = get_or_create_slug("session-1")
         # Slug is composed of 3 hero names joined by "-"; each hero name may itself contain "-"
         # Just verify it's a non-empty string and contains at least some hero name substrings
         assert isinstance(slug, str) and len(slug) > 0
 
     def test_cache_hit(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         first = get_or_create_slug("session-1")
         second = get_or_create_slug("session-1")
         assert first == second
@@ -84,7 +84,7 @@ class TestGetOrCreateSlug:
     def test_different_sessions_get_different_slugs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         a = get_or_create_slug("session-a")
         b = get_or_create_slug("session-b")
         # Extremely unlikely to be equal with 230+ names, but not impossible.
@@ -94,7 +94,7 @@ class TestGetOrCreateSlug:
 
     def test_collision_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """When all random choices collide, append session prefix for uniqueness."""
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         # Use a tiny hero list so we can predict and pre-create all combos
         monkeypatch.setattr("kimi_cli.tools.plan.heroes.HERO_NAMES", ["a", "b"])
         # Pre-create all possible 3-word combos from ["a", "b"]
@@ -113,7 +113,7 @@ class TestGetPlanFilePath:
     def test_returns_md_file_in_plans_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         path = get_plan_file_path("session-1")
         assert path.parent == tmp_path
         assert path.suffix == ".md"
@@ -121,7 +121,7 @@ class TestGetPlanFilePath:
 
 class TestReadPlanFile:
     def test_reads_existing_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         # First, get the path so the slug is generated
         path = get_plan_file_path("session-1")
         path.write_text("# My Plan", encoding="utf-8")
@@ -131,7 +131,7 @@ class TestReadPlanFile:
     def test_returns_none_for_missing_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         content = read_plan_file("session-nonexistent")
         assert content is None
 
@@ -227,7 +227,7 @@ class TestManualPlanModeInjections:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         assert await soul.toggle_plan_mode_from_manual() is True
@@ -249,7 +249,7 @@ class TestManualPlanModeInjections:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         assert await soul.toggle_plan_mode_from_manual() is True
@@ -268,7 +268,7 @@ class TestManualPlanModeInjections:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         assert await soul.toggle_plan_mode() is True
@@ -500,7 +500,7 @@ class TestKimiSoulPlanState:
     async def test_session_id_allocated_on_activation(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -509,7 +509,7 @@ class TestKimiSoulPlanState:
     async def test_session_id_idempotent(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._ensure_plan_session_id()
@@ -520,7 +520,7 @@ class TestKimiSoulPlanState:
     async def test_session_id_persists_after_deactivation(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -534,7 +534,7 @@ class TestKimiSoulPlanState:
     async def test_plan_file_path_valid_after_activation(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -545,7 +545,7 @@ class TestKimiSoulPlanState:
     async def test_read_current_plan_none_no_file(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -554,7 +554,7 @@ class TestKimiSoulPlanState:
     async def test_read_current_plan_returns_content(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -567,7 +567,7 @@ class TestKimiSoulPlanState:
     async def test_clear_current_plan_deletes_file(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -581,7 +581,7 @@ class TestKimiSoulPlanState:
     async def test_clear_current_plan_noop_no_file(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         soul._set_plan_mode(True, source="tool")
@@ -590,7 +590,7 @@ class TestKimiSoulPlanState:
     async def test_status_includes_plan_mode(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
 
         assert soul.status.plan_mode is False
@@ -640,7 +640,7 @@ class TestKimiSoulPlanSessionPersistence:
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Second KimiSoul created from same session state gets same plan file path."""
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul1 = _make_soul(runtime, tmp_path)
         soul1._set_plan_mode(True, source="tool")
         path1 = soul1.get_plan_file_path()
@@ -658,7 +658,7 @@ class TestKimiSoulPlanSessionPersistence:
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """After plan mode is turned off and process restarts, new activation gets fresh path."""
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul1 = _make_soul(runtime, tmp_path)
         soul1._set_plan_mode(True, source="tool")
         path1 = soul1.get_plan_file_path()

--- a/tests/core/test_plan_slash.py
+++ b/tests/core/test_plan_slash.py
@@ -42,7 +42,7 @@ class TestPlanSlashCommand:
     async def test_plan_on(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -55,7 +55,7 @@ class TestPlanSlashCommand:
     async def test_plan_on_idempotent(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -68,7 +68,7 @@ class TestPlanSlashCommand:
     async def test_plan_off(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -83,7 +83,7 @@ class TestPlanSlashCommand:
     async def test_plan_off_idempotent(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -96,7 +96,7 @@ class TestPlanSlashCommand:
     async def test_plan_view_with_content(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -115,7 +115,7 @@ class TestPlanSlashCommand:
     async def test_plan_view_no_content(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -129,7 +129,7 @@ class TestPlanSlashCommand:
     async def test_plan_clear(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -149,7 +149,7 @@ class TestPlanSlashCommand:
     async def test_plan_toggle_on(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
@@ -162,7 +162,7 @@ class TestPlanSlashCommand:
     async def test_plan_toggle_off(
         self, runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes._get_plans_dir", lambda: tmp_path)
         soul = _make_soul(runtime, tmp_path)
         sent: list[TextPart] = []
         monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))


### PR DESCRIPTION
## Summary

Plan files were stored in a hardcoded path `~/.kimi/plans` instead of respecting the `KIMI_SHARE_DIR` environment variable.

## Changes

- Use `get_share_dir() / "plans"` instead of hardcoded `Path.home() / ".kimi" / "plans"`
- Add automatic migration to move existing plan files from legacy path to new path
- Update tests to mock the internal `_get_plans_dir` function

## Migration Behavior

When the legacy `~/.kimi/plans` directory exists and is different from the target directory:
1. Copy all `*.md` plan files to the new location (skip if already exists)
2. Remove legacy directory only if it becomes empty after migration
3. Migration failures are silently ignored to avoid blocking normal operation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
