### PR TITLE
fix(file_filter): add utf-8 encoding to git file listing command

### DIFF
--- a/src/kimi_cli/utils/file_filter.py
+++ b/src/kimi_cli/utils/file_filter.py
@@ -237,6 +237,7 @@ def list_files_git(
             capture_output=True,
             text=True,
             timeout=_GIT_LS_FILES_TIMEOUT,
+            encoding="utf-8",
         )
         if result.returncode != 0:
             return None


### PR DESCRIPTION
## Description

On Windows systems with default locale set to GBK (e.g., Chinese Windows), using `@file` in prompts triggers a crash:

```
Exception in thread Thread-4 (_readerthread):
Traceback (most recent call last):
  File "C:\Users\fnmai\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\fnmai\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\fnmai\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\subprocess.py", line 1614, in _readerthread
    buffer.append(fh.read())
                  ~~~~~~~^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0xab in position 529: illegal multibyte sequence

Unhandled exception in event loop:
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\buffer.py", line 1923, in new_coroutine
    await coroutine(*a, **kw)
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\buffer.py", line 1740, in async_completer
    async for completion in async_generator:
    ...<12 lines>...
            break
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\completion\base.py", line 186, in get_completions_async
    for item in self.get_completions(document, complete_event):
                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\completion\deduplicate.py", line 30, in get_completions
    for completion in self.completer.get_completions(document, complete_event):
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\completion\base.py", line 367, in get_completions
    yield from completer.get_completions(document, complete_event)
  File "C:\Users\fnmai\git\kimi-cli\src\kimi_cli\ui\shell\prompt.py", line 775, in get_completions
    candidates = list(self._fuzzy.get_completions(mention_doc, complete_event))
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\completion\fuzzy_completer.py", line 91, in _get_fuzzy_completions
    inner_completions = list(
        self.completer.get_completions(document2, complete_event)
    )
  File "C:\Users\fnmai\AppData\Roaming\uv\tools\kimi-cli\Lib\site-packages\prompt_toolkit\completion\word_completer.py", line 62, in get_completions
    words = words()
  File "C:\Users\fnmai\git\kimi-cli\src\kimi_cli\ui\shell\prompt.py", line 664, in _get_paths
    return self._get_deep_paths()
           ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\fnmai\git\kimi-cli\src\kimi_cli\ui\shell\prompt.py", line 722, in _get_deep_paths
    paths = list_files_git(self._root, scope)
  File "C:\Users\fnmai\git\kimi-cli\src\kimi_cli\utils\file_filter.py", line 248, in list_files_git
    paths = _parse_ls_files_output(result.stdout)
  File "C:\Users\fnmai\git\kimi-cli\src\kimi_cli\utils\file_filter.py", line 158, in _parse_ls_files_output
    for entry in stdout.split("\0"):
                 ^^^^^^^^^^^^

Exception 'NoneType' object has no attribute 'split'
```

Minimal reproducer on Windows with GBK locale:

```python
import subprocess

cmd = [
    "git",
    "-c",
    "core.quotepath=false",
    "ls-files",
    "-z",
    "--recurse-submodules",
]

result = subprocess.run(cmd, capture_output=True, text=True)
print(result.stdout)
```

This minimal sample reproduces the issue:

```
Exception in thread Thread-1 (_readerthread):
Traceback (most recent call last):
  File "C:\Users\fnmai\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\fnmai\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\fnmai\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\subprocess.py", line 1614, in _readerthread
    buffer.append(fh.read())
                  ~~~~~~~^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0xab in position 529: illegal multibyte sequence
None
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
