### PR TITLE
只读模式 || read-only mode

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -128,6 +128,7 @@ class KimiCLI:
         # Run mode
         yolo: bool = False,
         plan_mode: bool = False,
+        readonly: bool = False,
         resumed: bool = False,
         ui_mode: str = "shell",
         # Extensions
@@ -151,6 +152,7 @@ class KimiCLI:
             model_name (str | None, optional): Name of the model to use. Defaults to None.
             thinking (bool | None, optional): Whether to enable thinking mode. Defaults to None.
             yolo (bool, optional): Approve all actions without confirmation. Defaults to False.
+            readonly (bool, optional): Block all file modifications. Defaults to False.
             agent_file (Path | None, optional): Path to the agent file. Defaults to None.
             mcp_configs (list[MCPConfig | dict[str, Any]] | None, optional): MCP configs to load
                 MCP tools from. Defaults to None.
@@ -247,12 +249,16 @@ class KimiCLI:
         if startup_progress is not None:
             startup_progress("Scanning workspace...")
 
+        # Determine readonly mode (CLI flag overrides config default)
+        effective_readonly = readonly or config.default_readonly
+
         runtime = await Runtime.create(
             config,
             oauth,
             llm,
             session,
             yolo,
+            readonly=effective_readonly,
             skills_dirs=skills_dirs,
         )
         runtime.ui_mode = ui_mode

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -203,6 +203,13 @@ def kimi(
             help="Start in plan mode. Default: no.",
         ),
     ] = False,
+    readonly: Annotated[
+        bool,
+        typer.Option(
+            "--readonly",
+            help="Start in readonly mode (block all file modifications). Default: no.",
+        ),
+    ] = False,
     prompt: Annotated[
         str | None,
         typer.Option(
@@ -611,6 +618,7 @@ def kimi(
                 thinking=thinking,
                 yolo=yolo or (ui == "print"),  # print mode implies yolo
                 plan_mode=plan,
+                readonly=readonly,
                 resumed=resumed,
                 agent_file=agent_file,
                 mcp_configs=mcp_configs,

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -208,6 +208,9 @@ class Config(BaseModel):
         ),
     )
     default_plan_mode: bool = Field(default=False, description="Default plan mode for new sessions")
+    default_readonly: bool = Field(
+        default=False, description="Default readonly mode (block all file modifications)"
+    )
     default_editor: str = Field(
         default="",
         description="Default external editor command (e.g. 'vim', 'code --wait')",

--- a/src/kimi_cli/session_state.py
+++ b/src/kimi_cli/session_state.py
@@ -24,6 +24,19 @@ class TodoItemState(BaseModel):
     status: Literal["pending", "in_progress", "done"]
 
 
+class PendingEdit(BaseModel):
+    """A pending edit operation recorded in readonly mode."""
+
+    tool_name: str
+    """Name of the tool that was intercepted, e.g. 'WriteFile', 'StrReplaceFile', 'Shell'."""
+    params: dict[str, object] = Field(default_factory=dict)
+    """The parameters that were passed to the tool."""
+    description: str = ""
+    """Human-readable description of the operation."""
+    timestamp: float = Field(default_factory=lambda: __import__("time").time())
+    """Unix timestamp when the edit was recorded."""
+
+
 class SessionState(BaseModel):
     version: int = 1
     approval: ApprovalStateData = Field(default_factory=ApprovalStateData)
@@ -32,6 +45,7 @@ class SessionState(BaseModel):
     title_generated: bool = False
     title_generate_attempts: int = 0
     plan_mode: bool = False
+    readonly: bool = False
     plan_session_id: str | None = None
     plan_slug: str | None = None
     # Archive state (previously in metadata.json)
@@ -41,6 +55,8 @@ class SessionState(BaseModel):
     auto_archive_exempt: bool = False
     # Todo list state
     todos: list[TodoItemState] = Field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    # Pending edits (recorded in readonly mode)
+    pending_edits: list[PendingEdit] = Field(default_factory=list)
 
 
 _LEGACY_METADATA_FILENAME = "metadata.json"

--- a/src/kimi_cli/soul/__init__.py
+++ b/src/kimi_cli/soul/__init__.py
@@ -90,6 +90,8 @@ class StatusSnapshot:
     """Whether YOLO (auto-approve) mode is enabled."""
     plan_mode: bool = False
     """Whether plan mode (read-only research and planning) is active."""
+    readonly: bool = False
+    """Whether readonly mode (block all file modifications) is active."""
     context_tokens: int = 0
     """The number of tokens currently in the context."""
     max_context_tokens: int = 0

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -194,6 +194,7 @@ class Runtime:
     role: Literal["root", "subagent"] = "root"
     ui_mode: str = "shell"
     resumed: bool = False
+    readonly: bool = False
     hook_engine: Any = None
     """HookEngine instance, set by KimiCLI after soul creation."""
 
@@ -215,6 +216,7 @@ class Runtime:
         llm: LLM | None,
         session: Session,
         yolo: bool,
+        readonly: bool = False,
         skills_dirs: list[KaosPath] | None = None,
     ) -> Runtime:
         ls_output, agents_md, environment = await asyncio.gather(
@@ -272,7 +274,11 @@ class Runtime:
             additional_dirs_info = "\n\n".join(parts)
 
         # Merge CLI flag with persisted session state
+        effective_readonly = readonly or session.state.readonly
         effective_yolo = yolo or session.state.approval.yolo
+        # Readonly mode takes precedence: disable yolo when readonly is active
+        if effective_readonly:
+            effective_yolo = False
         saved_actions = set(session.state.approval.auto_approve_actions)
 
         def _on_approval_change() -> None:
@@ -282,6 +288,7 @@ class Runtime:
 
         approval_state = ApprovalState(
             yolo=effective_yolo,
+            readonly=effective_readonly,
             auto_approve_actions=saved_actions,
             on_change=_on_approval_change,
         )
@@ -326,6 +333,7 @@ class Runtime:
             approval_runtime=ApprovalRuntime(),
             root_wire_hub=RootWireHub(),
             role="root",
+            readonly=effective_readonly,
         )
 
     def copy_for_subagent(
@@ -358,6 +366,7 @@ class Runtime:
             subagent_id=agent_id,
             subagent_type=subagent_type,
             role="subagent",
+            readonly=self.readonly,
         )
 
 

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -56,10 +56,12 @@ class ApprovalState:
     def __init__(
         self,
         yolo: bool = False,
+        readonly: bool = False,
         auto_approve_actions: set[str] | None = None,
         on_change: Callable[[], None] | None = None,
     ):
         self.yolo = yolo
+        self.readonly = readonly
         self.auto_approve_actions: set[str] = auto_approve_actions or set()
         """Set of action names that should automatically be approved."""
         self._on_change = on_change
@@ -97,6 +99,13 @@ class Approval:
 
     def is_yolo(self) -> bool:
         return self._state.yolo
+
+    def set_readonly(self, readonly: bool) -> None:
+        self._state.readonly = readonly
+        self._state.notify_change()
+
+    def is_readonly(self) -> bool:
+        return self._state.readonly
 
     async def request(
         self,

--- a/src/kimi_cli/soul/dynamic_injections/readonly_mode.py
+++ b/src/kimi_cli/soul/dynamic_injections/readonly_mode.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from kosong.message import Message
+
+from kimi_cli.soul.dynamic_injection import DynamicInjection, DynamicInjectionProvider
+
+if TYPE_CHECKING:
+    from kimi_cli.soul.kimisoul import KimiSoul
+
+_READONLY_INJECTION_TYPE = "readonly_mode"
+
+_READONLY_PROMPT = (
+    "当前处于只读模式。"
+    "当你需要修改代码时，请直接调用写操作工具（WriteFile、StrReplaceFile）或危险 Shell 命令。"
+    "这些工具会在只读模式下被自动拦截，并将操作记录到待修改清单中，不会实际修改文件。"
+    "用户可以发送 /pending 查看清单，发送 /pending-edit <序号> 修改某一项，发送 /pending-remove <序号> 删除单项，"
+    "发送 /pending-clear 清空全部，发送 /execute 批量执行所有暂存的操作。"
+    "不要只在文字中描述修改计划——直接调用工具，让系统自动收集待修改清单。"
+    "如果某个工具被拦截返回错误，不要反复重试同一个操作。"
+)
+
+
+class ReadonlyModeInjectionProvider(DynamicInjectionProvider):
+    """Injects a one-time reminder when readonly mode is active."""
+
+    def __init__(self) -> None:
+        self._injected: bool = False
+
+    async def get_injections(
+        self,
+        history: Sequence[Message],
+        soul: KimiSoul,
+    ) -> list[DynamicInjection]:
+        if not soul.is_readonly:
+            self._injected = False
+            return []
+        if self._injected:
+            return []
+        self._injected = True
+        return [DynamicInjection(type=_READONLY_INJECTION_TYPE, content=_READONLY_PROMPT)]
+
+    async def on_context_compacted(self) -> None:
+        # Compaction wipes history; the reminder may have been summarized away.
+        # Clear the one-shot flag so the next step re-injects while readonly is active.
+        self._injected = False

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -60,6 +60,7 @@ from kimi_cli.soul.dynamic_injection import (
     normalize_history,
 )
 from kimi_cli.soul.dynamic_injections.plan_mode import PlanModeInjectionProvider
+from kimi_cli.soul.dynamic_injections.readonly_mode import ReadonlyModeInjectionProvider
 from kimi_cli.soul.dynamic_injections.yolo_mode import YoloModeInjectionProvider
 from kimi_cli.soul.message import check_message, system, system_reminder, tool_result_to_message
 from kimi_cli.soul.slash import registry as soul_slash_registry
@@ -199,6 +200,7 @@ class KimiSoul:
             self._ensure_plan_session_id()
         self._injection_providers: list[DynamicInjectionProvider] = [
             PlanModeInjectionProvider(),
+            ReadonlyModeInjectionProvider(),
             *(
                 []
                 if self._runtime.config.skip_yolo_prompt_injection
@@ -239,6 +241,18 @@ class KimiSoul:
     def plan_mode(self) -> bool:
         """Whether plan mode (read-only research and planning) is active."""
         return self._plan_mode
+
+    @property
+    def is_readonly(self) -> bool:
+        """Whether readonly mode (block all file modifications) is active."""
+        return self._runtime.readonly
+
+    def set_readonly(self, enabled: bool) -> None:
+        """Enable or disable readonly mode."""
+        self._runtime.readonly = enabled
+        self._runtime.session.state.readonly = enabled
+        self._runtime.session.save_state()
+        self._approval.set_readonly(enabled)
 
     @property
     def hook_engine(self) -> HookEngine:
@@ -439,6 +453,7 @@ class KimiSoul:
             context_usage=self._context_usage,
             yolo_enabled=self._approval.is_yolo(),
             plan_mode=self._plan_mode,
+            readonly=self.is_readonly,
             context_tokens=token_count,
             max_context_tokens=max_size,
             mcp_status=self._mcp_status_snapshot(),

--- a/src/kimi_cli/soul/slash.py
+++ b/src/kimi_cli/soul/slash.py
@@ -223,6 +223,158 @@ async def add_dir(soul: KimiSoul, args: str):
     logger.info("Added additional directory: {path}", path=path)
 
 
+def _format_pending_list(soul: KimiSoul) -> str:
+    """Format the pending edits list for display."""
+    pending = soul.runtime.session.state.pending_edits
+    if not pending:
+        return "待修改清单为空。"
+    lines = [f"待修改清单（共 {len(pending)} 项）："]
+    for i, edit in enumerate(pending, 1):
+        lines.append(f"  {i}. [{edit.tool_name}] {edit.description}")
+    return "\n".join(lines)
+
+
+@registry.command
+async def execute(soul: KimiSoul, args: str):
+    """解除只读模式，并批量执行待修改清单中的操作"""
+    if not soul.is_readonly:
+        wire_send(TextPart(text="当前不处于只读模式，无需执行此命令。"))
+        return
+
+    pending = soul.runtime.session.state.pending_edits
+    soul.set_readonly(False)
+
+    if pending:
+        # Build a system message instructing the AI to execute pending edits
+        lines = [
+            "用户已通过 /execute 解除只读模式。请按照以下待修改清单按顺序执行操作：",
+            "",
+        ]
+        for i, edit in enumerate(pending, 1):
+            lines.append(f"{i}. [{edit.tool_name}] {edit.description}")
+        lines.extend([
+            "",
+            "注意：",
+            "- 请严格按照上述顺序执行",
+            "- 每个操作完成后等待结果再继续下一个",
+            "- 如果某一步失败，请分析原因并决定是否继续",
+            "- 执行完所有操作后，向用户汇报完成情况",
+        ])
+        await soul.context.append_message(
+            Message(role="user", content=[system("\n".join(lines))])
+        )
+        # Clear the pending edits list
+        soul.runtime.session.state.pending_edits = []
+        soul.runtime.session.save_state()
+        wire_send(TextPart(text="已解除只读模式，并将待修改清单注入对话上下文。AI 将按顺序执行。"))
+    else:
+        wire_send(TextPart(text="已解除只读模式。现在可以修改文件和执行 Shell 命令。"))
+
+    wire_send(StatusUpdate(readonly_mode=False))
+
+
+@registry.command
+async def readonly(soul: KimiSoul, args: str):
+    """进入只读模式，禁止修改文件和执行命令"""
+    if soul.is_readonly:
+        wire_send(TextPart(text="当前已处于只读模式。"))
+        return
+
+    soul.set_readonly(True)
+    wire_send(TextPart(text="已进入只读模式。文件修改和 Shell 命令已被禁用。发送 /execute 可解除。"))
+    wire_send(StatusUpdate(readonly_mode=True))
+
+
+@registry.command(name="pending")
+async def pending_list(soul: KimiSoul, args: str):
+    """查看待修改清单"""
+    text = _format_pending_list(soul)
+    wire_send(TextPart(text=text))
+
+
+@registry.command(name="pending-remove")
+async def pending_remove(soul: KimiSoul, args: str):
+    """按序号删除待修改清单中的某一项。Usage: /pending-remove <序号>"""
+    pending = soul.runtime.session.state.pending_edits
+    if not pending:
+        wire_send(TextPart(text="待修改清单为空，无需删除。"))
+        return
+
+    arg = args.strip()
+    if not arg:
+        wire_send(TextPart(text="Usage: /pending-remove <序号>。使用 /pending 查看清单序号。"))
+        return
+
+    try:
+        idx = int(arg)
+    except ValueError:
+        wire_send(TextPart(text=f"无效的序号: `{arg}`，请输入数字。"))
+        return
+
+    if idx < 1 or idx > len(pending):
+        wire_send(TextPart(text=f"序号 {idx} 超出范围（共 {len(pending)} 项）。"))
+        return
+
+    removed = pending.pop(idx - 1)
+    soul.runtime.session.save_state()
+    wire_send(TextPart(text=f"已删除第 {idx} 项: [{removed.tool_name}] {removed.description}"))
+
+
+@registry.command(name="pending-edit")
+async def pending_edit(soul: KimiSoul, args: str):
+    """把指定项的参数注入对话上下文以便修改。Usage: /pending-edit <序号>"""
+    pending = soul.runtime.session.state.pending_edits
+    if not pending:
+        wire_send(TextPart(text="待修改清单为空，无可编辑项。"))
+        return
+
+    arg = args.strip()
+    if not arg:
+        wire_send(TextPart(text="Usage: /pending-edit <序号>。使用 /pending 查看清单序号。"))
+        return
+
+    try:
+        idx = int(arg)
+    except ValueError:
+        wire_send(TextPart(text=f"无效的序号: `{arg}`，请输入数字。"))
+        return
+
+    if idx < 1 or idx > len(pending):
+        wire_send(TextPart(text=f"序号 {idx} 超出范围（共 {len(pending)} 项）。"))
+        return
+
+    edit = pending[idx - 1]
+    import json
+
+    params_json = json.dumps(edit.params, ensure_ascii=False, indent=2)
+    lines = [
+        f"用户希望修改待修改清单中的第 {idx} 项。",
+        f"原操作工具: {edit.tool_name}",
+        f"原描述: {edit.description}",
+        f"原参数:\n```json\n{params_json}\n```",
+        "",
+        "请根据用户的新要求，直接调用相应的工具重新发起操作（系统会将其记录为新待修改清单项）。",
+        f"旧项（第 {idx} 项）可以由用户稍后发送 /pending-remove {idx} 删除。",
+    ]
+    await soul.context.append_message(
+        Message(role="user", content=[system("\n".join(lines))])
+    )
+    wire_send(
+        TextPart(
+            text=f"已将第 {idx} 项的参数注入对话上下文。请告诉 AI 你想如何修改这一项。"
+        )
+    )
+
+
+@registry.command(name="pending-clear")
+async def pending_clear(soul: KimiSoul, args: str):
+    """清空待修改清单"""
+    count = len(soul.runtime.session.state.pending_edits)
+    soul.runtime.session.state.pending_edits = []
+    soul.runtime.session.save_state()
+    wire_send(TextPart(text=f"已清空待修改清单（清除了 {count} 项）。"))
+
+
 @registry.command
 async def export(soul: KimiSoul, args: str):
     """Export current session context to a markdown file"""

--- a/src/kimi_cli/tools/agent/__init__.py
+++ b/src/kimi_cli/tools/agent/__init__.py
@@ -118,6 +118,11 @@ class AgentTool(CallableTool2[Params]):
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
+        if getattr(self._runtime, "readonly", False):
+            return ToolError(
+                message="当前处于只读模式，无法启动子代理。请发送 /execute 解除只读模式后再执行此操作。",
+                brief="Readonly mode active",
+            )
         if self._runtime.role != "root":
             return ToolError(
                 message="Subagents cannot launch other subagents.",

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -11,7 +11,7 @@ from kimi_cli.soul.approval import Approval
 from kimi_cli.tools.display import DisplayBlock
 from kimi_cli.tools.file import FileActions
 from kimi_cli.tools.file.plan_mode import inspect_plan_edit_target
-from kimi_cli.tools.utils import load_desc
+from kimi_cli.tools.utils import load_desc, record_pending_edit
 from kimi_cli.utils.diff import build_diff_blocks
 from kimi_cli.utils.logging import logger
 from kimi_cli.utils.path import is_within_workspace
@@ -87,6 +87,25 @@ class StrReplaceFile(CallableTool2[Params]):
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
+        # Readonly mode: block all edit operations and record to pending edits
+        if getattr(self._runtime, "readonly", False):
+            edits = params.edit if isinstance(params.edit, list) else [params.edit]
+            record_pending_edit(
+                self._runtime,
+                tool_name=self.name,
+                params={"path": params.path, "edit": [e.model_dump() for e in edits]},
+                description=f"编辑文件 `{params.path}`（{len(edits)} 处修改）",
+            )
+            pending_count = len(self._runtime.session.state.pending_edits)
+            return ToolError(
+                message=(
+                    f"当前处于只读模式，无法直接编辑文件。"
+                    f"该操作已暂存到待修改清单（共 {pending_count} 项）。"
+                    f"发送 /pending 查看清单，发送 /execute 批量执行所有暂存操作。"
+                ),
+                brief="Readonly mode active",
+            )
+
         if not params.path:
             return ToolError(
                 message="File path cannot be empty.",

--- a/src/kimi_cli/tools/file/write.py
+++ b/src/kimi_cli/tools/file/write.py
@@ -11,7 +11,7 @@ from kimi_cli.soul.approval import Approval
 from kimi_cli.tools.display import DisplayBlock
 from kimi_cli.tools.file import FileActions
 from kimi_cli.tools.file.plan_mode import inspect_plan_edit_target
-from kimi_cli.tools.utils import load_desc
+from kimi_cli.tools.utils import load_desc, record_pending_edit
 from kimi_cli.utils.diff import build_diff_blocks
 from kimi_cli.utils.logging import logger
 from kimi_cli.utils.path import is_within_workspace
@@ -77,6 +77,24 @@ class WriteFile(CallableTool2[Params]):
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
+        # Readonly mode: block all write operations and record to pending edits
+        if getattr(self._runtime, "readonly", False):
+            record_pending_edit(
+                self._runtime,
+                tool_name=self.name,
+                params={"path": params.path, "content": params.content, "mode": params.mode},
+                description=f"写入文件 `{params.path}`（{params.mode}）",
+            )
+            pending_count = len(self._runtime.session.state.pending_edits)
+            return ToolError(
+                message=(
+                    f"当前处于只读模式，无法直接写入文件。"
+                    f"该操作已暂存到待修改清单（共 {pending_count} 项）。"
+                    f"发送 /pending 查看清单，发送 /execute 批量执行所有暂存操作。"
+                ),
+                brief="Readonly mode active",
+            )
+
         # TODO: checks:
         # - check if the path may contain secrets
         if not params.path:

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -13,7 +13,7 @@ from kimi_cli.soul.agent import Runtime
 from kimi_cli.soul.approval import Approval
 from kimi_cli.soul.toolset import get_current_tool_call_or_none
 from kimi_cli.tools.display import BackgroundTaskDisplayBlock, ShellDisplayBlock
-from kimi_cli.tools.utils import ToolResultBuilder, load_desc
+from kimi_cli.tools.utils import ToolResultBuilder, load_desc, record_pending_edit
 from kimi_cli.utils.environment import Environment
 from kimi_cli.utils.logging import logger
 from kimi_cli.utils.subprocess_env import get_noninteractive_env
@@ -73,12 +73,161 @@ class Shell(CallableTool2[Params]):
         self._shell_path = environment.shell_path
         self._runtime = runtime
 
+    @staticmethod
+    def _is_readonly_safe_command(command: str) -> bool:
+        """判断 Shell 命令在只读模式下是否安全（不会修改文件系统）。
+
+        采用保守策略：只放行明确已知的只读命令，其余一律视为危险。
+        """
+        stripped = command.strip().lower()
+
+        # 1. 基础危险符号：重定向
+        if ">" in stripped or ">>" in stripped:
+            return False
+
+        # 2. 管道写入
+        if "| tee" in stripped:
+            return False
+
+        # 3. 常见文件操作命令
+        dangerous_prefixes = (
+            "rm ", "mv ", "cp ", "chmod ", "chown ", "mkdir ", "rmdir ",
+            "touch ", "mkfifo ", "ln ", "dd ", "truncate ",
+        )
+        if stripped.startswith(dangerous_prefixes):
+            return False
+
+        # 4. git 危险操作
+        dangerous_git = (
+            "git push", "git commit", "git merge", "git rebase",
+            "git reset", "git cherry-pick", "git stash", "git clean",
+            "git checkout -b", "git checkout --", "git revert",
+        )
+        for dg in dangerous_git:
+            if dg in stripped:
+                return False
+
+        # 5. sed 原地编辑
+        if "sed " in stripped and " -i" in stripped:
+            return False
+
+        # 6. 安装/构建/包管理命令
+        install_prefixes = (
+            "pip install", "pip uninstall", "npm install", "npm uninstall",
+            "npm ci", "npm publish", "yarn add", "yarn remove", "pnpm install",
+            "cargo build", "cargo install", "make ", "cmake ", "g++ ", "gcc ",
+        )
+        if stripped.startswith(install_prefixes):
+            return False
+
+        # 7. PowerShell / .NET 文件写入 API（绕过检测的常见方式）
+        dotnet_file_ops = (
+            "writealltext", "writealllines", "writeallbytes",
+            "appendalltext", "appendalllines",
+            "file.create", "file.delete", "file.move", "file.copy",
+            "file.replace", "file.setattributes",
+            "directory.create", "directory.delete", "directory.move",
+            "streamwriter", "filestream", "binarywriter",
+        )
+        for pattern in dotnet_file_ops:
+            if pattern in stripped:
+                return False
+
+        # 8. PowerShell Cmdlet 文件操作
+        ps_file_ops = (
+            "set-content", "add-content", "out-file", "new-item",
+            "remove-item", "rename-item", "copy-item", "move-item",
+            "clear-content", "export-csv", "export-clixml",
+        )
+        for pattern in ps_file_ops:
+            if pattern in stripped:
+                return False
+
+        # 9. Python 文件写入（通过 -c 参数）
+        if any(x in stripped for x in ("python -c", "python3 -c", "py -c")):
+            py_write_patterns = (
+                "open(", "os.remove", "os.rename", "os.mkdir", "os.rmdir",
+                "os.makedirs", "shutil.copy", "shutil.move", "shutil.rmtree",
+                "pathlib.", "file.write", ".write(",
+            )
+            for pattern in py_write_patterns:
+                if pattern in stripped:
+                    return False
+
+        # 10. Node.js / JavaScript 文件写入（通过 -e 参数）
+        if "node -e" in stripped or "node -p" in stripped or "node --eval" in stripped:
+            return False
+
+        # 11. 其他脚本解释器调用（一律视为危险，无法判断其内部行为）
+        script_exec = (
+            "bash -c", "sh -c", "zsh -c", "pwsh -c", "cmd /c",
+            "php ", "ruby ", "perl ", "lua ", "tcl ", "awk -f", "gawk -f",
+        )
+        if stripped.startswith(script_exec):
+            return False
+
+        # 12. 网络下载命令（可能写入文件）
+        download_cmds = (
+            "curl -o", "curl --output", "wget -o", "wget --output-document",
+            "invoke-webrequest", "start-bitstransfer",
+        )
+        for pattern in download_cmds:
+            if pattern in stripped:
+                return False
+
+        return True
+
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
         builder = ToolResultBuilder()
 
         if not params.command:
             return builder.error("Command cannot be empty.", brief="Empty command")
+
+        # Readonly mode: block dangerous shell commands, allow read-only ones
+        if getattr(self._runtime, "readonly", False):
+            # Background tasks are always blocked in readonly mode
+            if params.run_in_background:
+                record_pending_edit(
+                    self._runtime,
+                    tool_name=self.name,
+                    params={
+                        "command": params.command,
+                        "timeout": params.timeout,
+                        "run_in_background": True,
+                        "description": params.description,
+                    },
+                    description=f"后台执行 Shell 命令 `{params.command[:80]}{'...' if len(params.command) > 80 else ''}`",
+                )
+                pending_count = len(self._runtime.session.state.pending_edits)
+                return builder.error(
+                    f"当前处于只读模式，后台 Shell 命令被禁用。"
+                    f"该操作已暂存到待修改清单（共 {pending_count} 项）。"
+                    f"发送 /pending 查看清单，发送 /execute 批量执行所有暂存操作。",
+                    brief="Readonly mode active",
+                )
+
+            # Foreground commands: allow read-only safe commands
+            if not self._is_readonly_safe_command(params.command):
+                record_pending_edit(
+                    self._runtime,
+                    tool_name=self.name,
+                    params={
+                        "command": params.command,
+                        "timeout": params.timeout,
+                        "run_in_background": False,
+                        "description": params.description,
+                    },
+                    description=f"执行 Shell 命令 `{params.command[:80]}{'...' if len(params.command) > 80 else ''}`",
+                )
+                pending_count = len(self._runtime.session.state.pending_edits)
+                return builder.error(
+                    f"当前处于只读模式，该 Shell 命令可能修改文件系统，已被拦截。"
+                    f"该操作已暂存到待修改清单（共 {pending_count} 项）。"
+                    f"发送 /pending 查看清单，发送 /execute 批量执行所有暂存操作。",
+                    brief="Readonly mode active",
+                )
+            # Safe command → proceed normally below
 
         if params.run_in_background:
             return await self._run_in_background(params)

--- a/src/kimi_cli/tools/utils.py
+++ b/src/kimi_cli/tools/utils.py
@@ -1,9 +1,41 @@
 import re
 from pathlib import Path
+from typing import Any
 
 from jinja2 import Environment, Undefined
 from kosong.tooling import BriefDisplayBlock, DisplayBlock, ToolError, ToolReturnValue
 from kosong.utils.typing import JsonType
+
+from kimi_cli.session_state import PendingEdit
+from kimi_cli.utils.logging import logger
+
+
+def record_pending_edit(
+    runtime: Any,
+    tool_name: str,
+    params: dict[str, object],
+    description: str,
+) -> None:
+    """Record an intercepted tool call to the pending edits list in readonly mode.
+
+    Args:
+        runtime: The agent runtime (must have `.session.state.pending_edits`).
+        tool_name: Name of the tool that was intercepted.
+        params: The parameters passed to the tool.
+        description: Human-readable description of the operation.
+    """
+    try:
+        session = runtime.session
+        session.state.pending_edits.append(
+            PendingEdit(
+                tool_name=tool_name,
+                params=params,
+                description=description,
+            )
+        )
+        session.save_state()
+    except Exception as e:
+        logger.warning("Failed to record pending edit: {error}", error=e)
 
 
 class _KeepPlaceholderUndefined(Undefined):

--- a/src/kimi_cli/wire/types.py
+++ b/src/kimi_cli/wire/types.py
@@ -174,6 +174,8 @@ class StatusUpdate(BaseModel):
     """The message ID of the current step."""
     plan_mode: bool | None = None
     """Whether plan mode (read-only) is active. None means no change."""
+    readonly_mode: bool | None = None
+    """Whether readonly mode (block all file modifications) is active. None means no change."""
     mcp_status: MCPStatusSnapshot | None = None
     """The current MCP startup snapshot. None means no change."""
 


### PR DESCRIPTION
# 只读模式功能清单

## 一、进入/退出只读模式

| 功能 | 方式 | 说明 |
|------|------|------|
| 启动时进入 | `--readonly` CLI 参数 | 命令行启动时直接以只读模式运行 |
| 启动时进入 | `default_readonly=true` 配置 | `kimi-cli` 配置文件中设置默认只读 |
| 运行中进入 | `/readonly` 斜杠命令 | 当前会话切换为只读模式 |
| 运行中退出 | `/execute` 斜杠命令 | 解除只读模式，并批量执行待修改清单 |

## 二、工具拦截策略

| 工具 | 只读模式行为 |
|------|-------------|
| `WriteFile` | **全部拦截**，记录到待修改清单 |
| `StrReplaceFile` | **全部拦截**，记录到待修改清单 |
| `AgentTool`（子代理） | **全部拦截**，禁止启动子代理 |
| `Shell` | **智能拦截**：<br>- 后台任务：一律拦截<br>- 前台命令：检测是否安全，危险命令拦截，只读命令（`ls`、`cat`、`grep`、`git status` 等）放行 |

## 三、Shell 危险命令检测

检测维度：

- 重定向符 `>` / `>>`
- 文件操作命令：`rm`、`mv`、`cp`、`mkdir`、`touch`、`chmod` 等
- Git 危险操作：`git push`、`git commit`、`git merge`、`git reset` 等
- `sed -i` 原地编辑
- 安装/构建命令：`pip install`、`npm install`、`cargo build`、`make` 等
- **.NET 文件操作 API**：`WriteAllText`、`File.Create`、`StreamWriter` 等
- **PowerShell Cmdlet**：`Set-Content`、`Out-File`、`New-Item`、`Remove-Item` 等
- **Python -c 文件写入**：`open(`、`os.remove`、`shutil` 等
- **Node.js -e**：一律拦截
- **其他脚本解释器**：`bash -c`、`php`、`ruby`、`perl` 等
- **网络下载**：`curl -o`、`wget --output-document`、`Invoke-WebRequest` 等

## 四、待修改清单（Pending Edits）

| 命令 | 功能 |
|------|------|
| `/pending` | 查看当前待修改清单 |
| `/pending-edit <序号>` | 将指定项的完整参数注入对话上下文，便于修改 |
| `/pending-remove <序号>` | 删除指定序号的待修改项 |
| `/pending-clear` | 清空全部待修改清单 |

**数据模型：**

- `tool_name`: 被拦截的工具名
- `params`: 工具调用的原始参数
- `description`: 人类可读的操作描述
- `timestamp`: 记录时间戳

## 五、批量执行流程

1. 用户发送 `/execute`
2. 系统解除只读模式
3. 将待修改清单按顺序注入 system message
4. AI 依次执行每个操作
5. 执行完成后清单自动清空

## 六、AI 行为引导

- `ReadonlyModeInjectionProvider` 动态注入提示词
- 明确告诉 AI：**直接调用工具**，系统会自动拦截并记录
- 禁止 AI 反复重试被拦截的操作
- 禁止 AI 只在文字中描述修改计划而不调用工具

## 七、状态持久化

- `SessionState.readonly`：会话级别的只读状态持久化
- `SessionState.pending_edits`：待修改清单持久化
- `StatusUpdate.readonly_mode`：UI 状态同步


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
# Read-only mode function list

## 1. Enter/exit read-only mode

| Function | Method | Description |
|------|------|------|
| Enter when starting | `--readonly` CLI parameter | Run directly in read-only mode when starting from the command line |
| Enter at startup | `default_readonly=true` configuration | Set the default read-only in the `kimi-cli` configuration file |
| Enter while running | `/readonly` slash command | Switch the current session to read-only mode |
| Exit while running | `/execute` slash command | Release read-only mode and execute the list to be modified in batches |

## 2. Tool interception strategy

| Tools | Read-only mode behavior |
|------|-------------|
| `WriteFile` | **Intercept all** and record to the list to be modified |
| `StrReplaceFile` | **Intercept all** and record to the list to be modified |
| `AgentTool` (sub-agent) | **Intercept all**, prohibit starting sub-agents |
| `Shell` | **Intelligent interception**:<br>- Background tasks: always intercept <br>- Foreground commands: detect whether it is safe, intercept dangerous commands, and release read-only commands (`ls`, `cat`, `grep`, `git status`, etc.) |

## 3. Shell dangerous command detection

Detection dimensions:

- Redirection character `>` / `>>`
- File operation commands: `rm`, `mv`, `cp`, `mkdir`, `touch`, `chmod`, etc.
- Git dangerous operations: `git push`, `git commit`, `git merge`, `git reset`, etc.
- `sed -i` Edit in place
- Installation/build commands: `pip install`, `npm install`, `cargo build`, `make`, etc.
- **.NET file operation API**: `WriteAllText`, `File.Create`, `StreamWriter`, etc.
- **PowerShell Cmdlets**: `Set-Content`, `Out-File`, `New-Item`, `Remove-Item`, etc.
- **Python -c file writing**: `open(`, `os.remove`, `shutil`, etc.
- **Node.js -e**: always intercept
- **Other script interpreters**: `bash -c`, `php`, `ruby`, `perl`, etc.
- **Network download**: `curl -o`, `wget --output-document`, `Invoke-WebRequest`, etc.

## 4. Pending Edits

| Command | Function |
|------|------|
| `/pending` | View the current pending modification list |
| `/pending-edit <serial number>` | Inject the complete parameters of the specified item into the conversation context for easy modification |
| `/pending-remove <serial number>` | Delete the pending modification item with the specified sequence number |
| `/pending-clear` | Clear all pending changes list |

**Data Model:**

- `tool_name`: The name of the intercepted tool
- `params`: the original parameters of the tool call
- `description`: human-readable description of the operation
- `timestamp`: record timestamp

## 5. Batch execution process

1. The user sends `/execute`
2. System releases read-only mode
3. Inject the list to be modified into the system message in order
4. AI performs each operation in turn
5. The list will be automatically cleared after execution is completed.

## 6. AI behavior guidance

- `ReadonlyModeInjectionProvider` dynamically injects prompt words
- Clearly tell the AI: **Call the tool directly** and the system will automatically intercept and record it
- Disable AI from repeatedly retrying intercepted operations
- Prohibit AI from only describing modification plans in text without calling tools

## 7. State persistence

- `SessionState.readonly`: session-level read-only state persistence
- `SessionState.pending_edits`: Persistence of the list to be modified
- `StatusUpdate.readonly_mode`: UI status synchronization
