### PR TITLE
fix(web): serve JavaScript assets with module-safe MIME type

### DIFF
--- a/src/kimi_cli/web/app.py
+++ b/src/kimi_cli/web/app.py
@@ -16,7 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.datastructures import MutableHeaders
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from kimi_cli import logger
@@ -98,6 +98,22 @@ class _StaticCacheHeadersMiddleware:
             await send(message)
 
         await self.app(scope, receive, _send_with_cache_headers)
+
+
+class _WebStaticFiles(StaticFiles):
+    """Serve JavaScript assets with a browser-safe MIME type."""
+
+    def file_response(
+        self,
+        full_path: str | os.PathLike[str],
+        stat_result: os.stat_result,
+        scope: Scope,
+        status_code: int = 200,
+    ) -> Response:
+        response = super().file_response(full_path, stat_result, scope, status_code)
+        if Path(full_path).suffix.lower() == ".js":
+            response.headers["content-type"] = "text/javascript; charset=utf-8"
+        return response
 
 
 def _get_private_addresses(addresses: list[str]) -> list[str]:
@@ -220,7 +236,7 @@ def create_app(
 
     # Mount static files as fallback (must be last)
     if STATIC_DIR.exists():
-        application.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
+        application.mount("/", _WebStaticFiles(directory=STATIC_DIR, html=True), name="static")
 
     return application
 

--- a/tests/web/test_static_mime.py
+++ b/tests/web/test_static_mime.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from kimi_cli.web import app as web_app
+
+
+def test_web_static_js_uses_javascript_mime_when_system_mapping_is_plain_text(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-test.js").write_text("console.log('ok')\n", encoding="utf-8")
+    (static_dir / "index.html").write_text(
+        '<script type="module" src="/assets/index-test.js"></script>',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(web_app, "STATIC_DIR", static_dir)
+
+    original_js_mime = mimetypes.guess_type("index-test.js")[0]
+    mimetypes.add_type("text/plain", ".js")
+    try:
+        with TestClient(web_app.create_app()) as client:
+            response = client.get("/assets/index-test.js")
+    finally:
+        mimetypes.add_type(original_js_mime or "text/javascript", ".js")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].split(";")[0] == "text/javascript"

--- a/tests/web/test_static_mime.py
+++ b/tests/web/test_static_mime.py
@@ -29,7 +29,8 @@ def test_web_static_js_uses_javascript_mime_when_system_mapping_is_plain_text(
         with TestClient(web_app.create_app()) as client:
             response = client.get("/assets/index-test.js")
     finally:
-        mimetypes.add_type(original_js_mime or "text/javascript", ".js")
+        if original_js_mime is not None:
+            mimetypes.add_type(original_js_mime, ".js")
 
     assert response.status_code == 200
     assert response.headers["content-type"].split(";")[0] == "text/javascript"


### PR DESCRIPTION
## Related Issue

Resolve #2074

## Description

This PR fixes a Web UI startup failure on Windows where JavaScript assets can be served with `text/plain` instead of a browser-safe JavaScript MIME type.

On some Windows environments, Python's MIME type detection can resolve `.js` files to `text/plain`. Since the Web UI loads Vite-built assets as module scripts, browsers reject those responses with strict MIME checking before the page can finish loading.

The fix is intentionally scoped to the `/web` static file path:

- add a small `StaticFiles` subclass for the Kimi Web UI
- preserve the existing Starlette static-file behavior
- override `Content-Type` only for served `.js` assets
- avoid changing CLI startup, auth/CORS, session worker logic, frontend build output, or global MIME mappings

A regression test simulates the problematic `.js -> text/plain` MIME mapping and verifies that the served asset still receives a module-safe JavaScript MIME type.

## Tests

- `python -m pytest tests/web/test_static_mime.py -vv`
- `python -m pytest tests/web -vv`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog. (N/A — targeted Web UI MIME bugfix)
- [ ] I have run `make gen-docs` to update the user documentation. (N/A — no user-facing documentation changes)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
