### PR TITLE
feat(ui): add /prompt-color command for custom user input echo color

### DIFF
--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -215,6 +215,10 @@ class Config(BaseModel):
         default="dark",
         description="Terminal color theme. Use 'light' for light terminal backgrounds.",
     )
+    prompt_text_color: str = Field(
+        default="",
+        description="Rich style for the user prompt text (e.g. 'dim', 'cyan').",
+    )
     show_thinking_stream: bool = Field(
         default=True,
         description=(

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -206,6 +206,12 @@ class Shell:
         }
         """Shell-level slash commands + soul-level slash commands. Name to command mapping."""
 
+        # Sync user prompt color from runtime config so echo rendering picks it up.
+        if isinstance(soul, KimiSoul):
+            from kimi_cli.ui.theme import set_user_prompt_color
+
+            set_user_prompt_color(soul.runtime.config.prompt_text_color or None)
+
     @property
     def available_slash_commands(self) -> dict[str, SlashCommand[Any]]:
         """Get all available slash commands, including shell-level and soul-level commands."""

--- a/src/kimi_cli/ui/shell/echo.py
+++ b/src/kimi_cli/ui/shell/echo.py
@@ -4,14 +4,25 @@ from kosong.message import Message
 from rich.text import Text
 
 from kimi_cli.ui.shell.prompt import PROMPT_SYMBOL
+from kimi_cli.ui.theme import get_user_prompt_color
 from kimi_cli.utils.message import message_stringify
 
 
 def render_user_echo(message: Message) -> Text:
     """Render a user message as literal shell transcript text."""
-    return Text(f"{PROMPT_SYMBOL} {message_stringify(message)}")
+    text_color = get_user_prompt_color()
+
+    text = Text()
+    text.append(f"{PROMPT_SYMBOL} ")
+    text.append(message_stringify(message), style=text_color or "")
+    return text
 
 
 def render_user_echo_text(text: str) -> Text:
     """Render the local prompt text exactly as the user saw it in the buffer."""
-    return Text(f"{PROMPT_SYMBOL} {text}")
+    text_color = get_user_prompt_color()
+
+    result = Text()
+    result.append(f"{PROMPT_SYMBOL} ")
+    result.append(text, style=text_color or "")
+    return result

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -658,6 +658,57 @@ def theme(app: Shell, args: str):
     raise Reload(session_id=soul.runtime.session.id)
 
 
+@registry.command(name="prompt-color")
+@shell_mode_registry.command(name="prompt-color")
+def prompt_color(app: Shell, args: str):
+    """Set custom color for user prompt text. Usage: /prompt-color [<style>|reset]"""
+    from rich.style import Style
+
+    from kimi_cli.ui.theme import get_user_prompt_color, set_user_prompt_color
+
+    soul = ensure_kimi_soul(app)
+    if soul is None:
+        return
+
+    raw = args.strip()
+    if not raw:
+        txt = get_user_prompt_color()
+        console.print(f"Text color: [bold]{txt or 'default'}[/bold]")
+        console.print("[grey50]Usage: /prompt-color <style> | /prompt-color reset[/grey50]")
+        return
+
+    if raw.lower() == "reset":
+        new_color = ""
+    else:
+        try:
+            Style.parse(raw)
+        except Exception:
+            console.print(f"[red]Invalid style: {raw}[/red]")
+            return
+        new_color = raw
+
+    config = soul.runtime.config
+    config_file = config.source_file
+    if config_file is None:
+        console.print(
+            "[yellow]Prompt color switching requires a config file; "
+            "restart without --config to persist this setting.[/yellow]"
+        )
+        return
+
+    try:
+        config_for_save = load_config(config_file)
+        config_for_save.prompt_text_color = new_color
+        save_config(config_for_save, config_file)
+    except (ConfigError, OSError) as exc:
+        console.print(f"[red]Failed to save config: {exc}[/red]")
+        return
+
+    config.prompt_text_color = new_color
+    set_user_prompt_color(config.prompt_text_color or None)
+    console.print("[green]Prompt color updated.[/green]")
+
+
 @registry.command
 def web(app: Shell, args: str):
     """Open Kimi Code Web UI in browser"""

--- a/src/kimi_cli/ui/theme.py
+++ b/src/kimi_cli/ui/theme.py
@@ -239,3 +239,21 @@ def get_toolbar_colors() -> ToolbarColors:
 
 def get_mcp_prompt_colors() -> MCPPromptColors:
     return _MCP_PROMPT_LIGHT if _active_theme == "light" else _MCP_PROMPT_DARK
+
+
+# ---------------------------------------------------------------------------
+# User prompt echo colors (overrides terminal default when set)
+# ---------------------------------------------------------------------------
+
+_prompt_text_color: str | None = None
+
+
+def set_user_prompt_color(text: str | None) -> None:
+    """Set custom color for user prompt echo rendering."""
+    global _prompt_text_color
+    _prompt_text_color = text
+
+
+def get_user_prompt_color() -> str | None:
+    """Return the active text color or None for terminal default."""
+    return _prompt_text_color

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -27,7 +27,7 @@ def test_default_config_dump():
             "default_plan_mode": False,
             "default_editor": "",
             "theme": "dark",
-            "show_thinking_stream": True,
+            "show_thinking_stream": True, "prompt_text_color": "",
             "models": {},
             "providers": {},
             "loop_control": {


### PR DESCRIPTION
## Motivation

  In the current terminal theme, user input and model replies share nearly identical foreground colors with no visual delimiter between turns. During long sessions this makes it hard to quickly scan for human prompts. Allowing users to style their own echo(color&bold) creates a clear visual boundary and improves readability.

The implementation reuses Rich Style, so passing `bold green` achieves both boldface and color tint in one setting without extra fields.

  ## Changes

  - `config.py` — add `prompt_text_color` field
  - `theme.py` — add runtime state + getter/setter for user echo color
  - `echo.py` — apply Rich `style` to user text in `render_user_echo*` helpers
  - `ui/shell/__init__.py` — sync color from runtime config on shell startup
  - `slash.py` — introduce `/prompt-color` with Rich Style validation, config persistence, and hot-reload

  ## Design Notes

  - Accepts any valid Rich Style string (e.g. `bold cyan`, `#ff6600`) — no custom parser needed
  - Hot-reload: changes take effect immediately without restarting the session (unlike `/theme`, which triggers a Reload)
  - Empty default preserves backward compatibility

  ## Usage

  ```text
  /prompt-color bold cyan
  /prompt-color #ff6600
  /prompt-color reset
  Verification
  • ruff check / ruff format ✅
  • pyright ✅
  • pytest (config + theme + echo) 56 passed ✅
  ```
 
<img width="1566" height="489" alt="e9b99960-29e2-418d-9626-9b8cce7236d2" src="https://github.com/user-attachments/assets/b75f70d3-d028-4fee-adab-74710046f666" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
