### PR TITLE
feat(cli): add git worktree support for isolated sessions

### DIFF
--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -130,6 +130,28 @@ def kimi(
             ),
         ),
     ] = None,
+    use_worktree: Annotated[
+        bool,
+        typer.Option(
+            "--worktree",
+            "-W",
+            help="Create a new git worktree and run the session inside it. Default: no.",
+        ),
+    ] = False,
+    worktree_name: Annotated[
+        str | None,
+        typer.Option(
+            "--worktree-name",
+            help="Name for the worktree directory (default: auto-generated).",
+        ),
+    ] = None,
+    worktree_branch: Annotated[
+        str | None,
+        typer.Option(
+            "--worktree-branch",
+            help="Branch to check out in the worktree (default: detached HEAD at current HEAD).",
+        ),
+    ] = None,
     session_id: Annotated[
         str | None,
         typer.Option(
@@ -376,6 +398,7 @@ def kimi(
     from kimi_cli.session import Session
     from kimi_cli.ui.shell.startup import ShellStartupProgress
     from kimi_cli.utils.logging import logger, open_original_stderr, redirect_stderr_to_logger
+    from kimi_cli.worktree import WorktreeError, create_worktree, find_git_root
 
     from .mcp import get_global_mcp_config_file
 
@@ -437,6 +460,14 @@ def kimi(
         {
             "--config": config_string is not None,
             "--config-file": config_file is not None,
+        },
+        {
+            "--worktree": use_worktree,
+            "--continue": continue_,
+        },
+        {
+            "--worktree": use_worktree,
+            "--session": session_id is not None or _picker_mode,
         },
     ]
     for option_set in conflict_option_sets:
@@ -529,6 +560,14 @@ def kimi(
     # exception handler can clean it up even when _run() fails before returning.
     _latest_created_session: Session | None = None
 
+    # Tracks whether we have already created a worktree in this invocation,
+    # so that Reload re-entries do not create nested worktrees.
+    _worktree_created: bool = False
+
+    # Tracks the parent repo path across Reload re-entries so that sessions
+    # created after Reload still get worktree state persisted.
+    _parent_repo_path: str | None = None
+
     async def _run(session_id: str | None, prefill_text: str | None = None) -> tuple[Session, int]:
         """
         Create/load session and run the CLI instance.
@@ -539,6 +578,28 @@ def kimi(
         startup_progress = ShellStartupProgress(enabled=ui == "shell")
         try:
             startup_progress.update("Preparing session...")
+
+            nonlocal work_dir
+            nonlocal _worktree_created
+            nonlocal _parent_repo_path
+
+            if use_worktree and not _worktree_created:
+                git_root = await find_git_root(work_dir)
+                if git_root is None:
+                    raise typer.BadParameter(
+                        "--worktree requires the working directory to be inside a git repository",
+                        param_hint="--worktree",
+                    )
+                _parent_repo_path = str(git_root)
+                try:
+                    work_dir = await create_worktree(
+                        git_root,
+                        name=worktree_name,
+                        branch=worktree_branch,
+                    )
+                except WorktreeError as exc:
+                    raise typer.BadParameter(str(exc), param_hint="--worktree") from exc
+                _worktree_created = True
 
             # Track if we're resuming an existing session (vs creating new)
             resumed = False
@@ -569,6 +630,12 @@ def kimi(
             else:
                 session = await Session.create(work_dir)
                 logger.info("Created new session: {session_id}", session_id=session.id)
+
+            # Persist worktree association for new worktree sessions
+            if use_worktree and _parent_repo_path is not None:
+                session.state.worktree_path = str(work_dir)
+                session.state.parent_repo_path = _parent_repo_path
+                session.save_state()
 
             nonlocal _latest_created_session
             _latest_created_session = session
@@ -700,13 +767,13 @@ def kimi(
         finally:
             startup_progress.stop()
 
-    async def _delete_empty_session(session: Session) -> None:
+    async def _delete_empty_session(session: Session, *, remove_worktree: bool = True) -> None:
         """Delete an empty session directory and clear last_session_id if it pointed to it."""
         logger.info(
             "Session {session_id} has empty context, removing it",
             session_id=session.id,
         )
-        await session.delete()
+        await session.delete(remove_worktree=remove_worktree)
         meta = load_metadata()
         wdm = meta.get_work_dir_meta(session.work_dir)
         if wdm is not None and wdm.last_session_id == session.id:
@@ -753,7 +820,7 @@ def kimi(
                     # Clean up old empty session when switching to a different session
                     old = e.source_session
                     if old is not None and old.id != e.session_id and old.is_empty():
-                        await _delete_empty_session(old)
+                        await _delete_empty_session(old, remove_worktree=False)
                         last_session = None
                     else:
                         last_session = e.source_session

--- a/src/kimi_cli/session.py
+++ b/src/kimi_cli/session.py
@@ -96,8 +96,29 @@ class Session:
         self.state.auto_archive_exempt = fresh.auto_archive_exempt
         save_session_state(self.state, self.dir)
 
-    async def delete(self) -> None:
-        """Delete the session directory."""
+    async def delete(self, *, remove_worktree: bool = True) -> None:
+        """Delete the session directory.
+
+        If the session was created inside a git worktree and *remove_worktree*
+        is ``True``, the git worktree is also removed (best-effort) so that
+        abandoned worktrees do not accumulate. Pass ``remove_worktree=False``
+        when the worktree is still in active use (e.g. ``/new`` slash command).
+        """
+        # Remove git worktree first, before the session directory disappears
+        if remove_worktree and self.state.worktree_path and self.state.parent_repo_path:
+            from kimi_cli.worktree import remove_worktree
+
+            try:
+                await remove_worktree(
+                    KaosPath(self.state.parent_repo_path),
+                    KaosPath(self.state.worktree_path),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to remove git worktree {path}, session dir will still be deleted",
+                    path=self.state.worktree_path,
+                )
+
         session_dir = self.work_dir_meta.sessions_dir / self.id
         if not session_dir.exists():
             return

--- a/src/kimi_cli/session_state.py
+++ b/src/kimi_cli/session_state.py
@@ -41,6 +41,11 @@ class SessionState(BaseModel):
     auto_archive_exempt: bool = False
     # Todo list state
     todos: list[TodoItemState] = Field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    # Worktree state
+    worktree_path: str | None = None
+    """Absolute path to the git worktree directory, if this session runs in one."""
+    parent_repo_path: str | None = None
+    """Absolute path to the parent git repository root, if this session runs in a worktree."""
 
 
 _LEGACY_METADATA_FILENAME = "metadata.json"

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -519,7 +519,7 @@ async def new(app: Shell, args: str):
     # /new commands (or switching away before the first message) does not
     # leave orphan empty session directories on disk.
     if current_session.is_empty():
-        await current_session.delete()
+        await current_session.delete(remove_worktree=False)
     session = await Session.create(work_dir)
     from kimi_cli.telemetry import track
 

--- a/src/kimi_cli/worktree.py
+++ b/src/kimi_cli/worktree.py
@@ -1,0 +1,205 @@
+"""Git worktree management for isolated agent sessions."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import kaos
+from kaos.path import KaosPath
+
+from kimi_cli.utils.logging import logger
+
+_TIMEOUT = 30.0
+
+
+class WorktreeError(Exception):
+    """Raised when a git worktree operation fails."""
+
+    def __init__(self, message: str, stderr: str | None = None) -> None:
+        super().__init__(message)
+        self.stderr = stderr
+
+
+async def find_git_root(path: KaosPath) -> KaosPath | None:
+    """Find the git repository root containing *path*.
+
+    Returns ``None`` if *path* is not inside a git repository.
+    """
+    cwd = str(path)
+    result = await _run_git(["rev-parse", "--show-toplevel"], cwd)
+    if result is None:
+        return None
+    return KaosPath(result).canonical()
+
+
+async def create_worktree(
+    repo_root: KaosPath,
+    name: str | None = None,
+    branch: str | None = None,
+) -> KaosPath:
+    """Create a new git worktree for an agent session.
+
+    Args:
+        repo_root: Absolute path to the git repository root.
+        name: Optional directory name for the worktree. Auto-generated if omitted.
+        branch: Optional branch to check out. If omitted, the worktree is created
+            in a detached HEAD state at the current HEAD.
+
+    Returns:
+        The absolute path of the newly created worktree directory.
+
+    Raises:
+        WorktreeError: If the worktree cannot be created.
+    """
+    repo_root = repo_root.canonical()
+
+    # Auto-generate name if not provided
+    if name is None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        name = f"kimi-{timestamp}"
+
+    # Ensure .kimi directory exists at repo root
+    kimi_dir = Path(str(repo_root)) / ".kimi"
+    kimi_dir.mkdir(parents=True, exist_ok=True)
+
+    worktrees_dir = kimi_dir / "worktrees"
+    worktrees_dir.mkdir(parents=True, exist_ok=True)
+
+    worktree_path = worktrees_dir / name
+
+    if worktree_path.exists():
+        raise WorktreeError(
+            f"Worktree directory already exists: {worktree_path}\n"
+            f"Use --worktree-name to choose a different name, or remove the existing directory."
+        )
+
+    args = ["worktree", "add"]
+    if branch is not None:
+        args.extend([str(worktree_path), branch])
+    else:
+        args.extend(["--detach", str(worktree_path)])
+
+    stdout, stderr, exit_code = await _run_git_raw(args, str(repo_root))
+
+    if exit_code != 0:
+        # Clean up partial directory if git created it
+        if worktree_path.exists():
+            await asyncio.to_thread(_rmtree_sync, Path(str(worktree_path)))
+        raise WorktreeError(
+            f"Failed to create git worktree at {worktree_path}\n"
+            f"git stderr: {stderr or '(no output)'}"
+        )
+
+    logger.info(
+        "Created git worktree: {path} (repo: {repo})",
+        path=worktree_path,
+        repo=repo_root,
+    )
+    return KaosPath.unsafe_from_local_path(worktree_path)
+
+
+async def remove_worktree(repo_root: KaosPath, worktree_path: KaosPath) -> None:
+    """Remove a git worktree and its directory.
+
+    Uses ``git worktree remove`` if the worktree is registered with git,
+    otherwise falls back to plain directory removal.
+    """
+    repo_root = repo_root.canonical()
+    worktree_path = worktree_path.canonical()
+
+    # Try git worktree remove first
+    stdout, stderr, exit_code = await _run_git_raw(
+        ["worktree", "remove", str(worktree_path)],
+        str(repo_root),
+    )
+
+    if exit_code != 0:
+        # Git may complain if the worktree is not registered; fall back to rm
+        logger.warning(
+            "git worktree remove failed ({code}), falling back to rmtree: {stderr}",
+            code=exit_code,
+            stderr=stderr,
+        )
+        if Path(str(worktree_path)).exists():
+            await asyncio.to_thread(_rmtree_sync, Path(str(worktree_path)))
+    else:
+        logger.info(
+            "Removed git worktree: {path}",
+            path=worktree_path,
+        )
+
+    # Also prune stale worktree metadata
+    await _run_git_raw(["worktree", "prune"], str(repo_root))
+
+
+async def list_worktrees(repo_root: KaosPath) -> list[dict[str, str]]:
+    """List registered git worktrees for the repository.
+
+    Returns a list of dicts with keys ``path`` and ``branch``.
+    """
+    repo_root = repo_root.canonical()
+    result = await _run_git(["worktree", "list", "--porcelain"], str(repo_root))
+    if result is None:
+        return []
+
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in result.splitlines():
+        if line.startswith("worktree "):
+            if current:
+                worktrees.append(current)
+            current = {"path": line[len("worktree "):].strip()}
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch "):].strip()
+        elif line.startswith("detached"):
+            current["branch"] = "(detached HEAD)"
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+async def _run_git(args: list[str], cwd: str, timeout: float = _TIMEOUT) -> str | None:
+    """Run a git command and return stripped stdout, or None on failure."""
+    stdout, stderr, exit_code = await _run_git_raw(args, cwd, timeout)
+    if exit_code != 0:
+        return None
+    return stdout.strip() if stdout else ""
+
+
+async def _run_git_raw(
+    args: list[str],
+    cwd: str,
+    timeout: float = _TIMEOUT,
+) -> tuple[str, str, int]:
+    """Run a git command and return (stdout, stderr, exit_code)."""
+    proc = None
+    try:
+        proc = await kaos.exec("git", "-C", cwd, *args)
+        proc.stdin.close()
+        stdout_bytes = await asyncio.wait_for(proc.stdout.read(-1), timeout=timeout)
+        stderr_bytes = await asyncio.wait_for(proc.stderr.read(-1), timeout=timeout)
+        exit_code = await asyncio.wait_for(proc.wait(), timeout=timeout)
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        return stdout, stderr, exit_code
+    except TimeoutError:
+        logger.debug("git {args} timed out after {t}s", args=args, t=timeout)
+        if proc is not None:
+            await proc.kill()
+            await proc.wait()
+        return "", "timeout", 1
+    except Exception:
+        logger.debug("git {args} failed", args=args)
+        if proc is not None and proc.returncode is None:
+            await proc.kill()
+            await proc.wait()
+        return "", "exception", 1
+
+
+def _rmtree_sync(path: Path) -> None:
+    """Synchronous rmtree helper for asyncio.to_thread."""
+    import shutil
+
+    shutil.rmtree(path, ignore_errors=True)

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,0 +1,209 @@
+"""Tests for kimi_cli.worktree."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from kaos import reset_current_kaos, set_current_kaos
+from kaos.local import LocalKaos
+from kaos.path import KaosPath
+
+from kimi_cli.worktree import (
+    WorktreeError,
+    create_worktree,
+    find_git_root,
+    list_worktrees,
+    remove_worktree,
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_local_kaos() -> None:
+    token = set_current_kaos(LocalKaos())
+    try:
+        yield
+    finally:
+        reset_current_kaos(token)
+
+
+def _kaos_path(p: Path) -> KaosPath:
+    return KaosPath.unsafe_from_local_path(p)
+
+
+async def _git_init(path: Path) -> None:
+    """Initialize a git repo at *path*."""
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "init",
+        cwd=path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "config",
+        "user.email",
+        "test@test.com",
+        cwd=path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "config",
+        "user.name",
+        "Test",
+        cwd=path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+
+
+async def _git_commit(path: Path, message: str = "commit") -> None:
+    """Stage all and commit."""
+    proc = await asyncio.create_subprocess_exec(
+        "git", "add", ".", cwd=path, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+    )
+    await proc.communicate()
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "commit",
+        "-m",
+        message,
+        cwd=path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+
+
+class TestFindGitRoot:
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_git_dir(self, tmp_path: Path) -> None:
+        result = await find_git_root(_kaos_path(tmp_path))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_finds_root(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        subdir = tmp_path / "a" / "b"
+        subdir.mkdir(parents=True)
+        result = await find_git_root(_kaos_path(subdir))
+        assert result is not None
+        assert str(result) == str(tmp_path)
+
+
+class TestCreateWorktree:
+    @pytest.mark.asyncio
+    async def test_creates_worktree_detached(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        repo = _kaos_path(tmp_path)
+        wt = await create_worktree(repo, name="feature-x")
+
+        assert wt.name == "feature-x"
+        assert (Path(str(wt)) / "file.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_creates_worktree_on_branch(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        # Create a branch from HEAD without checking it out in the main worktree.
+        # This leaves the branch free for a worktree checkout.
+        proc = await asyncio.create_subprocess_exec(
+            "git", "branch", "feature-y",
+            cwd=tmp_path, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+
+        repo = _kaos_path(tmp_path)
+        wt = await create_worktree(repo, name="feature-y-wt", branch="feature-y")
+
+        assert wt.name == "feature-y-wt"
+        assert (Path(str(wt)) / "file.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_auto_generates_name(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        repo = _kaos_path(tmp_path)
+        wt = await create_worktree(repo)
+
+        assert wt.name.startswith("kimi-")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_duplicate_name(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        repo = _kaos_path(tmp_path)
+        await create_worktree(repo, name="dup")
+
+        with pytest.raises(WorktreeError, match="already exists"):
+            await create_worktree(repo, name="dup")
+
+    @pytest.mark.asyncio
+    async def test_raises_outside_git_repo(self, tmp_path: Path) -> None:
+        with pytest.raises(WorktreeError):
+            await create_worktree(_kaos_path(tmp_path), name="x")
+
+
+class TestRemoveWorktree:
+    @pytest.mark.asyncio
+    async def test_removes_worktree(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        repo = _kaos_path(tmp_path)
+        wt = await create_worktree(repo, name="to-remove")
+        wt_path = Path(str(wt))
+        assert wt_path.exists()
+
+        await remove_worktree(repo, wt)
+        assert not wt_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_noop_for_missing_path(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        repo = _kaos_path(tmp_path)
+        missing = _kaos_path(tmp_path / ".kimi" / "worktrees" / "ghost")
+        # Should not raise
+        await remove_worktree(repo, missing)
+
+
+class TestListWorktrees:
+    @pytest.mark.asyncio
+    async def test_lists_worktrees(self, tmp_path: Path) -> None:
+        await _git_init(tmp_path)
+        (tmp_path / "file.txt").write_text("hello")
+        await _git_commit(tmp_path, "initial")
+
+        repo = _kaos_path(tmp_path)
+        wt1 = await create_worktree(repo, name="wt1")
+        wt2 = await create_worktree(repo, name="wt2")
+
+        wts = await list_worktrees(repo)
+        paths = {w["path"] for w in wts}
+        assert str(wt1) in paths
+        assert str(wt2) in paths
+
+    @pytest.mark.asyncio
+    async def test_empty_for_non_git(self, tmp_path: Path) -> None:
+        wts = await list_worktrees(_kaos_path(tmp_path))
+        assert wts == []

--- a/tests/test_worktree_cli.py
+++ b/tests/test_worktree_cli.py
@@ -1,0 +1,48 @@
+"""Tests for worktree CLI integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from kimi_cli.cli import cli
+
+
+runner = CliRunner()
+
+
+class TestWorktreeCliOptions:
+    def test_help_shows_worktree_options(self) -> None:
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "--worktree" in result.output
+        assert "--worktree-name" in result.output
+        # Typer may truncate long option names in the help table
+        assert "--worktree-bran" in result.output
+
+    def test_worktree_conflicts_with_continue(self) -> None:
+        result = runner.invoke(cli, ["--worktree", "--continue"])
+        assert result.exit_code != 0
+        assert "Cannot combine" in result.output
+        assert "--worktree" in result.output
+        assert "--continue" in result.output
+
+    def test_worktree_conflicts_with_session(self) -> None:
+        result = runner.invoke(cli, ["--worktree", "--session", "abc"])
+        assert result.exit_code != 0
+        assert "Cannot combine" in result.output
+        assert "--worktree" in result.output
+        assert "--session" in result.output
+
+    def test_worktree_rejects_non_git_directory(self, tmp_path: Path) -> None:
+        result = runner.invoke(cli, ["--worktree", "-w", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "inside a git repository" in result.output
+
+    def test_worktree_branch_without_worktree_is_allowed(self) -> None:
+        """Currently we do not error on --worktree-branch without --worktree;
+        the flag is simply ignored. This can be tightened later if desired."""
+        result = runner.invoke(cli, ["--worktree-branch", "main", "--help"])
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Add `--worktree` / `-W` flag to create a new git worktree and run the session inside it. This allows multiple parallel kimi sessions on the same repository without file conflicts or branch-switching overhead.

## New CLI Options

- `--worktree`, `-W` — Create a new git worktree for the session
- `--worktree-name <name>` — Custom worktree directory name
- `--worktree-branch <branch>` — Branch to check out (default: detached HEAD)

## Usage Example

```bash
cd ~/my-project
kimi --worktree -p "refactor the auth module"

# With a custom name and branch
kimi --worktree --worktree-name feature-oauth --worktree-branch feature/oauth -p "implement OAuth2"
```

## Implementation Details

- New `worktree.py` module with `create_worktree()`, `remove_worktree()`, `list_worktrees()`, and `find_git_root()` helpers.
- `SessionState` extended with `worktree_path` and `parent_repo_path`.
- `Session.delete()` cleans up the git worktree to avoid accumulation of abandoned worktrees.
- Conflict checks prevent combining `--worktree` with `--continue` or `--session`.

## Tests

- Unit tests for worktree creation, removal, listing, and error cases.
- CLI tests for option parsing and conflict detection.
- All 1825 tests pass.

## Motivation

Inspired by Codex and Claude Code worktree workflows, which use git worktrees to isolate parallel agent sessions on the same repo.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
