### PR TITLE
feat(config): Add Granular Auto-Approval Rules (like Claude Code) to config file

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -32,6 +32,8 @@ The configuration file contains the following top-level configuration items:
 | `theme` | `string` | Terminal color theme, either `"dark"` or `"light"` (defaults to `"dark"`) |
 | `show_thinking_stream` | `boolean` | Whether to stream the raw reasoning text in the live area as a 6-line scrolling preview and commit the full reasoning markdown to history when the block ends (defaults to `true`; set to `false` to show only the compact `Thinking ...` indicator and a one-line trace summary) |
 | `merge_all_available_skills` | `boolean` | Whether to merge skills from all brand directories (defaults to `true`); see [Skills configuration](../customization/skills.md) |
+| `default_auto_approve_actions` | `array` | List of action name patterns to auto-approve by default in every session. Supports glob patterns (`*`, `?`). Examples: `["mcp:obsidian_*"]`. Defaults to `[]` |
+| `auto_approve_workspace_dirs` | `array` | List of workspace directory names (relative to `work_dir`) for which file write/edit approvals should be skipped automatically. Example: `["skills", "plans"]`. Defaults to `[]` |
 | `providers` | `table` | API provider configuration |
 | `models` | `table` | Model configuration |
 | `loop_control` | `table` | Agent loop control parameters |
@@ -50,6 +52,12 @@ default_editor = ""
 theme = "dark"
 show_thinking_stream = true
 merge_all_available_skills = true
+
+# Auto-approve all obsidian MCP tools by default
+# default_auto_approve_actions = ["mcp:obsidian_*"]
+
+# Skip approval for file edits inside these workspace directories
+# auto_approve_workspace_dirs = ["skills", "plans"]
 
 [providers.kimi-for-coding]
 type = "kimi"

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -32,6 +32,8 @@ kimi --config '{"default_model": "kimi-for-coding", "providers": {...}, "models"
 | `theme` | `string` | 终端配色主题，可选 `"dark"` 或 `"light"`（默认为 `"dark"`） |
 | `show_thinking_stream` | `boolean` | 是否在 Live 区域以 6 行滚动预览方式实时展示模型的原始思考文本，并在 thinking 块结束时把完整思考内容（Markdown）写入历史记录（默认为 `true`；设为 `false` 则仅显示紧凑的 `Thinking ...` 指示器和一行 trace 总结） |
 | `merge_all_available_skills` | `boolean` | 是否合并所有品牌目录中的 Skills（默认为 `true`）；详见 [Skills 配置](../customization/skills.md) |
+| `default_auto_approve_actions` | `array` | 每次会话默认自动审批的操作名称模式列表。支持 glob 通配符（`*`、`?`）。示例：`["mcp:obsidian_*"]`。默认为 `[]` |
+| `auto_approve_workspace_dirs` | `array` | 文件写入/编辑操作自动跳过审批的工作区目录名称列表（相对于 `work_dir`）。示例：`["skills", "plans"]`。默认为 `[]` |
 | `providers` | `table` | API 供应商配置 |
 | `models` | `table` | 模型配置 |
 | `loop_control` | `table` | Agent 循环控制参数 |
@@ -50,6 +52,12 @@ default_editor = ""
 theme = "dark"
 show_thinking_stream = true
 merge_all_available_skills = true
+
+# 默认自动审批所有 Obsidian MCP 工具
+# default_auto_approve_actions = ["mcp:obsidian_*"]
+
+# 在这些工作区目录内的文件编辑操作跳过审批
+# auto_approve_workspace_dirs = ["skills", "plans"]
 
 [providers.kimi-for-coding]
 type = "kimi"

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -263,6 +263,20 @@ class Config(BaseModel):
         default=True,
         description="Enable anonymous telemetry to help improve kimi-cli. Set to false to disable.",
     )
+    default_auto_approve_actions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "List of action name patterns to auto-approve by default in every session. "
+            "Supports glob patterns (*, ?). Examples: 'mcp:obsidian_*', 'edit file'."
+        ),
+    )
+    auto_approve_workspace_dirs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "List of workspace directory names (relative to work_dir) for which "
+            "file write/edit approvals should be skipped automatically."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_model(self) -> Self:
@@ -279,6 +293,85 @@ def get_config_file() -> Path:
     return get_share_dir() / "config.toml"
 
 
+_DEFAULT_CONFIG_TEMPLATE = '''\
+# Kimi Code CLI configuration file
+# Documentation: https://kimi-cli.github.io/configuration/config-files
+
+# Default model to use for new sessions. Must match a key in the [models] table.
+default_model = ""
+
+# Default behavior flags
+default_thinking = false
+default_yolo = false
+default_plan_mode = false
+
+# External editor command (e.g. "vim", "code --wait"). Leave empty for auto-detect.
+default_editor = ""
+
+# Terminal color theme: "dark" or "light"
+theme = "dark"
+
+# Stream reasoning text in the live area? Set to false for a compact indicator only.
+show_thinking_stream = true
+
+# Merge skills from all brand directories (kimi, claude, codex, etc.)
+merge_all_available_skills = true
+
+# ------------------------------------------------------------------------------
+# Auto-approval configuration
+# ------------------------------------------------------------------------------
+# Glob patterns for actions that should be auto-approved in EVERY session.
+# These are merged with any session-specific approvals you make interactively.
+# Examples:
+#   default_auto_approve_actions = ["mcp:obsidian_*"]
+#   default_auto_approve_actions = ["mcp:obsidian_*", "mcp:memory_*"]
+default_auto_approve_actions = []
+
+# Workspace directory names (relative to the current work_dir) where file
+# write/edit approvals are skipped automatically. Useful for skills, plans,
+# notes, or other directories the agent routinely modifies.
+# Examples:
+#   auto_approve_workspace_dirs = ["skills", "plans"]
+#   auto_approve_workspace_dirs = ["docs", "notes"]
+auto_approve_workspace_dirs = []
+
+# Extra directories to discover skills from (absolute, ~-prefixed, or relative)
+extra_skill_dirs = []
+
+# Enable anonymous telemetry to help improve kimi-cli. Set to false to disable.
+telemetry = true
+
+# Suppress the YOLO mode hint injected into the system prompt.
+skip_yolo_prompt_injection = false
+
+[loop_control]
+max_steps_per_turn = 500
+max_retries_per_step = 3
+max_ralph_iterations = 0
+reserved_context_size = 50000
+compaction_trigger_ratio = 0.85
+
+[background]
+max_running_tasks = 4
+read_max_bytes = 30000
+notification_tail_lines = 20
+notification_tail_chars = 3000
+wait_poll_interval_ms = 500
+worker_heartbeat_interval_ms = 5000
+worker_stale_after_ms = 15000
+kill_grace_period_ms = 2000
+keep_alive_on_exit = false
+agent_task_timeout_s = 900
+print_wait_ceiling_s = 3600
+
+[notifications]
+claim_stale_after_ms = 15000
+
+[mcp.client]
+tool_call_timeout_ms = 60000
+'''
+
+
 def get_default_config() -> Config:
     """Get the default configuration."""
     return Config(
@@ -287,6 +380,12 @@ def get_default_config() -> Config:
         providers={},
         services=Services(),
     )
+
+
+def _write_default_config_file(config_file: Path) -> None:
+    """Write the default config file with comments and examples."""
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(_DEFAULT_CONFIG_TEMPLATE, encoding="utf-8")
 
 
 def load_config(config_file: Path | None = None) -> Config:
@@ -315,9 +414,16 @@ def load_config(config_file: Path | None = None) -> Config:
         _migrate_json_config_to_toml()
 
     if not config_file.exists():
-        config = get_default_config()
-        logger.debug("No config file found, creating default config: {config}", config=config)
-        save_config(config, config_file)
+        logger.debug("No config file found, creating default config at: {file}", file=config_file)
+        _write_default_config_file(config_file)
+        try:
+            data = tomlkit.loads(_DEFAULT_CONFIG_TEMPLATE)
+            config = Config.model_validate(data)
+        except (TOMLKitError, ValidationError) as e:
+            # This should never happen because the template is static and tested,
+            # but fall back to the plain default config if it does.
+            logger.warning("Default config template failed validation: {error}", error=e)
+            config = get_default_config()
         config.is_from_default_location = is_default_config_file
         config.source_file = config_file
         return config

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -271,6 +271,7 @@ class Runtime:
 
         # Merge CLI flag with persisted session state
         effective_yolo = yolo or session.state.approval.yolo
+        default_actions = set(config.default_auto_approve_actions or [])
         saved_actions = set(session.state.approval.auto_approve_actions)
 
         def _on_approval_change() -> None:
@@ -280,7 +281,7 @@ class Runtime:
 
         approval_state = ApprovalState(
             yolo=effective_yolo,
-            auto_approve_actions=saved_actions,
+            auto_approve_actions=default_actions | saved_actions,
             on_change=_on_approval_change,
         )
         notifications = NotificationManager(

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import uuid
 from collections.abc import Callable
 from typing import Literal
@@ -142,7 +143,7 @@ class Approval:
             )
             return ApprovalResult(approved=True)
 
-        if action in self._state.auto_approve_actions:
+        if any(fnmatch.fnmatch(action, pattern) for pattern in self._state.auto_approve_actions):
             from kimi_cli.telemetry import track
 
             track(

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -14,7 +14,7 @@ from kimi_cli.tools.file.plan_mode import inspect_plan_edit_target
 from kimi_cli.tools.utils import load_desc
 from kimi_cli.utils.diff import build_diff_blocks
 from kimi_cli.utils.logging import logger
-from kimi_cli.utils.path import is_within_workspace
+from kimi_cli.utils.path import is_within_directory, is_within_workspace
 
 _BASE_DESCRIPTION = load_desc(Path(__file__).parent / "replace.md")
 
@@ -50,6 +50,7 @@ class StrReplaceFile(CallableTool2[Params]):
         self._work_dir = runtime.builtin_args.KIMI_WORK_DIR
         self._additional_dirs = runtime.additional_dirs
         self._approval = approval
+        self._auto_approve_dirs = runtime.config.auto_approve_workspace_dirs or []
         self._plan_mode_checker: Callable[[], bool] | None = None
         self._plan_file_path_getter: Callable[[], Path | None] | None = None
 
@@ -59,6 +60,15 @@ class StrReplaceFile(CallableTool2[Params]):
         """Bind plan mode state checker and plan file path getter."""
         self._plan_mode_checker = checker
         self._plan_file_path_getter = path_getter
+
+    def _is_auto_approved_dir(self, path: KaosPath) -> bool:
+        """Check if path is within a configured auto-approve workspace directory."""
+        if not self._auto_approve_dirs:
+            return False
+        for dir_name in self._auto_approve_dirs:
+            if is_within_directory(path, self._work_dir / dir_name):
+                return True
+        return False
 
     async def _validate_path(self, path: KaosPath) -> ToolError | None:
         """Validate that the path is safe to edit."""
@@ -155,8 +165,8 @@ class StrReplaceFile(CallableTool2[Params]):
                 else FileActions.EDIT_OUTSIDE
             )
 
-            # Plan file edits are auto-approved; all other edits need approval.
-            if not is_plan_file_edit:
+            # Plan file edits and auto-approved dirs are skipped; all other edits need approval.
+            if not is_plan_file_edit and not self._is_auto_approved_dir(p):
                 result = await self._approval.request(
                     self.name,
                     action,

--- a/src/kimi_cli/tools/file/write.py
+++ b/src/kimi_cli/tools/file/write.py
@@ -14,7 +14,7 @@ from kimi_cli.tools.file.plan_mode import inspect_plan_edit_target
 from kimi_cli.tools.utils import load_desc
 from kimi_cli.utils.diff import build_diff_blocks
 from kimi_cli.utils.logging import logger
-from kimi_cli.utils.path import is_within_workspace
+from kimi_cli.utils.path import is_within_directory, is_within_workspace
 
 _BASE_DESCRIPTION = load_desc(Path(__file__).parent / "write.md")
 
@@ -47,6 +47,7 @@ class WriteFile(CallableTool2[Params]):
         self._work_dir = runtime.builtin_args.KIMI_WORK_DIR
         self._additional_dirs = runtime.additional_dirs
         self._approval = approval
+        self._auto_approve_dirs = runtime.config.auto_approve_workspace_dirs or []
         self._plan_mode_checker: Callable[[], bool] | None = None
         self._plan_file_path_getter: Callable[[], Path | None] | None = None
 
@@ -56,6 +57,15 @@ class WriteFile(CallableTool2[Params]):
         """Bind plan mode state checker and plan file path getter."""
         self._plan_mode_checker = checker
         self._plan_file_path_getter = path_getter
+
+    def _is_auto_approved_dir(self, path: KaosPath) -> bool:
+        """Check if path is within a configured auto-approve workspace directory."""
+        if not self._auto_approve_dirs:
+            return False
+        for dir_name in self._auto_approve_dirs:
+            if is_within_directory(path, self._work_dir / dir_name):
+                return True
+        return False
 
     async def _validate_path(self, path: KaosPath) -> ToolError | None:
         """Validate that the path is safe to write."""
@@ -134,8 +144,8 @@ class WriteFile(CallableTool2[Params]):
                 new_text,
             )
 
-            # Plan file writes are auto-approved; other writes need approval
-            if not is_plan_file_write:
+            # Plan file writes and auto-approved dirs are skipped; other writes need approval
+            if not is_plan_file_write and not self._is_auto_approved_dir(p):
                 action = (
                     FileActions.EDIT
                     if is_within_workspace(p, self._work_dir, self._additional_dirs)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -60,6 +60,8 @@ def test_default_config_dump():
             "extra_skill_dirs": [],
             "telemetry": True,
             "skip_yolo_prompt_injection": False,
+            "default_auto_approve_actions": [],
+            "auto_approve_workspace_dirs": [],
         }
     )
 
@@ -81,6 +83,20 @@ def test_load_config_sets_source_file(tmp_path):
 
     assert config.source_file == config_file.resolve()
     assert not config.is_from_default_location
+
+
+def test_load_config_creates_template_with_comments(tmp_path):
+    """New config files should be created from the commented template."""
+    config_file = tmp_path / "config.toml"
+
+    config = load_config(config_file)
+
+    text = config_file.read_text(encoding="utf-8")
+    assert "# Auto-approval configuration" in text
+    assert "default_auto_approve_actions" in text
+    assert "auto_approve_workspace_dirs" in text
+    # Compare excluding metadata fields that differ by load path
+    assert config.model_dump(exclude={"is_from_default_location", "source_file"}) == get_default_config().model_dump()
 
 
 def test_load_config_text_has_no_source_file():

--- a/tests/core/test_session_state.py
+++ b/tests/core/test_session_state.py
@@ -452,3 +452,28 @@ class TestApprovalStateCallback:
         approval = Approval(state=state)
         approval.set_yolo(True)  # should not raise
         assert state.yolo is True
+
+    @pytest.mark.asyncio
+    async def test_glob_pattern_auto_approve(self):
+        from kimi_cli.soul.approval import Approval, ApprovalState
+        from kimi_cli.soul.toolset import current_tool_call
+        from kimi_cli.wire.types import ToolCall
+
+        state = ApprovalState(auto_approve_actions={"mcp:obsidian_*", "Shell"})
+        approval = Approval(state=state)
+
+        token = current_tool_call.set(
+            ToolCall(id="test", function=ToolCall.FunctionBody(name="obsidian_search", arguments=None))
+        )
+        try:
+            result = await approval.request(
+                sender="obsidian_search", action="mcp:obsidian_search", description="search"
+            )
+            assert result.approved is True
+
+            result2 = await approval.request(
+                sender="obsidian_write", action="mcp:obsidian_write", description="write"
+            )
+            assert result2.approved is True
+        finally:
+            current_tool_call.reset(token)

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -246,3 +246,32 @@ async def test_replace_empty_strings(
     assert not result.is_error
     assert "successfully edited" in result.message
     assert await file_path.read_text() == "Hello !"
+
+
+async def test_replace_auto_approved_workspace_dir(runtime, temp_work_dir: KaosPath):
+    """Test that edits in auto-approved workspace dirs skip approval."""
+    from kimi_cli.soul.approval import Approval
+    from kimi_cli.soul.toolset import current_tool_call
+    from kimi_cli.wire.types import ToolCall
+
+    runtime.config.auto_approve_workspace_dirs = ["plans"]
+    approval = Approval(yolo=False)
+    tool = StrReplaceFile(runtime, approval)
+
+    plans_dir = temp_work_dir / "plans"
+    await plans_dir.mkdir(parents=True, exist_ok=True)
+    file_path = plans_dir / "todo.txt"
+    await file_path.write_text("old content")
+
+    token = current_tool_call.set(
+        ToolCall(id="test", function=ToolCall.FunctionBody(name="StrReplaceFile", arguments=None))
+    )
+    try:
+        result = await tool(
+            Params(path=str(file_path), edit=Edit(old="old", new="new"))
+        )
+    finally:
+        current_tool_call.reset(token)
+
+    assert not result.is_error
+    assert await file_path.read_text() == "new content"

--- a/tests/tools/test_write_file.py
+++ b/tests/tools/test_write_file.py
@@ -171,3 +171,28 @@ async def test_write_large_content(write_file_tool: WriteFile, temp_work_dir: Ka
     assert not result.is_error
     assert await file_path.exists()
     assert await file_path.read_text() == content
+
+
+async def test_write_auto_approved_workspace_dir(runtime, temp_work_dir: KaosPath):
+    """Test that writes to auto-approved workspace dirs skip approval."""
+    from kimi_cli.soul.approval import Approval
+    from kimi_cli.soul.toolset import current_tool_call
+    from kimi_cli.wire.types import ToolCall
+
+    runtime.config.auto_approve_workspace_dirs = ["skills"]
+    approval = Approval(yolo=False)
+    tool = WriteFile(runtime, approval)
+
+    skills_dir = temp_work_dir / "skills"
+    await skills_dir.mkdir(parents=True, exist_ok=True)
+
+    token = current_tool_call.set(
+        ToolCall(id="test", function=ToolCall.FunctionBody(name="WriteFile", arguments=None))
+    )
+    try:
+        result = await tool(Params(path=str(skills_dir / "test.txt"), content="hello"))
+    finally:
+        current_tool_call.reset(token)
+
+    assert not result.is_error
+    assert await (skills_dir / "test.txt").read_text() == "hello"


### PR DESCRIPTION
A feat related to Issue #1631. Granular auto-approval which can be dictated via the config.toml. Also added example comments to config.toml line to help get an understanding of how to configure.

- Adds default_auto_approve_actions to config (glob patterns) for global approvals including MCP tools. i.e. Approve all Obsidian MCP tool calls.
- Adds auto_approve_workspace_dirs to skip approval for specific directories like .kimi/plans.
- Updates file tools to respect workspace bypass and improves config templates.

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->
Issue #1631

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
