### PR TITLE
fix(config): tolerate UTF-8 BOM in config files

### DIFF
--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -323,7 +323,7 @@ def load_config(config_file: Path | None = None) -> Config:
         return config
 
     try:
-        config_text = config_file.read_text(encoding="utf-8")
+        config_text = config_file.read_text(encoding="utf-8-sig")
         if config_file.suffix.lower() == ".json":
             data = json.loads(config_text)
         else:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -83,6 +83,30 @@ def test_load_config_sets_source_file(tmp_path):
     assert not config.is_from_default_location
 
 
+def test_load_config_accepts_utf8_bom_toml(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        """\ufeffdefault_model = "kimi-k2"
+
+[models.kimi-k2]
+provider = "test"
+model = "kimi-k2"
+max_context_size = 100000
+
+[providers.test]
+type = "_echo"
+base_url = "http://localhost"
+api_key = "test"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_file)
+
+    assert config.default_model == "kimi-k2"
+    assert config.source_file == config_file.resolve()
+
+
 def test_load_config_text_has_no_source_file():
     config = load_config_from_string('{"default_model": ""}')
 


### PR DESCRIPTION
Fixes #2043

## Summary
- Read disk config files with `utf-8-sig` so a leading UTF-8 BOM is ignored before TOML/JSON parsing.
- Add regression coverage for a BOM-prefixed `config.toml`.
- Keep config schema and save behavior unchanged.

## Root Cause
`load_config()` read config files with `utf-8`, which preserves a leading `\ufeff`. `tomlkit` then parsed that BOM as TOML content and raised `Empty key at line 1 col 0`.

## Validation
- `uv run pytest tests/core/test_config.py -k "bom" -q`
- `uv run pytest tests/core/test_config.py -q`
- `uv run ruff check src/kimi_cli/config.py tests/core/test_config.py`
- `uv run ruff format --check src/kimi_cli/config.py tests/core/test_config.py`
- `uv run pyright src/kimi_cli/config.py tests/core/test_config.py`

## Note
- On this Windows machine, full `uv run pyright` still reports existing POSIX-only attribute issues in `tests/e2e/shell_pty_helpers.py`; the changed files pass targeted pyright.
