### PR TITLE
feat(acp): notify clients when approval is required

### DIFF
--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -49,6 +49,8 @@ from kimi_cli.wire.types import (
 _current_turn_id = ContextVar[str | None]("current_turn_id", default=None)
 _terminal_tool_call_ids = ContextVar[set[str] | None]("terminal_tool_call_ids", default=None)
 
+APPROVAL_REQUIRED_NOTIFICATION = "kimi/approval_required"
+
 
 def get_current_acp_tool_call_id_or_none() -> str | None:
     """See `_ToolCallState.acp_tool_call_id`."""
@@ -415,6 +417,8 @@ class ACPSession:
                     )
                 )
 
+            await self._send_approval_required_notification(request, state)
+
             # Send permission request and wait for response
             logger.debug("Requesting permission for action: {action}", action=request.action)
             response = await self._conn.request_permission(
@@ -465,6 +469,31 @@ class ACPSession:
             logger.exception("Error handling approval request:")
             # On error, reject the request
             request.resolve("reject")
+
+    async def _send_approval_required_notification(
+        self, request: ApprovalRequest, state: _ToolCallState
+    ) -> None:
+        """Notify ACP clients that an approval is pending before opening the prompt."""
+        try:
+            await self._conn.ext_notification(
+                APPROVAL_REQUIRED_NOTIFICATION,
+                {
+                    "session_id": self._id,
+                    "request_id": request.id,
+                    "tool_call_id": state.acp_tool_call_id,
+                    "title": "Kimi: Approval required",
+                    "message": "Kimi: Approval required. Please check the Kimi Code panel.",
+                    "action_label": "Open Kimi",
+                    "focus_command": "kimi.webview.focus",
+                    "tool_title": state.get_title(),
+                    "approval_action": request.action,
+                    "description": request.description,
+                    "source_kind": request.source_kind,
+                    "source_id": request.source_id,
+                },
+            )
+        except Exception:
+            logger.debug("ACP client did not handle approval notification", exc_info=True)
 
     async def _send_plan_update(self, block: TodoDisplayBlock) -> None:
         """Send todo list updates as ACP agent plan updates."""

--- a/tests/acp/test_session_notifications.py
+++ b/tests/acp/test_session_notifications.py
@@ -1,20 +1,36 @@
 from __future__ import annotations
 
+from typing import Any
+
 import acp
 import pytest
+from kosong.message import ToolCall
 
-from kimi_cli.acp.session import ACPSession
-from kimi_cli.wire.types import Notification, TextPart, TurnBegin, TurnEnd
+from kimi_cli.acp.session import APPROVAL_REQUIRED_NOTIFICATION, ACPSession
+from kimi_cli.wire.types import ApprovalRequest, Notification, TextPart, TurnBegin, TurnEnd
 
 
 class _FakeConn:
     def __init__(self) -> None:
-        from typing import Any
-
         self.updates: list[tuple[str, Any]] = []
+        self.ext_notifications: list[tuple[str, dict[str, Any]]] = []
 
     async def session_update(self, session_id: str, update: object) -> None:
         self.updates.append((session_id, update))
+
+    async def request_permission(
+        self,
+        options: list[acp.schema.PermissionOption],
+        session_id: str,
+        tool_call: acp.schema.ToolCallUpdate,
+        **kwargs: object,
+    ) -> acp.schema.RequestPermissionResponse:
+        return acp.schema.RequestPermissionResponse(
+            outcome=acp.schema.AllowedOutcome(outcome="selected", option_id="approve")
+        )
+
+    async def ext_notification(self, method: str, params: dict[str, object]) -> None:
+        self.ext_notifications.append((method, params))
 
 
 class _FakeCLI:
@@ -36,6 +52,26 @@ class _FakeCLI:
         yield TurnEnd()
 
 
+class _ApprovalCLI:
+    async def run(self, _user_input, _cancel_event):
+        tool_call = ToolCall(
+            id="tool-1",
+            function=ToolCall.FunctionBody(name="Shell", arguments='{"command": "make test"}'),
+        )
+        request = ApprovalRequest(
+            id="approval-1",
+            tool_call_id="tool-1",
+            sender="Shell",
+            action="Shell: make test",
+            description="Run make test",
+        )
+
+        yield TurnBegin(user_input=[TextPart(text="hello")])
+        yield tool_call
+        yield request
+        yield TurnEnd()
+
+
 @pytest.mark.asyncio
 async def test_acp_session_surfaces_notification_as_message_chunk() -> None:
     conn = _FakeConn()
@@ -52,3 +88,32 @@ async def test_acp_session_surfaces_notification_as_message_chunk() -> None:
     )
     assert "Task ID: b1234567" in notification_update.content.text
     assert text_update.content.text == "done"
+
+
+@pytest.mark.asyncio
+async def test_acp_session_sends_approval_required_ext_notification() -> None:
+    conn = _FakeConn()
+    session = ACPSession("session-1", _ApprovalCLI(), conn)  # type: ignore[arg-type]
+
+    response = await session.prompt([acp.text_block("hello")])
+
+    assert response.stop_reason == "end_turn"
+    assert len(conn.ext_notifications) == 1
+    method, params = conn.ext_notifications[0]
+    assert method == APPROVAL_REQUIRED_NOTIFICATION
+    tool_call_id = params.pop("tool_call_id")
+    assert params == {
+        "session_id": "session-1",
+        "request_id": "approval-1",
+        "title": "Kimi: Approval required",
+        "message": "Kimi: Approval required. Please check the Kimi Code panel.",
+        "action_label": "Open Kimi",
+        "focus_command": "kimi.webview.focus",
+        "tool_title": "Shell: make test",
+        "approval_action": "Shell: make test",
+        "description": "Run make test",
+        "source_kind": None,
+        "source_id": None,
+    }
+    assert isinstance(tool_call_id, str)
+    assert tool_call_id.endswith("/tool-1")


### PR DESCRIPTION
## Related Issue

Resolve #2040

## Description

Adds an ACP custom notification before an approval request is sent to the client.

When a tool call requires approval, the ACP session now emits:

`kimi/approval_required`

The payload includes the notification message, the `Open Kimi` action label, and `focus_command: "kimi.webview.focus"` so the VS Code extension can show a native `vscode.window.showInformationMessage()` notification and focus the Kimi panel when clicked.

This keeps the existing approval dialog unchanged; the notification is only a best-effort alert for clients that support it. Clients that do not handle the custom notification continue through the normal `session/request_permission` flow.

Added a focused ACP unit test covering the emitted notification payload.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

## Testing

- `uv run pytest tests\acp\test_session_notifications.py`
- `uv run ruff check src\kimi_cli\acp\session.py tests\acp\test_session_notifications.py`
- `git diff --check`

Note: I could not manually test the full VS Code notification flow because I do not have a Kimi account subscription or API key. The CLI-side ACP notification is covered by unit tests.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
