### PR TITLE
feat(proctitle): set dynamic terminal title with cwd + session topic

### DIFF
--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -570,6 +570,18 @@ def kimi(
                 session = await Session.create(work_dir)
                 logger.info("Created new session: {session_id}", session_id=session.id)
 
+            # Refresh the terminal tab/window title with the live session
+            # context so users with many tabs can identify each one. Mirrors
+            # what Copilot CLI and Claude Code do; updates infrequently
+            # (here on session establishment, in soul/kimisoul.py after the
+            # auto-generated topic, and on /title).
+            from kimi_cli.utils.proctitle import update_terminal_title_for_session
+
+            update_terminal_title_for_session(
+                work_dir=str(work_dir),
+                topic=session.state.custom_title or session.title or None,
+            )
+
             nonlocal _latest_created_session
             _latest_created_session = session
 

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -584,7 +584,11 @@ def kimi(
             if _initial_topic == "Untitled":
                 _initial_topic = None
             update_terminal_title_for_session(
-                work_dir=str(work_dir),
+                # session.work_dir is canonicalized by Session.create / find /
+                # continue_; the raw CLI work_dir argument may still be a
+                # relative path like "." or "..", which would render as a
+                # useless tab title basename.
+                work_dir=str(session.work_dir),
                 topic=_initial_topic,
             )
 

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -577,9 +577,15 @@ def kimi(
             # auto-generated topic, and on /title).
             from kimi_cli.utils.proctitle import update_terminal_title_for_session
 
+            # Skip the placeholder title that Session.refresh() assigns to
+            # empty sessions; otherwise every fresh tab would display the
+            # noisy and identical "Untitled" topic.
+            _initial_topic = session.state.custom_title or session.title or None
+            if _initial_topic == "Untitled":
+                _initial_topic = None
             update_terminal_title_for_session(
                 work_dir=str(work_dir),
-                topic=session.state.custom_title or session.title or None,
+                topic=_initial_topic,
             )
 
             nonlocal _latest_created_session

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -639,8 +639,11 @@ class KimiSoul:
                                 work_dir=str(session.work_dir),
                                 topic=session.state.custom_title,
                             )
-                        except Exception:
-                            logger.debug("Failed to refresh terminal title")
+                        except OSError:
+                            logger.opt(exception=True).debug(
+                                "Failed to refresh terminal title for session {session_id}",
+                                session_id=session.id,
+                            )
         finally:
             if turn_started and not turn_finished:
                 wire_send(TurnEnd())

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -625,6 +625,22 @@ class KimiSoul:
                             fresh.custom_title = title
                             save_session_state(fresh, session.dir)
                         session.state.custom_title = fresh.custom_title
+
+                        # Reflect the freshly-derived topic in the terminal
+                        # tab/window title so multi-tab users can identify
+                        # each session. Best-effort; never let it disrupt
+                        # the turn loop.
+                        try:
+                            from kimi_cli.utils.proctitle import (
+                                update_terminal_title_for_session,
+                            )
+
+                            update_terminal_title_for_session(
+                                work_dir=str(session.work_dir),
+                                topic=session.state.custom_title,
+                            )
+                        except Exception:
+                            logger.debug("Failed to refresh terminal title")
         finally:
             if turn_started and not turn_finished:
                 wire_send(TurnEnd())

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -550,6 +550,16 @@ async def title(app: Shell, args: str):
     session.state.custom_title = new_title
     session.state.title_generated = True
     session.title = new_title
+    # Update the terminal tab/window title to reflect the user's choice.
+    try:
+        from kimi_cli.utils.proctitle import update_terminal_title_for_session
+
+        update_terminal_title_for_session(
+            work_dir=str(session.work_dir),
+            topic=new_title,
+        )
+    except Exception:
+        pass
     console.print(f"[green]Session title set to: {new_title}[/green]")
 
 

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -558,8 +558,11 @@ async def title(app: Shell, args: str):
             work_dir=str(session.work_dir),
             topic=new_title,
         )
-    except Exception:
-        pass
+    except OSError:
+        logger.opt(exception=True).debug(
+            "Failed to refresh terminal title for session {session_id}",
+            session_id=session.id,
+        )
     console.print(f"[green]Session title set to: {new_title}[/green]")
 
 

--- a/src/kimi_cli/utils/logging.py
+++ b/src/kimi_cli/utils/logging.py
@@ -122,3 +122,17 @@ def open_original_stderr() -> Iterator[IO[bytes] | None]:
     finally:
         if stream is not None:
             stream.close()
+
+
+def get_original_stderr_handle() -> IO[bytes] | None:
+    """Return a fresh binary handle to the pre-redirect stderr fd, if any.
+
+    Returns ``None`` when stderr redirection has not been installed yet, in
+    which case ``sys.stderr`` still points at the original fd and callers
+    can write to it directly. The caller owns the returned handle and is
+    responsible for closing it (or caching it for the process lifetime).
+    """
+    redirector = _stderr_redirector
+    if redirector is None:
+        return None
+    return redirector.open_original_stderr_handle()

--- a/src/kimi_cli/utils/proctitle.py
+++ b/src/kimi_cli/utils/proctitle.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import os
 import sys
+
+# Maximum length of the topic snippet rendered in the terminal title. Tabs
+# are typically narrow; 40 characters fits while still being descriptive.
+_TITLE_TOPIC_MAX = 40
 
 
 def set_process_title(title: str) -> None:
@@ -31,3 +36,52 @@ def init_process_name(name: str = "Kimi Code") -> None:
     """Initialize process name: OS process title + terminal tab title."""
     set_process_title(name)
     set_terminal_title(name)
+
+
+def _truncate_topic(topic: str, max_len: int = _TITLE_TOPIC_MAX) -> str:
+    """Collapse whitespace and clamp ``topic`` to ``max_len`` chars."""
+    flat = " ".join(topic.split())
+    if len(flat) <= max_len:
+        return flat
+    return flat[: max_len - 1].rstrip() + "\u2026"
+
+
+def compose_session_terminal_title(
+    work_dir: str | os.PathLike[str] | None = None,
+    topic: str | None = None,
+    *,
+    base_name: str = "Kimi Code",
+) -> str:
+    """Compose a terminal tab title that conveys live session context.
+
+    Format: ``"<base>[ \u00b7 <topic>][ \u00b7 <cwd-basename>]"``.
+
+    The intent is to mirror what Copilot CLI and Claude Code do — give
+    each tab a stable, human-readable identifier so users with many open
+    sessions can find the right one at a glance, while still being
+    low-frequency (the topic comes from the session's auto-generated /
+    user-set title and only changes at well-defined moments).
+    """
+    parts: list[str] = [base_name]
+    if topic:
+        clipped = _truncate_topic(topic)
+        if clipped:
+            parts.append(clipped)
+    if work_dir is not None:
+        basename = os.path.basename(os.path.normpath(str(work_dir)))
+        if basename:
+            parts.append(basename)
+    return " \u00b7 ".join(parts)
+
+
+def update_terminal_title_for_session(
+    work_dir: str | os.PathLike[str] | None = None,
+    topic: str | None = None,
+    *,
+    base_name: str = "Kimi Code",
+) -> None:
+    """Refresh the terminal tab/window title for the live session.
+
+    Safe to call repeatedly; no-ops when stderr is not a TTY.
+    """
+    set_terminal_title(compose_session_terminal_title(work_dir, topic, base_name=base_name))

--- a/src/kimi_cli/utils/proctitle.py
+++ b/src/kimi_cli/utils/proctitle.py
@@ -109,10 +109,16 @@ def set_terminal_title(title: str) -> None:
     stderr = sys.stderr
     if not stderr.isatty():
         return
+    # On legacy Windows code pages or ASCII/C locale, stderr cannot encode
+    # arbitrary Unicode (Chinese topic, emoji, etc.) and would otherwise
+    # raise UnicodeEncodeError mid-startup. Title updates are best-effort,
+    # so degrade gracefully: substitute unencodable characters with "?".
     try:
-        stderr.write(osc)
+        encoding = getattr(stderr, "encoding", None) or "utf-8"
+        safe = osc.encode(encoding, errors="replace").decode(encoding, errors="replace")
+        stderr.write(safe)
         stderr.flush()
-    except OSError:
+    except (OSError, UnicodeError, LookupError):
         pass
 
 

--- a/src/kimi_cli/utils/proctitle.py
+++ b/src/kimi_cli/utils/proctitle.py
@@ -68,6 +68,13 @@ def _get_original_stderr_handle() -> IO[bytes] | None:
             with contextlib.suppress(OSError):
                 candidate.close()
             return None
+        # Mark the cached fd non-inheritable so subprocesses spawned later
+        # (shell commands, MCP servers) do not accidentally inherit a TTY
+        # handle they should not own. The redirector returns an
+        # inheritable fd by default; flipping the flag here is local to
+        # our cached copy.
+        with contextlib.suppress(OSError, AttributeError):
+            os.set_inheritable(candidate.fileno(), False)
         _original_stderr_handle = candidate
         return candidate
 

--- a/src/kimi_cli/utils/proctitle.py
+++ b/src/kimi_cli/utils/proctitle.py
@@ -1,11 +1,75 @@
 from __future__ import annotations
 
+import contextlib
 import os
+import re
 import sys
+import threading
+from typing import IO
 
 # Maximum length of the topic snippet rendered in the terminal title. Tabs
 # are typically narrow; 40 characters fits while still being descriptive.
 _TITLE_TOPIC_MAX = 40
+
+# Strip C0 controls (0x00-0x1f), DEL (0x7f), and C1 controls (0x80-0x9f)
+# from the OSC payload. Without this, a topic or cwd basename containing
+# BEL / ESC / CR / LF could terminate the title sequence early and let an
+# attacker inject arbitrary terminal escape codes. All other Unicode
+# (Chinese, Japanese, emoji, accented Latin, etc.) is preserved verbatim.
+_OSC_CONTROL_BYTES_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _sanitize_osc_payload(payload: str) -> str:
+    """Strip control bytes that could break out of an OSC title sequence."""
+    return _OSC_CONTROL_BYTES_RE.sub("", payload)
+
+
+# Cached binary handle to the pre-redirect stderr fd. Opened lazily on
+# first successful use and held for the process lifetime so we avoid an
+# os.dup + fdopen round-trip on every title refresh. The redirector is
+# installed after CLI parsing, so early callers (init_process_name) fall
+# back to sys.stderr until then.
+_original_stderr_lock = threading.Lock()
+_original_stderr_handle: IO[bytes] | None = None
+
+
+def _get_original_stderr_handle() -> IO[bytes] | None:
+    """Return a cached, TTY-bound handle to the pre-redirect stderr, or None.
+
+    Returns ``None`` if the stderr redirector has not been installed yet
+    (callers should fall back to ``sys.stderr``) or if the original stderr
+    fd is not a TTY (callers should no-op rather than emit OSC bytes into
+    a log file or pipe). Negative results from "redirector not installed"
+    are intentionally not cached so a later call after the redirector is
+    installed can still succeed.
+    """
+    global _original_stderr_handle
+    handle = _original_stderr_handle
+    if handle is not None:
+        return handle
+    with _original_stderr_lock:
+        if _original_stderr_handle is not None:
+            return _original_stderr_handle
+        # Lazy import: utils.logging pulls in `kimi_cli.logger`, which
+        # touches several utils modules during startup.
+        from kimi_cli.utils.logging import get_original_stderr_handle
+
+        try:
+            candidate = get_original_stderr_handle()
+        except OSError:
+            return None
+        if candidate is None:
+            return None
+        try:
+            is_tty = os.isatty(candidate.fileno())
+        except OSError:
+            is_tty = False
+        if not is_tty:
+            with contextlib.suppress(OSError):
+                candidate.close()
+            return None
+        _original_stderr_handle = candidate
+        return candidate
 
 
 def set_process_title(title: str) -> None:
@@ -19,15 +83,35 @@ def set_process_title(title: str) -> None:
 
 
 def set_terminal_title(title: str) -> None:
-    """Set the terminal tab/window title via ANSI OSC escape sequence.
+    """Set the terminal tab/window title via an ANSI OSC escape sequence.
 
-    Only writes when stderr is a TTY to avoid polluting piped output.
+    Prefers the pre-redirect stderr fd (via the logging redirector) so
+    that title refreshes keep working after ``redirect_stderr_to_logger``
+    swaps fd 2 for a pipe. Falls back to ``sys.stderr`` only when no
+    redirector is installed yet (early startup, before CLI fully boots).
+    No-ops when no TTY is reachable, so piped output and ``kimi --print``
+    never see stray OSC bytes. The composed payload is sanitized at this
+    chokepoint to prevent control-byte injection from user-influenced
+    topic strings or filesystem-derived cwd basenames.
     """
-    if not sys.stderr.isatty():
+    payload = _sanitize_osc_payload(title)
+    osc = f"\033]0;{payload}\007"
+
+    handle = _get_original_stderr_handle()
+    if handle is not None:
+        try:
+            handle.write(osc.encode("utf-8", errors="replace"))
+            handle.flush()
+        except OSError:
+            pass
+        return
+
+    stderr = sys.stderr
+    if not stderr.isatty():
         return
     try:
-        sys.stderr.write(f"\033]0;{title}\007")
-        sys.stderr.flush()
+        stderr.write(osc)
+        stderr.flush()
     except OSError:
         pass
 

--- a/tests/utils/test_proctitle.py
+++ b/tests/utils/test_proctitle.py
@@ -278,9 +278,9 @@ def test_set_terminal_title_degrades_on_unencodable_stderr(
     monkeypatch: pytest.MonkeyPatch,
 ):
     # Force the original-stderr-handle path to miss so the sys.stderr
-    # fallback is exercised.
-    proctitle._original_stderr_handle = None
-    proctitle._original_stderr_attempted = True
+    # fallback is exercised. The autouse _reset_cached_handle fixture
+    # already nulled the cache; we additionally stub the lookup helper
+    # to simulate "redirector not yet installed".
     monkeypatch.setattr(
         "kimi_cli.utils.logging.get_original_stderr_handle",
         lambda: None,
@@ -305,8 +305,6 @@ def test_set_terminal_title_degrades_on_unencodable_stderr(
 def test_set_terminal_title_degrades_when_stderr_write_raises(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    proctitle._original_stderr_handle = None
-    proctitle._original_stderr_attempted = True
     monkeypatch.setattr(
         "kimi_cli.utils.logging.get_original_stderr_handle",
         lambda: None,

--- a/tests/utils/test_proctitle.py
+++ b/tests/utils/test_proctitle.py
@@ -265,3 +265,62 @@ def test_set_terminal_title_noop_when_original_stderr_not_tty(
     assert writes == []
     assert handle.closed is True
     assert proctitle._original_stderr_handle is None
+
+
+class _AsciiOnlyTTY(io.StringIO):
+    encoding = "ascii"
+
+    def isatty(self) -> bool:  # type: ignore[override]
+        return True
+
+
+def test_set_terminal_title_degrades_on_unencodable_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Force the original-stderr-handle path to miss so the sys.stderr
+    # fallback is exercised.
+    proctitle._original_stderr_handle = None
+    proctitle._original_stderr_attempted = True
+    monkeypatch.setattr(
+        "kimi_cli.utils.logging.get_original_stderr_handle",
+        lambda: None,
+    )
+
+    fake = _AsciiOnlyTTY()
+    monkeypatch.setattr(sys, "stderr", fake)
+
+    # Chinese characters cannot be encoded in ascii; the fallback must
+    # NOT raise UnicodeEncodeError, it should write a best-effort form.
+    proctitle.set_terminal_title("hello \u4e2d\u6587")
+
+    out = fake.getvalue()
+    assert out.startswith("\033]0;")
+    assert out.endswith("\007")
+    # Original Chinese chars are replaced with '?', but the surrounding
+    # OSC envelope and ASCII text are preserved intact.
+    assert "hello" in out
+    assert "?" in out
+
+
+def test_set_terminal_title_degrades_when_stderr_write_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    proctitle._original_stderr_handle = None
+    proctitle._original_stderr_attempted = True
+    monkeypatch.setattr(
+        "kimi_cli.utils.logging.get_original_stderr_handle",
+        lambda: None,
+    )
+
+    class _BoomTTY(io.StringIO):
+        encoding = "utf-8"
+
+        def isatty(self) -> bool:  # type: ignore[override]
+            return True
+
+        def write(self, s: str) -> int:  # type: ignore[override]
+            raise UnicodeEncodeError("ascii", s, 0, 1, "boom")
+
+    monkeypatch.setattr(sys, "stderr", _BoomTTY())
+    # Must not propagate; title updates are best-effort.
+    proctitle.set_terminal_title("anything")

--- a/tests/utils/test_proctitle.py
+++ b/tests/utils/test_proctitle.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from kimi_cli.utils import proctitle
+
+
+def test_truncate_topic_collapses_whitespace():
+    assert proctitle._truncate_topic("hello   world\n  again") == "hello world again"
+
+
+def test_truncate_topic_clamps_long_input():
+    out = proctitle._truncate_topic("x" * 200, max_len=10)
+    assert len(out) == 10
+    assert out.endswith("\u2026")
+
+
+def test_truncate_topic_passthrough_when_short():
+    assert proctitle._truncate_topic("short", max_len=40) == "short"
+
+
+def test_compose_terminal_title_base_only():
+    assert proctitle.compose_session_terminal_title() == "Kimi Code"
+
+
+def test_compose_terminal_title_cwd_only():
+    title = proctitle.compose_session_terminal_title(work_dir="/home/user/projects/my-project")
+    assert title == "Kimi Code \u00b7 my-project"
+
+
+def test_compose_terminal_title_with_topic_and_cwd():
+    title = proctitle.compose_session_terminal_title(
+        work_dir="/tmp/proj",
+        topic="Refactor auth module to use JWT",
+    )
+    assert title == "Kimi Code \u00b7 Refactor auth module to use JWT \u00b7 proj"
+
+
+def test_compose_terminal_title_topic_truncated():
+    long_topic = "a" * 100
+    title = proctitle.compose_session_terminal_title(work_dir="/x", topic=long_topic)
+    # Topic is truncated to 40 chars (39 + ellipsis)
+    assert "\u2026" in title
+    assert " \u00b7 x" in title
+
+
+def test_compose_terminal_title_ignores_empty_topic():
+    title = proctitle.compose_session_terminal_title(work_dir="/x/proj", topic="")
+    assert title == "Kimi Code \u00b7 proj"
+
+
+def test_compose_terminal_title_normalizes_trailing_separator():
+    title = proctitle.compose_session_terminal_title(work_dir="/x/proj/")
+    assert title.endswith("proj")
+
+
+class _TTYStringIO(io.StringIO):
+    def isatty(self) -> bool:  # type: ignore[override]
+        return True
+
+
+def test_set_terminal_title_emits_osc_when_tty(monkeypatch: pytest.MonkeyPatch):
+    fake = _TTYStringIO()
+    monkeypatch.setattr(sys, "stderr", fake)
+    proctitle.set_terminal_title("hello")
+    assert fake.getvalue() == "\033]0;hello\007"
+
+
+def test_set_terminal_title_noop_when_not_tty(monkeypatch: pytest.MonkeyPatch):
+    fake = io.StringIO()  # default isatty() == False
+    monkeypatch.setattr(sys, "stderr", fake)
+    proctitle.set_terminal_title("nope")
+    assert fake.getvalue() == ""
+
+
+def test_update_terminal_title_for_session_emits_composed_title(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _TTYStringIO()
+    monkeypatch.setattr(sys, "stderr", fake)
+    proctitle.update_terminal_title_for_session(
+        work_dir="/tmp/proj",
+        topic="ship release",
+    )
+    assert fake.getvalue() == "\033]0;Kimi Code \u00b7 ship release \u00b7 proj\007"

--- a/tests/utils/test_proctitle.py
+++ b/tests/utils/test_proctitle.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import io
+import os
 import sys
 
 import pytest
 
 from kimi_cli.utils import proctitle
+
+
+@pytest.fixture(autouse=True)
+def _reset_cached_handle(monkeypatch: pytest.MonkeyPatch):
+    """Reset the module-level cache so each test sees a clean slate."""
+    monkeypatch.setattr(proctitle, "_original_stderr_handle", None)
 
 
 def test_truncate_topic_collapses_whitespace():
@@ -57,6 +64,23 @@ def test_compose_terminal_title_normalizes_trailing_separator():
     assert title.endswith("proj")
 
 
+def test_compose_terminal_title_preserves_chinese_characters():
+    title = proctitle.compose_session_terminal_title(
+        work_dir="C:/项目/我的-app",
+        topic="重构鉴权 模块",
+    )
+    assert "重构鉴权 模块" in title
+    assert "我的-app" in title
+
+
+def test_compose_terminal_title_preserves_emoji():
+    title = proctitle.compose_session_terminal_title(
+        work_dir="/x/proj",
+        topic="🚀 ship release",
+    )
+    assert "🚀 ship release" in title
+
+
 class _TTYStringIO(io.StringIO):
     def isatty(self) -> bool:  # type: ignore[override]
         return True
@@ -86,3 +110,158 @@ def test_update_terminal_title_for_session_emits_composed_title(
         topic="ship release",
     )
     assert fake.getvalue() == "\033]0;Kimi Code \u00b7 ship release \u00b7 proj\007"
+
+
+def test_sanitize_osc_payload_strips_c0_c1_and_del():
+    raw = "ok\x07\x1b[31mEVIL\x00\x1f\x7f\x80\x9fend"
+    assert proctitle._sanitize_osc_payload(raw) == "ok[31mEVILend"
+
+
+def test_sanitize_osc_payload_preserves_unicode():
+    raw = "中文 日本語 🚀 café"
+    assert proctitle._sanitize_osc_payload(raw) == raw
+
+
+def test_set_terminal_title_sanitizes_control_bytes(monkeypatch: pytest.MonkeyPatch):
+    fake = _TTYStringIO()
+    monkeypatch.setattr(sys, "stderr", fake)
+    proctitle.set_terminal_title("evil\x07\x1b]0;hijack\x07tail")
+    written = fake.getvalue()
+    assert written.startswith("\033]0;")
+    assert written.endswith("\007")
+    payload = written[len("\033]0;") : -1]
+    for forbidden in ("\x1b", "\x07", "\n", "\r", "\t", "\x1f", "\x9f", "\x7f"):
+        assert forbidden not in payload, f"control byte {forbidden!r} leaked into payload"
+    assert payload == "evil]0;hijacktail"
+
+
+def test_set_terminal_title_chinese_round_trip_via_osc(monkeypatch: pytest.MonkeyPatch):
+    fake = _TTYStringIO()
+    monkeypatch.setattr(sys, "stderr", fake)
+    title = proctitle.compose_session_terminal_title(
+        work_dir="C:/项目/我的-app",
+        topic="重构鉴权 模块 to use JWT",
+    )
+    proctitle.set_terminal_title(title)
+    written = fake.getvalue()
+    payload = written[len("\033]0;") : -1]
+    assert payload == title
+    assert "重构鉴权" in payload
+    assert "我的-app" in payload
+
+
+def test_set_terminal_title_emoji_round_trip_via_osc(monkeypatch: pytest.MonkeyPatch):
+    fake = _TTYStringIO()
+    monkeypatch.setattr(sys, "stderr", fake)
+    title = "Kimi Code \u00b7 🚀 ship release \u00b7 proj"
+    proctitle.set_terminal_title(title)
+    payload = fake.getvalue()[len("\033]0;") : -1]
+    assert payload == title
+    assert "🚀" in payload
+
+
+class _TTYBytesIO(io.BytesIO):
+    """BytesIO that pretends to wrap a TTY-bound fd via a sentinel fileno."""
+
+    _SENTINEL_FD = 4242
+
+    def fileno(self) -> int:  # type: ignore[override]
+        return self._SENTINEL_FD
+
+
+def test_set_terminal_title_uses_pre_redirect_handle_when_stderr_redirected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """After redirect_stderr_to_logger swaps fd 2 for a pipe, sys.stderr.isatty()
+    is False but the title must still reach the original terminal via the
+    cached pre-redirect handle from utils.logging.get_original_stderr_handle.
+    """
+    redirected_stderr = io.StringIO()  # default isatty() == False, like the pipe
+    monkeypatch.setattr(sys, "stderr", redirected_stderr)
+
+    captured = _TTYBytesIO()
+    real_isatty = os.isatty
+
+    def fake_isatty(fd: int) -> bool:
+        if fd == _TTYBytesIO._SENTINEL_FD:
+            return True
+        return real_isatty(fd)
+
+    monkeypatch.setattr(os, "isatty", fake_isatty)
+    monkeypatch.setattr(
+        "kimi_cli.utils.logging.get_original_stderr_handle",
+        lambda: captured,
+    )
+
+    proctitle.set_terminal_title("from-redirected")
+
+    # Must NOT have written to the redirected (non-TTY) sys.stderr
+    assert redirected_stderr.getvalue() == ""
+    # Must have written the OSC payload to the cached original-stderr handle
+    assert captured.getvalue() == b"\033]0;from-redirected\007"
+    # And the handle must now be cached for subsequent calls
+    assert proctitle._original_stderr_handle is captured
+
+
+def test_set_terminal_title_falls_back_to_stderr_when_redirector_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _TTYStringIO()
+    monkeypatch.setattr(sys, "stderr", fake)
+    monkeypatch.setattr(
+        "kimi_cli.utils.logging.get_original_stderr_handle",
+        lambda: None,
+    )
+    proctitle.set_terminal_title("startup")
+    assert fake.getvalue() == "\033]0;startup\007"
+    assert proctitle._original_stderr_handle is None
+
+
+def test_set_terminal_title_noop_when_original_stderr_not_tty(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If the user already redirected stderr to a file before launch, the
+    pre-redirect fd is not a TTY either; emitting OSC bytes there would
+    corrupt the file. We must no-op in that case.
+    """
+    redirected_stderr = io.StringIO()  # not a TTY
+    monkeypatch.setattr(sys, "stderr", redirected_stderr)
+
+    writes: list[bytes] = []
+
+    class _NonTTYHandle:
+        closed = False
+
+        def fileno(self) -> int:
+            return 4243
+
+        def write(self, data: bytes) -> int:
+            writes.append(data)
+            return len(data)
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    handle = _NonTTYHandle()
+    real_isatty = os.isatty
+
+    def fake_isatty(fd: int) -> bool:
+        if fd == 4243:
+            return False
+        return real_isatty(fd)
+
+    monkeypatch.setattr(os, "isatty", fake_isatty)
+    monkeypatch.setattr(
+        "kimi_cli.utils.logging.get_original_stderr_handle",
+        lambda: handle,
+    )
+
+    proctitle.set_terminal_title("nowhere")
+
+    assert redirected_stderr.getvalue() == ""
+    assert writes == []
+    assert handle.closed is True
+    assert proctitle._original_stderr_handle is None

--- a/tests/utils/test_proctitle.py
+++ b/tests/utils/test_proctitle.py
@@ -322,3 +322,49 @@ def test_set_terminal_title_degrades_when_stderr_write_raises(
     monkeypatch.setattr(sys, "stderr", _BoomTTY())
     # Must not propagate; title updates are best-effort.
     proctitle.set_terminal_title("anything")
+
+
+def test_get_original_stderr_handle_marks_fd_non_inheritable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Cached fd must not leak into spawned subprocesses."""
+    import contextlib as _contextlib
+    import os as _os
+
+    # Build a real OS pipe and pretend its read end is the original TTY.
+    rfd, wfd = _os.pipe()
+    _os.set_inheritable(rfd, True)  # simulate the redirector's default
+
+    class _FakeTTY:
+        def __init__(self, fd: int):
+            self._fd = fd
+
+        def fileno(self) -> int:
+            return self._fd
+
+        def write(self, data: bytes) -> int:
+            return 0
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            with _contextlib.suppress(OSError):
+                _os.close(self._fd)
+
+    handle = _FakeTTY(rfd)
+    monkeypatch.setattr(
+        "kimi_cli.utils.logging.get_original_stderr_handle",
+        lambda: handle,
+    )
+    monkeypatch.setattr(_os, "isatty", lambda fd: fd == rfd)
+
+    try:
+        result = proctitle._get_original_stderr_handle()
+        assert result is handle
+        assert _os.get_inheritable(rfd) is False
+    finally:
+        with _contextlib.suppress(OSError):
+            handle.close()
+        with _contextlib.suppress(OSError):
+            _os.close(wfd)


### PR DESCRIPTION
## Related issue

Resolves #1475 (regression from v1.15.0). Prior attempt #1519 was
closed without merge; this version differs by also surfacing the
session **topic** (not just cwd), which is what disambiguates tabs
when the same project has multiple concurrent sessions.

## Problem

Since v1.15.0 (#1254) the terminal tab/window title has been a
static `Kimi Code` string. Users with multiple sessions across
multiple tabs cannot tell which session belongs to which tab.
Copilot CLI and Claude Code both keep their tab title in sync with
the live session.

## Solution

Format: `Kimi Code · <topic> · <cwd-basename>`

Topic comes from the session's auto-generated title (derived from
the first user message) or the user-set `/title` value, clipped to
40 characters with an ellipsis. cwd basename is taken from the
canonicalised `session.work_dir` so `kimi --work-dir .` still
gives a useful project name.

Examples:

- Fresh session: `Kimi Code · my-project`
- After first turn: `Kimi Code · Refactor auth module to use JWT · my-project`
- After `/title Q4 planning`: `Kimi Code · Q4 planning · my-project`

## Update points

Three lifecycle hooks, no flapping on every token / tool call:

- `cli/__init__.py` — after session establishment.
- `soul/kimisoul.py` — after the first-turn auto-title is derived.
- `ui/shell/slash.py` — on `/title`.

## Implementation hardening

- `set_terminal_title` routes through the pre-redirect stderr fd
  via `utils.logging.get_original_stderr_handle`, so refreshes keep
  working after `redirect_stderr_to_logger` swaps fd 2 for a pipe.
  Falls back to `sys.stderr` only during early startup; no-ops
  cleanly when no TTY is reachable so `--print` and pipes stay
  clean.
- `_sanitize_osc_payload` strips C0/C1 controls (`\x00-\x1f`,
  `\x7f-\x9f`) at a single chokepoint so user-influenced topic /
  cwd cannot inject terminal escape codes. All other Unicode is
  preserved verbatim.
- `sys.stderr` fallback pre-encodes through the stream's encoding
  with `errors='replace'`, so legacy Windows code pages or ASCII /
  C locales don't crash on Chinese / emoji titles.
- The cached pre-redirect fd is marked non-inheritable so spawned
  subprocesses (shell tools, MCP servers) don't leak a TTY handle.

## Files

- `src/kimi_cli/utils/proctitle.py` (helpers + sanitiser)
- `src/kimi_cli/utils/logging.py` (`get_original_stderr_handle` helper)
- `src/kimi_cli/cli/__init__.py`, `soul/kimisoul.py`,
  `ui/shell/slash.py` (the three update points)
- `tests/utils/test_proctitle.py` (25 tests: composition,
  truncation, OSC emission, TTY gating, redirected-stderr fallback,
  encoding-safe fallback, non-inheritable fd, control-char sanitiser,
  Chinese / emoji round-trip)

## Out of scope

OS process title via `setproctitle`, runtime.json sidecar
(separate PR #2082).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue (#1475).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run make gen-changelog to update the changelog.
- [ ] I have run make gen-docs to update the user documentation.
