### PR TITLE
feat(telemetry): implement session tracking and telemetry server

### DIFF
--- a/scripts/telemetry_debug_server.py
+++ b/scripts/telemetry_debug_server.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tiny local telemetry receiver for inspecting outbound events.
+
+Point the telemetry endpoint at http://127.0.0.1:8765/v1/event, then run:
+
+    uv run python scripts/telemetry_debug_server.py
+
+Set EVENT_FILTER below to a bare event name such as "session_started" or to the
+outbound name "kfc_session_started". Leave it as None to print every event.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+HOST = "127.0.0.1"
+PORT = 8765
+
+# None means print all events. Examples: "session_started", "kfc_session_started".
+EVENT_FILTER: str | None = None
+
+# The production transport prefixes outbound event names with "kfc_".
+SERVER_EVENT_PREFIX = "kfc_"
+
+
+def _canonical_event_name(name: str) -> str:
+    if name.startswith(SERVER_EVENT_PREFIX):
+        return name[len(SERVER_EVENT_PREFIX) :]
+    return name
+
+
+def _matches_event(event: dict[str, Any]) -> bool:
+    if not EVENT_FILTER:
+        return True
+    name = event.get("event")
+    if not isinstance(name, str):
+        return False
+    wanted = _canonical_event_name(EVENT_FILTER.strip())
+    return _canonical_event_name(name) == wanted
+
+
+def _compact_event_summary(event: dict[str, Any]) -> str:
+    name = event.get("event", "<missing>")
+    client = event.get("property_client_name")
+    session_id = event.get("session_id")
+    pieces = [str(name)]
+    if client:
+        pieces.append(f"client={client}")
+    if session_id:
+        pieces.append(f"session={session_id}")
+    return " ".join(pieces)
+
+
+class TelemetryHandler(BaseHTTPRequestHandler):
+    server_version = "TelemetryDebugServer/0.1"
+
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(b"ok\n")
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw_body = self.rfile.read(length)
+
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except Exception as exc:
+            self.send_response(400)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(f"invalid json: {exc}\n".encode("utf-8", errors="replace"))
+            return
+
+        events = payload.get("events") if isinstance(payload, dict) else None
+        if not isinstance(events, list):
+            self.send_response(400)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"payload must contain an events list\n")
+            return
+
+        matched = [event for event in events if isinstance(event, dict) and _matches_event(event)]
+        if matched:
+            now = datetime.now().isoformat(timespec="seconds")
+            user_id = payload.get("user_id")
+            print(
+                f"\n[{now}] POST {self.path} user_id={user_id!r} "
+                f"matched={len(matched)}/{len(events)}"
+            )
+            for idx, event in enumerate(matched, start=1):
+                print(f"--- event {idx}: {_compact_event_summary(event)}")
+                print(json.dumps(event, ensure_ascii=False, indent=2, sort_keys=True))
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}\n')
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+def main() -> None:
+    event_filter = EVENT_FILTER or "<all>"
+    print(f"Telemetry debug server listening on http://{HOST}:{PORT}/v1/event")
+    print(f"EVENT_FILTER = {event_filter}")
+    with ThreadingHTTPServer((HOST, PORT), TelemetryHandler) as server:
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping telemetry debug server.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -255,6 +255,8 @@ class KimiCLI:
             yolo,
             skills_dirs=skills_dirs,
         )
+        runtime.ui_mode = ui_mode
+        runtime.resumed = resumed
         runtime.notifications.recover()
         runtime.background_tasks.reconcile()
         _cleanup_stale_foreground_subagents(runtime)
@@ -339,13 +341,15 @@ class KimiCLI:
             )
             attach_sink(sink)
 
-        from kimi_cli.telemetry import track
+        from kimi_cli.telemetry import track, track_session_started_once
         from kimi_cli.telemetry.crash import install_asyncio_handler, set_phase
 
         # App init finished — enter runtime phase and hook asyncio crashes.
         install_asyncio_handler()
         set_phase("runtime")
 
+        if ui_mode != "wire":
+            track_session_started_once(ui_mode=ui_mode, resumed=resumed)
         track("started", resumed=resumed, yolo=yolo)
         track(
             "startup_perf",

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -192,6 +192,8 @@ class Runtime:
     subagent_id: str | None = None
     subagent_type: str | None = None
     role: Literal["root", "subagent"] = "root"
+    ui_mode: str = "shell"
+    resumed: bool = False
     hook_engine: Any = None
     """HookEngine instance, set by KimiCLI after soul creation."""
 

--- a/src/kimi_cli/telemetry/__init__.py
+++ b/src/kimi_cli/telemetry/__init__.py
@@ -18,6 +18,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import time
 import uuid
@@ -42,6 +43,8 @@ _device_id: str | None = None
 _session_id: str | None = None
 _client_info: tuple[str, str | None] | None = None
 """(name, version) tuple, set atomically via set_client_info."""
+_session_started_sessions: set[str] = set()
+"""Session ids that already emitted the session_started event in this process."""
 _sink: EventSink | None = None
 _disabled: bool = False
 
@@ -69,9 +72,45 @@ def set_client_info(*, name: str, version: str | None = None) -> None:
 def get_client_info() -> tuple[str, str | None] | None:
     """Return the current (name, version) tuple, or None if unset.
 
-    Exposed for the sink to enrich events with the latest client info.
+    Used by session-level telemetry to attribute wire/acp sessions.
     """
     return _client_info
+
+
+def track_session_started_once(
+    *,
+    ui_mode: str,
+    resumed: bool,
+    client_name: str | None = None,
+    client_version: str | None = None,
+) -> None:
+    """Emit one session_started event for the current session in this process."""
+    session_id = _session_id
+    if not session_id or session_id in _session_started_sessions:
+        return
+
+    ui = (ui_mode or "unknown").strip().lower()
+    name = client_name
+    version = client_version
+    if name is None and ui in {"wire", "acp"}:
+        client_info = get_client_info()
+        if client_info is not None:
+            name, version = client_info
+    if not name:
+        name = ui or "unknown"
+
+    _session_started_sessions.add(session_id)
+    track(
+        "session_started",
+        client_name=name,
+        client_version=version,
+        ui_mode=ui,
+        resumed=resumed,
+    )
+
+    if _sink is not None:
+        with suppress(Exception):
+            asyncio.get_running_loop().create_task(_sink.flush())
 
 
 def disable() -> None:

--- a/src/kimi_cli/telemetry/sink.py
+++ b/src/kimi_cli/telemetry/sink.py
@@ -54,15 +54,6 @@ class EventSink:
         ctx = {**self._context, "ui_mode": self._ui_mode}
         if self._model:
             ctx["model"] = self._model
-        # Read the client_info tuple atomically (single pointer load) so we
-        # never observe a half-updated pair.
-        from kimi_cli.telemetry import get_client_info
-
-        client_info = get_client_info()
-        if client_info is not None:
-            ctx["client_name"] = client_info[0]
-            if client_info[1]:
-                ctx["client_version"] = client_info[1]
         enriched = {**event, "context": ctx}
 
         with self._lock:

--- a/src/kimi_cli/wire/server.py
+++ b/src/kimi_cli/wire/server.py
@@ -525,6 +525,7 @@ class WireServer:
             result["hooks"] = cast(JsonType, hooks_info)
 
         self._apply_wire_client_info(msg.params.client)
+        self._track_session_started(msg.params.client)
 
         if msg.params.capabilities is not None:
             self._client_supports_question = msg.params.capabilities.supports_question
@@ -627,6 +628,19 @@ class WireServer:
             headers["User-Agent"] = f"{USER_AGENT}{ua_suffix}"
             kimi_client._custom_headers = headers  # pyright: ignore[reportPrivateUsage]
 
+    def _track_session_started(self, client: ClientInfo | None) -> None:
+        if not isinstance(self._soul, KimiSoul):
+            return
+
+        from kimi_cli.telemetry import track_session_started_once
+
+        track_session_started_once(
+            ui_mode="wire",
+            resumed=self._soul.runtime.resumed,
+            client_name=client.name if client is not None else None,
+            client_version=client.version if client is not None else None,
+        )
+
     async def _handle_prompt(
         self, msg: JSONRPCPromptMessage
     ) -> JSONRPCSuccessResponse | JSONRPCErrorResponse:
@@ -638,6 +652,9 @@ class WireServer:
                     code=ErrorCodes.INVALID_STATE, message="An agent turn is already in progress"
                 ),
             )
+
+        if not self._initialized:
+            self._track_session_started(None)
 
         self._cancel_event = asyncio.Event()
         runtime = self._soul.runtime if isinstance(self._soul, KimiSoul) else None

--- a/tests/core/test_wire_server_steer.py
+++ b/tests/core/test_wire_server_steer.py
@@ -7,12 +7,15 @@ import pytest
 from kosong.message import ContentPart
 from kosong.tooling.empty import EmptyToolset
 
+import kimi_cli.telemetry as telemetry_mod
 from kimi_cli.approval_runtime import ApprovalSource
 from kimi_cli.soul.agent import Agent, Runtime
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.telemetry import set_context
 from kimi_cli.utils.aioqueue import QueueShutDown
 from kimi_cli.wire.jsonrpc import (
+    ClientInfo,
     ErrorCodes,
     JSONRPCErrorResponse,
     JSONRPCEventMessage,
@@ -33,6 +36,41 @@ def _make_soul(runtime: Runtime, tmp_path: Path) -> KimiSoul:
         runtime=runtime,
     )
     return KimiSoul(agent, context=Context(file_backend=tmp_path / "history.jsonl"))
+
+
+def _reset_telemetry() -> None:
+    telemetry_mod._event_queue.clear()
+    telemetry_mod._device_id = None
+    telemetry_mod._session_id = None
+    telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
+    telemetry_mod._sink = None
+    telemetry_mod._disabled = False
+
+
+def test_wire_client_info_emits_session_started(
+    runtime: Runtime,
+    tmp_path: Path,
+) -> None:
+    _reset_telemetry()
+    try:
+        set_context(device_id="dev-wire", session_id=runtime.session.id)
+        runtime.ui_mode = "wire"
+        runtime.resumed = True
+        soul = _make_soul(runtime, tmp_path)
+        server = WireServer(soul)
+
+        server._track_session_started(ClientInfo(name="kiwi", version="1.2.3"))
+
+        event = telemetry_mod._event_queue[-1]
+        assert event["event"] == "session_started"
+        assert event["session_id"] == runtime.session.id
+        assert event["properties"]["client_name"] == "kiwi"
+        assert event["properties"]["client_version"] == "1.2.3"
+        assert event["properties"]["ui_mode"] == "wire"
+        assert event["properties"]["resumed"] is True
+    finally:
+        _reset_telemetry()
 
 
 @pytest.mark.asyncio

--- a/tests/telemetry/test_crash.py
+++ b/tests/telemetry/test_crash.py
@@ -29,6 +29,7 @@ def _reset_state():
     telemetry_mod._device_id = None
     telemetry_mod._session_id = None
     telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
     # crash module
@@ -46,6 +47,7 @@ def _reset_state():
     telemetry_mod._device_id = None
     telemetry_mod._session_id = None
     telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
 

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -34,6 +34,7 @@ def _reset_telemetry_state():
     telemetry_mod._device_id = None
     telemetry_mod._session_id = None
     telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
     yield
@@ -41,6 +42,7 @@ def _reset_telemetry_state():
     telemetry_mod._device_id = None
     telemetry_mod._session_id = None
     telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
 
@@ -763,8 +765,8 @@ class TestContextEnrichment:
 # ---------------------------------------------------------------------------
 
 
-class TestClientInfo:
-    """Verify set_client_info and its propagation through sink enrichment."""
+class TestSessionStarted:
+    """Verify session_started attribution and client info handling."""
 
     def _make_sink(self) -> tuple[EventSink, MagicMock]:
         transport = MagicMock(spec=AsyncTransport)
@@ -776,31 +778,14 @@ class TestClientInfo:
         sink.flush_sync()
         return transport.save_to_disk.call_args[0][0][0]
 
-    def test_no_client_info_means_fields_absent(self):
-        """If set_client_info is never called, context has neither field."""
-        sink, transport = self._make_sink()
-        enriched = self._enrich(sink, transport)
-        assert "client_name" not in enriched["context"]
-        assert "client_version" not in enriched["context"]
-
-    def test_set_client_info_populates_both_fields(self):
-        """set_client_info with name+version injects both into context."""
+    def test_context_never_contains_client_info(self):
+        """Client attribution belongs on session_started properties, not context."""
         from kimi_cli.telemetry import set_client_info
 
         set_client_info(name="vscode", version="1.90.0")
         sink, transport = self._make_sink()
         enriched = self._enrich(sink, transport)
-        assert enriched["context"]["client_name"] == "vscode"
-        assert enriched["context"]["client_version"] == "1.90.0"
-
-    def test_set_client_info_name_only_omits_version(self):
-        """When version is None, client_version key is not added."""
-        from kimi_cli.telemetry import set_client_info
-
-        set_client_info(name="zed")
-        sink, transport = self._make_sink()
-        enriched = self._enrich(sink, transport)
-        assert enriched["context"]["client_name"] == "zed"
+        assert "client_name" not in enriched["context"]
         assert "client_version" not in enriched["context"]
 
     def test_set_client_info_empty_name_is_ignored(self):
@@ -809,11 +794,7 @@ class TestClientInfo:
 
         set_client_info(name="cursor", version="0.40.0")
         set_client_info(name="", version="anything")
-        sink, transport = self._make_sink()
-        enriched = self._enrich(sink, transport)
-        # Previous value preserved
-        assert enriched["context"]["client_name"] == "cursor"
-        assert enriched["context"]["client_version"] == "0.40.0"
+        assert telemetry_mod._client_info == ("cursor", "0.40.0")
 
     def test_set_client_info_overwrites_previous(self):
         """Non-empty set_client_info replaces the tuple atomically."""
@@ -821,10 +802,7 @@ class TestClientInfo:
 
         set_client_info(name="vscode", version="1.90.0")
         set_client_info(name="zed", version="0.180.0")
-        sink, transport = self._make_sink()
-        enriched = self._enrich(sink, transport)
-        assert enriched["context"]["client_name"] == "zed"
-        assert enriched["context"]["client_version"] == "0.180.0"
+        assert telemetry_mod._client_info == ("zed", "0.180.0")
 
     def test_client_info_stored_as_tuple(self):
         """_client_info is stored as a tuple so readers never see a half-update."""
@@ -833,17 +811,59 @@ class TestClientInfo:
         set_client_info(name="kimi-web", version="2.0.0")
         assert telemetry_mod._client_info == ("kimi-web", "2.0.0")
 
-    def test_values_pass_through_verbatim(self):
-        """No sanitization: values should reach the backend unchanged."""
-        from kimi_cli.telemetry import set_client_info
+    def test_track_session_started_shell(self):
+        from kimi_cli.telemetry import track_session_started_once
 
-        weird_name = "VS Code\n(Insiders)"
-        weird_version = "1.90.0-beta\ttest"
-        set_client_info(name=weird_name, version=weird_version)
-        sink, transport = self._make_sink()
-        enriched = self._enrich(sink, transport)
-        assert enriched["context"]["client_name"] == weird_name
-        assert enriched["context"]["client_version"] == weird_version
+        set_context(device_id="dev", session_id="sess-shell")
+        track_session_started_once(ui_mode="shell", resumed=False)
+
+        event = _collect_events()[-1]
+        assert event["event"] == "session_started"
+        assert event["properties"]["client_name"] == "shell"
+        assert event["properties"]["client_version"] is None
+        assert event["properties"]["ui_mode"] == "shell"
+        assert event["properties"]["resumed"] is False
+
+    def test_track_session_started_wire_uses_current_client_info(self):
+        from kimi_cli.telemetry import set_client_info, track_session_started_once
+
+        set_context(device_id="dev", session_id="sess-wire")
+        set_client_info(name="kiwi", version="1.2.3")
+        track_session_started_once(ui_mode="wire", resumed=True)
+
+        event = _collect_events()[-1]
+        assert event["event"] == "session_started"
+        assert event["properties"]["client_name"] == "kiwi"
+        assert event["properties"]["client_version"] == "1.2.3"
+        assert event["properties"]["ui_mode"] == "wire"
+        assert event["properties"]["resumed"] is True
+
+    def test_track_session_started_once_per_session(self):
+        from kimi_cli.telemetry import track_session_started_once
+
+        set_context(device_id="dev", session_id="sess-once")
+        track_session_started_once(ui_mode="wire", resumed=False, client_name="kiwi")
+        track_session_started_once(ui_mode="wire", resumed=False, client_name="vscode")
+
+        events = [event for event in _collect_events() if event["event"] == "session_started"]
+        assert len(events) == 1
+        assert events[0]["properties"]["client_name"] == "kiwi"
+
+    def test_track_session_started_explicit_client_info_wins(self):
+        from kimi_cli.telemetry import set_client_info, track_session_started_once
+
+        set_context(device_id="dev", session_id="sess-explicit")
+        set_client_info(name="kiwi", version="1.2.3")
+        track_session_started_once(
+            ui_mode="wire",
+            resumed=False,
+            client_name="kimi-code-for-vs-code",
+            client_version="1.90.0",
+        )
+
+        event = _collect_events()[-1]
+        assert event["properties"]["client_name"] == "kimi-code-for-vs-code"
+        assert event["properties"]["client_version"] == "1.90.0"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -24,6 +24,7 @@ def _reset_telemetry_state():
     telemetry_mod._device_id = None
     telemetry_mod._session_id = None
     telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
     yield
@@ -31,6 +32,7 @@ def _reset_telemetry_state():
     telemetry_mod._device_id = None
     telemetry_mod._session_id = None
     telemetry_mod._client_info = None
+    telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
 


### PR DESCRIPTION
## Summary
- emit a `session_started` telemetry event once per session with raw Wire client info as event properties
- stop attaching client name/version to telemetry context while preserving UI mode context
- add a local telemetry debug server script and focused telemetry/Wire tests

## Test Plan
- `uv run pytest tests/telemetry tests/core/test_wire_server_steer.py::test_wire_client_info_emits_session_started`
- `uv run ruff check src/kimi_cli/telemetry/__init__.py src/kimi_cli/telemetry/sink.py src/kimi_cli/app.py src/kimi_cli/wire/server.py src/kimi_cli/soul/agent.py tests/telemetry/test_instrumentation.py tests/telemetry/test_telemetry.py tests/telemetry/test_crash.py tests/core/test_wire_server_steer.py`
- `uv run ruff format --check src/kimi_cli/telemetry/__init__.py src/kimi_cli/telemetry/sink.py src/kimi_cli/app.py src/kimi_cli/wire/server.py src/kimi_cli/soul/agent.py tests/telemetry/test_instrumentation.py tests/telemetry/test_telemetry.py tests/telemetry/test_crash.py tests/core/test_wire_server_steer.py`
- `uv run pyright src/kimi_cli/telemetry src/kimi_cli/wire/server.py src/kimi_cli/app.py src/kimi_cli/soul/agent.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
