### PR TITLE
chore(release): bump kimi-cli to 1.40.0 and kosong to 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.40.0 (2026-04-28)
+
 - Core: Fix `--yolo` mode unintentionally preventing the model from calling `AskUserQuestion` — yolo used to inject a system reminder telling the model it was in "non-interactive mode" and must not ask, and the ask-user tool auto-dismissed in yolo. Both were wrong: yolo only bypasses permission approvals; it does not mean "the user is gone". Yolo no longer injects model guidance, and the user remains reachable through `AskUserQuestion`
 - CLI: Split permission bypass from unattended execution — `--yolo` bypasses permission approvals while the user is still at the terminal, while `--afk` / `/afk` means away-from-keyboard: `AskUserQuestion` is auto-dismissed and approvals are handled automatically. `--print` now uses runtime AFK behavior instead of yolo, matching its non-interactive execution model. The status bar shows `yolo` and `afk` independently, and `/yolo` and `/afk` toggle their own flag without disturbing the other
 - Config: Replace `skip_yolo_prompt_injection` with `skip_afk_prompt_injection` now that yolo no longer injects model guidance. The old config key is ignored if present

--- a/docs/en/release-notes/breaking-changes.md
+++ b/docs/en/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@ This page documents breaking changes in Kimi Code CLI releases and provides migr
 
 ## Unreleased
 
+## 1.40.0
+
 ### `--print` now uses runtime AFK semantics instead of YOLO semantics
 
 Print mode still runs non-interactively and handles approvals automatically, but it now sets an invocation-only AFK overlay instead of enabling YOLO. This means `--print` treats the user as unavailable and auto-dismisses `AskUserQuestion`, while later interactive resumes do not inherit AFK solely because of a previous print run.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+## 1.40.0 (2026-04-28)
+
 - Core: Fix `--yolo` mode unintentionally preventing the model from calling `AskUserQuestion` — yolo used to inject a system reminder telling the model it was in "non-interactive mode" and must not ask, and the ask-user tool auto-dismissed in yolo. Both were wrong: yolo only bypasses permission approvals; it does not mean "the user is gone". Yolo no longer injects model guidance, and the user remains reachable through `AskUserQuestion`
 - CLI: Split permission bypass from unattended execution — `--yolo` bypasses permission approvals while the user is still at the terminal, while `--afk` / `/afk` means away-from-keyboard: `AskUserQuestion` is auto-dismissed and approvals are handled automatically. `--print` now uses runtime AFK behavior instead of yolo, matching its non-interactive execution model. The status bar shows `yolo` and `afk` independently, and `/yolo` and `/afk` toggle their own flag without disturbing the other
 - Config: Replace `skip_yolo_prompt_injection` with `skip_afk_prompt_injection` now that yolo no longer injects model guidance. The old config key is ignored if present

--- a/docs/zh/release-notes/breaking-changes.md
+++ b/docs/zh/release-notes/breaking-changes.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 1.40.0
+
 ### `--print` 现在使用 runtime AFK 语义而不是 YOLO 语义
 
 Print 模式仍然是非交互运行，并且会自动处理审批，但现在设置的是仅本次调用生效的 AFK 覆盖，而不是启用 YOLO。也就是说，`--print` 会把用户视为不在场并自动 dismiss `AskUserQuestion`，但之后以交互方式恢复同一会话时，不会仅仅因为之前运行过 Print 模式而继承 AFK。

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+## 1.40.0 (2026-04-28)
+
 - Core：修复 `--yolo` 模式意外阻止模型调用 `AskUserQuestion` 的问题——以前 yolo 会注入一段 system reminder，告诉模型当前处于“非交互模式”，不能向用户提问；同时 ask-user 工具在 yolo 下也会自动 dismiss。这两处都是错的：yolo 只绕过权限审批，并不意味着“用户已离开”。现在 yolo 不再向模型注入指导；用户仍可通过 `AskUserQuestion` 触达
 - CLI：把权限审批绕过和无人值守执行拆分为两个正交模式——`--yolo` 表示用户仍在终端前、但绕过权限审批；`--afk` / `/afk` 表示 away-from-keyboard：`AskUserQuestion` 会被自动 dismiss，审批也会自动处理。`--print` 现在使用 runtime AFK 行为而不是 yolo，更符合它的非交互执行模型。状态栏独立显示 `yolo` 和 `afk`，`/yolo` 与 `/afk` 各自切换自身的 flag，互不干扰
 - Config：由于 yolo 不再向模型注入指导，`skip_yolo_prompt_injection` 替换为 `skip_afk_prompt_injection`。旧配置键如果仍存在会被忽略

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.39.0"
+version = "1.40.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.39.0"]
+dependencies = ["kimi-cli==1.40.0"]
 
 [project.scripts]
 kimi-code = "kimi_cli.__main__:main"

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.53.0 (2026-04-28)
+
 - Kimi: Fix stale API key after OAuth token refresh — `on_retryable_error` now reads the current `api_key` from the live client instead of the cached `_api_key`, so that OAuth token refreshes applied via `client.api_key` are preserved when the client is rebuilt after a retryable error
 
 ## 0.52.0 (2026-04-24)

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kosong"
-version = "0.52.0"
+version = "0.53.0"
 description = "The LLM abstraction layer for modern AI agent applications."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.39.0"
+version = "1.40.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -9,7 +9,7 @@ dependencies = [
     "aiofiles>=24.0,<26.0",
     "aiohttp==3.13.3",
     "typer==0.21.1",
-    "kosong[contrib]==0.52.0",
+    "kosong[contrib]==0.53.0",
     # loguru stays >=0.6.0 because notify-py (via batrachian-toad) caps it at <=0.6.0 on 3.14+.
     "loguru>=0.6.0,<0.8",
     "prompt-toolkit==3.0.52",

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.39.0"
+version = "1.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1300,7 +1300,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.39.0"
+version = "1.40.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },
@@ -1346,7 +1346,7 @@ dev = [
 
 [[package]]
 name = "kosong"
-version = "0.52.0"
+version = "0.53.0"
 source = { editable = "packages/kosong" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump kimi-cli + kimi-code from 1.39.0 → 1.40.0 (14 commits since last release)
- Bump kosong from 0.52.0 → 0.53.0 (1 commit since last release)
- pykaos (0.9.0) and kimi-sdk (0.2.1) have no changes since their last release, skipped
- Cut `Unreleased` sections in `CHANGELOG.md`, `packages/kosong/CHANGELOG.md`, and `docs/{en,zh}/release-notes/breaking-changes.md` to versioned headers
- Sync `docs/{en,zh}/release-notes/changelog.md`
- Update root `kosong[contrib]==0.53.0` pin to match the workspace package

## kimi-cli 1.40.0 highlights
- Core: yolo no longer injects model guidance; `AskUserQuestion` is reachable in yolo
- CLI: split permission bypass (`--yolo`) from unattended execution (`--afk` / `/afk`); `--print` now uses runtime AFK semantics
- Config: `skip_yolo_prompt_injection` replaced by `skip_afk_prompt_injection`
- Web: preserve manual session titles vs late AI-generated title; keep tool media previews visible after collapsing tool details; surface session ops failures as toasts
- Auth/Core: managed `/models` refresh handles 401 via OAuth refresh; connection-recovery retry path correctly re-enters OAuth refresh on 401; OAuth token refresh preserved on connection recovery
- Approvals: requests no longer auto-timeout after 5 minutes (active foreground/subagent approvals wait indefinitely)
- Shell: fix `/usage` remaining quota rendering; show active background agent task count in prompt status bar; echo `/skill:*` and `/flow:*` inputs in transcript
- Core: raise default `max_steps_per_turn` from 500 to 1000

## kosong 0.53.0 highlights
- Kimi: fix stale API key after OAuth token refresh — `on_retryable_error` now reads the current `api_key` from the live client instead of the cached `_api_key`

## Breaking changes (1.40.0)
- `--print` now uses runtime AFK semantics instead of YOLO semantics
- `skip_yolo_prompt_injection` replaced by `skip_afk_prompt_injection`

## Test plan
- [x] `python scripts/check_version_tag.py --pyproject pyproject.toml --expected-version 1.40.0`
- [x] `python scripts/check_version_tag.py --pyproject packages/kimi-code/pyproject.toml --expected-version 1.40.0`
- [x] `python scripts/check_version_tag.py --pyproject packages/kosong/pyproject.toml --expected-version 0.53.0`
- [x] `python scripts/check_kimi_dependency_versions.py` (kosong / pykaos pins match)
- [x] `uv sync` clean
- [x] pre-commit hooks (format / check) pass

## Release tags after merge
After this PR is merged into `main`, the user will run:

```
git checkout main
git pull
git tag 1.40.0
git tag kosong-0.53.0
git push origin 1.40.0 kosong-0.53.0
```

The numeric `1.40.0` tag triggers `release-kimi-cli` (which publishes both `kimi-cli` and `kimi-code` to PyPI plus GitHub Release binaries). The `kosong-0.53.0` tag triggers `release-kosong` (PyPI + docs). It is recommended to push the kosong tag first so PyPI has `kosong==0.53.0` available before `kimi-cli==1.40.0` resolves its pinned dependency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
