### PR TITLE
fix(mcp): add schema exposure guardrails for large MCP tool lists

### DIFF
--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -177,6 +177,8 @@ class MCPClientConfig(BaseModel):
     """Maximum characters exposed for a single MCP tool description."""
     max_total_tool_schema_bytes: int = Field(default=200_000, ge=1)
     """Per-server byte budget for MCP tool schemas exposed to the model."""
+    max_total_mcp_tool_schema_bytes: int = Field(default=300_000, ge=1)
+    """Approximate global byte budget for all visible MCP tool schemas per request."""
     max_visible_tools_per_server: int = Field(default=64, ge=1)
     """Maximum number of MCP tools exposed to the model per server."""
 

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -173,6 +173,12 @@ class MCPClientConfig(BaseModel):
 
     tool_call_timeout_ms: int = 60000
     """Timeout for tool calls in milliseconds."""
+    max_tool_description_chars: int = Field(default=1000, ge=0)
+    """Maximum characters exposed for a single MCP tool description."""
+    max_total_tool_schema_bytes: int = Field(default=200_000, ge=1)
+    """Per-server byte budget for MCP tool schemas exposed to the model."""
+    max_visible_tools_per_server: int = Field(default=64, ge=1)
+    """Maximum number of MCP tools exposed to the model per server."""
 
 
 class MCPConfig(BaseModel):

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import importlib
 import inspect
 import json
@@ -83,6 +84,8 @@ def get_current_tool_call_or_none() -> ToolCall | None:
 
 
 type ToolType = CallableTool | CallableTool2[Any]
+
+_MAX_MCP_TOOL_NAME_LENGTH = 64
 
 
 if TYPE_CHECKING:
@@ -788,7 +791,18 @@ def _canonical_mcp_tool_name(server_name: str, tool_name: str) -> str:
     """Build a namespaced MCP tool name that avoids cross-server collisions."""
     server_fragment = _normalize_tool_name_fragment(server_name)
     tool_fragment = _normalize_tool_name_fragment(tool_name)
-    return f"mcp__{server_fragment}__{tool_fragment}"
+    digest = hashlib.sha1(f"{server_name}\0{tool_name}".encode()).hexdigest()[:8]
+    prefix = "mcp__"
+    separator = "__"
+    suffix = f"{separator}{digest}"
+    available = _MAX_MCP_TOOL_NAME_LENGTH - len(prefix) - len(separator) - len(suffix)
+    if available <= 1:
+        return f"{prefix}{digest}"
+    server_budget = max(1, available // 3)
+    tool_budget = max(1, available - server_budget)
+    server_fragment = server_fragment[:server_budget].rstrip("_-") or "s"
+    tool_fragment = tool_fragment[:tool_budget].rstrip("_-") or "tool"
+    return f"{prefix}{server_fragment}{separator}{tool_fragment}{suffix}"
 
 
 def _normalize_tool_name_fragment(value: str) -> str:
@@ -802,7 +816,8 @@ def _dedupe_tool_name(name: str, used_names: set[str]) -> str:
         return name
     suffix = 2
     while True:
-        candidate = f"{name}__{suffix}"
+        suffix_text = f"__{suffix}"
+        candidate = f"{name[: _MAX_MCP_TOOL_NAME_LENGTH - len(suffix_text)]}{suffix_text}"
         if candidate not in used_names:
             return candidate
         suffix += 1

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -5,6 +5,7 @@ import contextlib
 import importlib
 import inspect
 import json
+import re
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -449,13 +450,20 @@ class KimiToolset:
             try:
                 async with server_info.client as client:
                     mcp_client_config = runtime.config.mcp.client
+                    used_names = {tool.name for tool in server_info.tools}
                     for tool in await client.list_tools():
+                        exposed_name = _dedupe_tool_name(
+                            _canonical_mcp_tool_name(server_name, tool.name),
+                            used_names,
+                        )
+                        used_names.add(exposed_name)
                         server_info.tools.append(
                             MCPTool(
                                 server_name,
                                 tool,
                                 client,
                                 runtime=runtime,
+                                exposed_name=exposed_name,
                                 max_description_chars=mcp_client_config.max_tool_description_chars,
                             )
                         )
@@ -535,6 +543,27 @@ class KimiToolset:
             ]
             results = await asyncio.gather(*tasks) if tasks else []
             failed_servers = {name: error for name, error in results if error is not None}
+            if not failed_servers:
+                hidden_globally = _apply_global_mcp_schema_budget(
+                    runtime, self._mcp_servers, self, self._hidden_tools
+                )
+                if hidden_globally > 0:
+                    visible_globally = sum(
+                        1
+                        for info in self._mcp_servers.values()
+                        for tool in info.tools
+                        if tool.name not in self._hidden_tools
+                    )
+                    logger.warning(
+                        "Hidden {hidden} MCP tools due to global schema budget across servers; "
+                        "{visible} remain visible.",
+                        hidden=hidden_globally,
+                        visible=visible_globally,
+                    )
+                    _toast_mcp(
+                        f"MCP global tool budget applied: {visible_globally} visible, "
+                        f"{hidden_globally} hidden across servers."
+                    )
 
             for mcp_config in mcp_configs:
                 # Skip empty MCP configs (no servers defined)
@@ -610,6 +639,7 @@ class MCPTool[T: ClientTransport](CallableTool):
         client: fastmcp.Client[T],
         *,
         runtime: Runtime,
+        exposed_name: str,
         max_description_chars: int,
         **kwargs: Any,
     ):
@@ -619,19 +649,21 @@ class MCPTool[T: ClientTransport](CallableTool):
                 mcp_description[:max_description_chars].rstrip() + " [description truncated]"
             )
         super().__init__(
-            name=mcp_tool.name,
+            name=exposed_name,
             description=(
-                f"This is an MCP (Model Context Protocol) tool from MCP server `{server_name}`.\n\n"
+                "This is an MCP (Model Context Protocol) tool from "
+                f"MCP server `{server_name}`. Original tool name: `{mcp_tool.name}`.\n\n"
                 f"{mcp_description}"
             ),
             parameters=mcp_tool.inputSchema,
             **kwargs,
         )
+        self._server_name = server_name
         self._mcp_tool = mcp_tool
         self._client = client
         self._runtime = runtime
         self._timeout = timedelta(milliseconds=runtime.config.mcp.client.tool_call_timeout_ms)
-        self._action_name = f"mcp:{mcp_tool.name}"
+        self._action_name = f"mcp:{server_name}:{mcp_tool.name}"
 
     async def __call__(self, *args: Any, **kwargs: Any) -> ToolReturnValue:
         description = f"Call MCP tool `{self._mcp_tool.name}`."
@@ -739,7 +771,7 @@ def _media_part_size(part: ContentPart) -> int | None:
 
 
 def _tool_schema_bytes(tool: Tool) -> int:
-    """Estimate the JSON-serialized byte size of a tool definition."""
+    """Estimate tool-definition bytes before provider normalization."""
     payload = {
         "type": "function",
         "function": {
@@ -750,6 +782,52 @@ def _tool_schema_bytes(tool: Tool) -> int:
     }
     encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
     return len(encoded)
+
+
+def _canonical_mcp_tool_name(server_name: str, tool_name: str) -> str:
+    """Build a namespaced MCP tool name that avoids cross-server collisions."""
+    server_fragment = _normalize_tool_name_fragment(server_name)
+    tool_fragment = _normalize_tool_name_fragment(tool_name)
+    return f"mcp__{server_fragment}__{tool_fragment}"
+
+
+def _normalize_tool_name_fragment(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_-]", "_", value)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized or "tool"
+
+
+def _dedupe_tool_name(name: str, used_names: set[str]) -> str:
+    if name not in used_names:
+        return name
+    suffix = 2
+    while True:
+        candidate = f"{name}__{suffix}"
+        if candidate not in used_names:
+            return candidate
+        suffix += 1
+
+
+def _apply_global_mcp_schema_budget(
+    runtime: Runtime,
+    mcp_servers: dict[str, MCPServerInfo],
+    toolset: KimiToolset,
+    hidden_tools: set[str],
+) -> int:
+    max_total = runtime.config.mcp.client.max_total_mcp_tool_schema_bytes
+    total_schema_bytes = 0
+    hidden_count = 0
+    for server_info in mcp_servers.values():
+        for tool in server_info.tools:
+            if tool.name in hidden_tools:
+                continue
+            schema_bytes = _tool_schema_bytes(tool.base)
+            if total_schema_bytes + schema_bytes > max_total:
+                toolset.hide(tool.name)
+                hidden_count += 1
+                continue
+            total_schema_bytes += schema_bytes
+    return hidden_count
 
 
 def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -647,17 +647,16 @@ class MCPTool[T: ClientTransport](CallableTool):
         max_description_chars: int,
         **kwargs: Any,
     ):
-        mcp_description = _truncate_mcp_description(
-            mcp_tool.description or "No description provided.",
-            max_description_chars,
+        raw_description = mcp_tool.description or "No description provided."
+        full_description = (
+            "This is an MCP (Model Context Protocol) tool from "
+            f"MCP server `{server_name}`. Original tool name: `{mcp_tool.name}`.\n\n"
+            f"{raw_description}"
         )
+        mcp_description = _truncate_mcp_description(full_description, max_description_chars)
         super().__init__(
             name=exposed_name,
-            description=(
-                "This is an MCP (Model Context Protocol) tool from "
-                f"MCP server `{server_name}`. Original tool name: `{mcp_tool.name}`.\n\n"
-                f"{mcp_description}"
-            ),
+            description=mcp_description,
             parameters=mcp_tool.inputSchema,
             **kwargs,
         )

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -448,13 +448,57 @@ class KimiToolset:
             server_info.status = "connecting"
             try:
                 async with server_info.client as client:
+                    mcp_client_config = runtime.config.mcp.client
                     for tool in await client.list_tools():
                         server_info.tools.append(
-                            MCPTool(server_name, tool, client, runtime=runtime)
+                            MCPTool(
+                                server_name,
+                                tool,
+                                client,
+                                runtime=runtime,
+                                max_description_chars=mcp_client_config.max_tool_description_chars,
+                            )
                         )
 
+                total_schema_bytes = 0
+                visible_tools = 0
+                hidden_by_count = 0
+                hidden_by_budget = 0
                 for tool in server_info.tools:
                     self.add(tool)
+                    schema_bytes = _tool_schema_bytes(tool.base)
+                    if visible_tools >= mcp_client_config.max_visible_tools_per_server:
+                        self.hide(tool.name)
+                        hidden_by_count += 1
+                        continue
+                    if (
+                        total_schema_bytes + schema_bytes
+                        > mcp_client_config.max_total_tool_schema_bytes
+                    ):
+                        self.hide(tool.name)
+                        hidden_by_budget += 1
+                        continue
+                    visible_tools += 1
+                    total_schema_bytes += schema_bytes
+
+                hidden_tools = hidden_by_count + hidden_by_budget
+                if hidden_tools > 0:
+                    logger.warning(
+                        "MCP server '{server_name}' exposes {total} tools; "
+                        "{visible} visible, {hidden} hidden "
+                        "(over_count={over_count}, over_budget={over_budget}).",
+                        server_name=server_name,
+                        total=len(server_info.tools),
+                        visible=visible_tools,
+                        hidden=hidden_tools,
+                        over_count=hidden_by_count,
+                        over_budget=hidden_by_budget,
+                    )
+                    _toast_mcp(
+                        "MCP server "
+                        f"`{server_name}` exposes {len(server_info.tools)} tools; "
+                        f"{visible_tools} visible, {hidden_tools} hidden due to tool budget."
+                    )
 
                 server_info.status = "connected"
                 logger.info("Connected MCP server: {server_name}", server_name=server_name)
@@ -566,13 +610,19 @@ class MCPTool[T: ClientTransport](CallableTool):
         client: fastmcp.Client[T],
         *,
         runtime: Runtime,
+        max_description_chars: int,
         **kwargs: Any,
     ):
+        mcp_description = mcp_tool.description or "No description provided."
+        if len(mcp_description) > max_description_chars:
+            mcp_description = (
+                mcp_description[:max_description_chars].rstrip() + " [description truncated]"
+            )
         super().__init__(
             name=mcp_tool.name,
             description=(
                 f"This is an MCP (Model Context Protocol) tool from MCP server `{server_name}`.\n\n"
-                f"{mcp_tool.description or 'No description provided.'}"
+                f"{mcp_description}"
             ),
             parameters=mcp_tool.inputSchema,
             **kwargs,
@@ -686,6 +736,20 @@ def _media_part_size(part: ContentPart) -> int | None:
     if isinstance(part, VideoURLPart):
         return len(part.video_url.url)
     return None
+
+
+def _tool_schema_bytes(tool: Tool) -> int:
+    """Estimate the JSON-serialized byte size of a tool definition."""
+    payload = {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters,
+        },
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return len(encoded)
 
 
 def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -86,6 +86,7 @@ def get_current_tool_call_or_none() -> ToolCall | None:
 type ToolType = CallableTool | CallableTool2[Any]
 
 _MAX_MCP_TOOL_NAME_LENGTH = 64
+_TRUNCATION_MARKER = " [description truncated]"
 
 
 if TYPE_CHECKING:
@@ -646,11 +647,10 @@ class MCPTool[T: ClientTransport](CallableTool):
         max_description_chars: int,
         **kwargs: Any,
     ):
-        mcp_description = mcp_tool.description or "No description provided."
-        if len(mcp_description) > max_description_chars:
-            mcp_description = (
-                mcp_description[:max_description_chars].rstrip() + " [description truncated]"
-            )
+        mcp_description = _truncate_mcp_description(
+            mcp_tool.description or "No description provided.",
+            max_description_chars,
+        )
         super().__init__(
             name=exposed_name,
             description=(
@@ -785,6 +785,17 @@ def _tool_schema_bytes(tool: Tool) -> int:
     }
     encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
     return len(encoded)
+
+
+def _truncate_mcp_description(description: str, max_chars: int) -> str:
+    """Truncate MCP description to a strict cap, including marker when possible."""
+    if len(description) <= max_chars:
+        return description
+    if max_chars <= 0:
+        return ""
+    if max_chars <= len(_TRUNCATION_MARKER):
+        return description[:max_chars]
+    return description[: max_chars - len(_TRUNCATION_MARKER)].rstrip() + _TRUNCATION_MARKER
 
 
 def _canonical_mcp_tool_name(server_name: str, tool_name: str) -> str:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -59,6 +59,7 @@ def test_default_config_dump():
                     "tool_call_timeout_ms": 60000,
                     "max_tool_description_chars": 1000,
                     "max_total_tool_schema_bytes": 200000,
+                    "max_total_mcp_tool_schema_bytes": 300000,
                     "max_visible_tools_per_server": 64,
                 }
             },

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -54,7 +54,14 @@ def test_default_config_dump():
                 "claim_stale_after_ms": 15000,
             },
             "services": {"moonshot_search": None, "moonshot_fetch": None},
-            "mcp": {"client": {"tool_call_timeout_ms": 60000}},
+            "mcp": {
+                "client": {
+                    "tool_call_timeout_ms": 60000,
+                    "max_tool_description_chars": 1000,
+                    "max_total_tool_schema_bytes": 200000,
+                    "max_visible_tools_per_server": 64,
+                }
+            },
             "hooks": [],
             "merge_all_available_skills": True,
             "extra_skill_dirs": [],

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from kosong.tooling import CallableTool2, ToolOk, ToolReturnValue
 from kosong.tooling.error import ToolNotFoundError as KosongToolNotFoundError
+from mcp.types import Tool as MCPRawTool
 from pydantic import BaseModel
 
 from kimi_cli.soul.toolset import KimiToolset, MCPTool, _tool_schema_bytes
@@ -184,15 +184,8 @@ def test_hide_unhide_cycle():
     assert "ToolA" in _tool_names(ts)
 
 
-@dataclass
-class _FakeMCPRawTool:
-    name: str
-    description: str
-    inputSchema: dict[str, Any]
-
-
 class _FakeMCPClient:
-    def __init__(self, tools: list[_FakeMCPRawTool]):
+    def __init__(self, tools: list[MCPRawTool]):
         self._tools = tools
 
     async def __aenter__(self):
@@ -216,7 +209,7 @@ def _fake_mcp_config(server_name: str):
 
 async def test_mcp_tool_description_is_truncated_without_schema_changes(runtime):
     long_desc = "x" * 2000
-    raw = _FakeMCPRawTool(
+    raw = MCPRawTool(
         name="LongTool",
         description=long_desc,
         inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
@@ -224,8 +217,9 @@ async def test_mcp_tool_description_is_truncated_without_schema_changes(runtime)
     tool = MCPTool(
         "server-a",
         raw,
-        _FakeMCPClient([raw]),
+        cast(Any, _FakeMCPClient([raw])),
         runtime=runtime,
+        exposed_name="mcp__server_a__LongTool",
         max_description_chars=100,
     )
 
@@ -235,12 +229,12 @@ async def test_mcp_tool_description_is_truncated_without_schema_changes(runtime)
 
 async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, monkeypatch):
     server_name = "server-a"
-    small = _FakeMCPRawTool(
+    small = MCPRawTool(
         name="SmallTool",
         description="small",
         inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
     )
-    large = _FakeMCPRawTool(
+    large = MCPRawTool(
         name="LargeTool",
         description="large",
         inputSchema={
@@ -259,8 +253,9 @@ async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, m
     preview_small = MCPTool(
         server_name,
         small,
-        _FakeMCPClient([small]),
+        cast(Any, _FakeMCPClient([small])),
         runtime=runtime,
+        exposed_name="mcp__server_a__SmallTool",
         max_description_chars=runtime.config.mcp.client.max_tool_description_chars,
     )
     small_bytes = _tool_schema_bytes(preview_small.base)
@@ -278,14 +273,17 @@ async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, m
     ts = KimiToolset()
     await ts.load_mcp_tools([_fake_mcp_config(server_name)], runtime, in_background=False)
 
-    assert [t.name for t in ts.mcp_servers[server_name].tools] == ["SmallTool", "LargeTool"]
-    assert {t.name for t in ts.tools} == {"SmallTool"}
+    assert [t.name for t in ts.mcp_servers[server_name].tools] == [
+        "mcp__server-a__SmallTool",
+        "mcp__server-a__LargeTool",
+    ]
+    assert {t.name for t in ts.tools} == {"mcp__server-a__SmallTool"}
 
 
 async def test_load_mcp_tools_shows_budget_toast_for_hidden_tools(runtime, monkeypatch):
     server_name = "server-b"
     tools = [
-        _FakeMCPRawTool(
+        MCPRawTool(
             name=f"Tool{i}",
             description="small",
             inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
@@ -312,5 +310,86 @@ async def test_load_mcp_tools_shows_budget_toast_for_hidden_tools(runtime, monke
     await ts.load_mcp_tools([_fake_mcp_config(server_name)], runtime, in_background=True)
     await ts.wait_for_mcp_tools()
 
-    assert {t.name for t in ts.tools} == {"Tool0"}
+    assert {t.name for t in ts.tools} == {"mcp__server-b__Tool0"}
     assert any("hidden due to tool budget" in message for message in toasts)
+
+
+async def test_load_mcp_tools_applies_global_schema_budget(runtime, monkeypatch):
+    runtime.config.mcp.client.max_visible_tools_per_server = 10
+    runtime.config.mcp.client.max_total_tool_schema_bytes = 1_000_000
+    runtime.config.mcp.client.max_total_mcp_tool_schema_bytes = 500
+
+    server_a = "server-a"
+    server_b = "server-b"
+    tools_a = [
+        MCPRawTool(
+            name=f"ToolA{i}",
+            description="x" * 80,
+            inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
+        )
+        for i in range(2)
+    ]
+    tools_b = [
+        MCPRawTool(
+            name=f"ToolB{i}",
+            description="x" * 80,
+            inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
+        )
+        for i in range(2)
+    ]
+
+    def fake_client_factory(mcp_config):
+        name = next(iter(mcp_config.mcpServers.keys()))
+        if name == server_a:
+            return _FakeMCPClient(tools_a)
+        if name == server_b:
+            return _FakeMCPClient(tools_b)
+        raise AssertionError(f"unexpected server name: {name}")
+
+    monkeypatch.setattr("fastmcp.Client", fake_client_factory)
+
+    ts = KimiToolset()
+    await ts.load_mcp_tools(
+        [_fake_mcp_config(server_a), _fake_mcp_config(server_b)],
+        runtime,
+        in_background=False,
+    )
+    visible = [t.name for t in ts.tools]
+    assert len(visible) < 4
+    assert len(visible) >= 1
+
+
+async def test_load_mcp_tools_namespaced_tool_names_avoid_name_collisions(runtime, monkeypatch):
+    tool_name = "search"
+    server_a = "s1"
+    server_b = "s2"
+    runtime.config.mcp.client.max_visible_tools_per_server = 10
+    runtime.config.mcp.client.max_total_tool_schema_bytes = 1_000_000
+    runtime.config.mcp.client.max_total_mcp_tool_schema_bytes = 1_000_000
+
+    def make_tool():
+        return MCPRawTool(
+            name=tool_name,
+            description="desc",
+            inputSchema={"type": "object", "properties": {"query": {"type": "string"}}},
+        )
+
+    def fake_client_factory(mcp_config):
+        name = next(iter(mcp_config.mcpServers.keys()))
+        if name == server_a:
+            return _FakeMCPClient([make_tool()])
+        if name == server_b:
+            return _FakeMCPClient([make_tool()])
+        raise AssertionError(f"unexpected server name: {name}")
+
+    monkeypatch.setattr("fastmcp.Client", fake_client_factory)
+
+    ts = KimiToolset()
+    await ts.load_mcp_tools(
+        [_fake_mcp_config(server_a), _fake_mcp_config(server_b)],
+        runtime,
+        in_background=False,
+    )
+
+    visible = {t.name for t in ts.tools}
+    assert visible == {"mcp__s1__search", "mcp__s2__search"}

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -233,6 +233,24 @@ async def test_mcp_tool_description_is_truncated_without_schema_changes(runtime)
     assert tool.base.parameters == raw.inputSchema
 
 
+async def test_mcp_tool_full_description_respects_cap(runtime):
+    raw = MCPRawTool(
+        name="VeryLongToolName" * 20,
+        description="x" * 2000,
+        inputSchema={"type": "object", "properties": {}},
+    )
+    tool = MCPTool(
+        "VeryLongServerName" * 20,
+        raw,
+        cast(Any, _FakeMCPClient([raw])),
+        runtime=runtime,
+        exposed_name=_canonical_mcp_tool_name("server", raw.name),
+        max_description_chars=100,
+    )
+
+    assert len(tool.base.description) <= 100
+
+
 async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, monkeypatch):
     server_name = "server-a"
     small = MCPRawTool(

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -17,6 +17,7 @@ from kimi_cli.soul.toolset import (
     MCPTool,
     _canonical_mcp_tool_name,
     _tool_schema_bytes,
+    _truncate_mcp_description,
 )
 from kimi_cli.wire.types import ToolCall, ToolResult
 
@@ -420,3 +421,14 @@ def test_canonical_mcp_tool_name_avoids_normalization_collisions():
     second = _canonical_mcp_tool_name("server_one", tool_name)
 
     assert first != second
+
+
+def test_truncated_mcp_description_respects_cap_with_marker():
+    desc = _truncate_mcp_description("x" * 2000, 100)
+    assert len(desc) <= 100
+    assert desc.endswith(" [description truncated]")
+
+
+def test_truncated_mcp_description_respects_tiny_cap():
+    assert len(_truncate_mcp_description("x" * 2000, 0)) == 0
+    assert len(_truncate_mcp_description("x" * 2000, 8)) <= 8

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+from dataclasses import dataclass
+from typing import Any
 
 from kosong.tooling import CallableTool2, ToolOk, ToolReturnValue
 from kosong.tooling.error import ToolNotFoundError as KosongToolNotFoundError
 from pydantic import BaseModel
 
-from kimi_cli.soul.toolset import KimiToolset
+from kimi_cli.soul.toolset import KimiToolset, MCPTool, _tool_schema_bytes
 from kimi_cli.wire.types import ToolCall, ToolResult
 
 
@@ -181,8 +183,134 @@ def test_hide_unhide_cycle():
     ts.unhide("ToolA")
     assert "ToolA" in _tool_names(ts)
 
-    ts.hide("ToolA")
-    assert "ToolA" not in _tool_names(ts)
 
-    ts.unhide("ToolA")
-    assert "ToolA" in _tool_names(ts)
+@dataclass
+class _FakeMCPRawTool:
+    name: str
+    description: str
+    inputSchema: dict[str, Any]
+
+
+class _FakeMCPClient:
+    def __init__(self, tools: list[_FakeMCPRawTool]):
+        self._tools = tools
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def list_tools(self):
+        return list(self._tools)
+
+    async def close(self):
+        return None
+
+
+def _fake_mcp_config(server_name: str):
+    from fastmcp.mcp_config import MCPConfig
+
+    return MCPConfig.model_validate({"mcpServers": {server_name: {"command": "echo", "args": []}}})
+
+
+async def test_mcp_tool_description_is_truncated_without_schema_changes(runtime):
+    long_desc = "x" * 2000
+    raw = _FakeMCPRawTool(
+        name="LongTool",
+        description=long_desc,
+        inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
+    )
+    tool = MCPTool(
+        "server-a",
+        raw,
+        _FakeMCPClient([raw]),
+        runtime=runtime,
+        max_description_chars=100,
+    )
+
+    assert "[description truncated]" in tool.base.description
+    assert tool.base.parameters == raw.inputSchema
+
+
+async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, monkeypatch):
+    server_name = "server-a"
+    small = _FakeMCPRawTool(
+        name="SmallTool",
+        description="small",
+        inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
+    )
+    large = _FakeMCPRawTool(
+        name="LargeTool",
+        description="large",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 0,
+                    "maxItems": 500,
+                }
+            },
+        },
+    )
+
+    preview_small = MCPTool(
+        server_name,
+        small,
+        _FakeMCPClient([small]),
+        runtime=runtime,
+        max_description_chars=runtime.config.mcp.client.max_tool_description_chars,
+    )
+    small_bytes = _tool_schema_bytes(preview_small.base)
+
+    runtime.config.mcp.client.max_visible_tools_per_server = 10
+    runtime.config.mcp.client.max_total_tool_schema_bytes = small_bytes + 1
+
+    def fake_client_factory(mcp_config):
+        name = next(iter(mcp_config.mcpServers.keys()))
+        assert name == server_name
+        return _FakeMCPClient([small, large])
+
+    monkeypatch.setattr("fastmcp.Client", fake_client_factory)
+
+    ts = KimiToolset()
+    await ts.load_mcp_tools([_fake_mcp_config(server_name)], runtime, in_background=False)
+
+    assert [t.name for t in ts.mcp_servers[server_name].tools] == ["SmallTool", "LargeTool"]
+    assert {t.name for t in ts.tools} == {"SmallTool"}
+
+
+async def test_load_mcp_tools_shows_budget_toast_for_hidden_tools(runtime, monkeypatch):
+    server_name = "server-b"
+    tools = [
+        _FakeMCPRawTool(
+            name=f"Tool{i}",
+            description="small",
+            inputSchema={"type": "object", "properties": {"value": {"type": "string"}}},
+        )
+        for i in range(3)
+    ]
+    runtime.config.mcp.client.max_visible_tools_per_server = 1
+    runtime.config.mcp.client.max_total_tool_schema_bytes = 1_000_000
+
+    def fake_client_factory(mcp_config):
+        name = next(iter(mcp_config.mcpServers.keys()))
+        assert name == server_name
+        return _FakeMCPClient(tools)
+
+    toasts: list[str] = []
+
+    def fake_toast(message: str, *args, **kwargs):
+        toasts.append(message)
+
+    monkeypatch.setattr("fastmcp.Client", fake_client_factory)
+    monkeypatch.setattr("kimi_cli.ui.shell.prompt.toast", fake_toast)
+
+    ts = KimiToolset()
+    await ts.load_mcp_tools([_fake_mcp_config(server_name)], runtime, in_background=True)
+    await ts.wait_for_mcp_tools()
+
+    assert {t.name for t in ts.tools} == {"Tool0"}
+    assert any("hidden due to tool budget" in message for message in toasts)

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -12,7 +12,12 @@ from kosong.tooling.error import ToolNotFoundError as KosongToolNotFoundError
 from mcp.types import Tool as MCPRawTool
 from pydantic import BaseModel
 
-from kimi_cli.soul.toolset import KimiToolset, MCPTool, _tool_schema_bytes
+from kimi_cli.soul.toolset import (
+    KimiToolset,
+    MCPTool,
+    _canonical_mcp_tool_name,
+    _tool_schema_bytes,
+)
 from kimi_cli.wire.types import ToolCall, ToolResult
 
 
@@ -219,7 +224,7 @@ async def test_mcp_tool_description_is_truncated_without_schema_changes(runtime)
         raw,
         cast(Any, _FakeMCPClient([raw])),
         runtime=runtime,
-        exposed_name="mcp__server_a__LongTool",
+        exposed_name=_canonical_mcp_tool_name("server-a", raw.name),
         max_description_chars=100,
     )
 
@@ -255,7 +260,7 @@ async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, m
         small,
         cast(Any, _FakeMCPClient([small])),
         runtime=runtime,
-        exposed_name="mcp__server_a__SmallTool",
+        exposed_name=_canonical_mcp_tool_name(server_name, small.name),
         max_description_chars=runtime.config.mcp.client.max_tool_description_chars,
     )
     small_bytes = _tool_schema_bytes(preview_small.base)
@@ -274,10 +279,10 @@ async def test_load_mcp_tools_hides_tools_when_schema_budget_exceeded(runtime, m
     await ts.load_mcp_tools([_fake_mcp_config(server_name)], runtime, in_background=False)
 
     assert [t.name for t in ts.mcp_servers[server_name].tools] == [
-        "mcp__server-a__SmallTool",
-        "mcp__server-a__LargeTool",
+        _canonical_mcp_tool_name(server_name, "SmallTool"),
+        _canonical_mcp_tool_name(server_name, "LargeTool"),
     ]
-    assert {t.name for t in ts.tools} == {"mcp__server-a__SmallTool"}
+    assert {t.name for t in ts.tools} == {_canonical_mcp_tool_name(server_name, "SmallTool")}
 
 
 async def test_load_mcp_tools_shows_budget_toast_for_hidden_tools(runtime, monkeypatch):
@@ -310,7 +315,7 @@ async def test_load_mcp_tools_shows_budget_toast_for_hidden_tools(runtime, monke
     await ts.load_mcp_tools([_fake_mcp_config(server_name)], runtime, in_background=True)
     await ts.wait_for_mcp_tools()
 
-    assert {t.name for t in ts.tools} == {"mcp__server-b__Tool0"}
+    assert {t.name for t in ts.tools} == {_canonical_mcp_tool_name(server_name, "Tool0")}
     assert any("hidden due to tool budget" in message for message in toasts)
 
 
@@ -392,4 +397,26 @@ async def test_load_mcp_tools_namespaced_tool_names_avoid_name_collisions(runtim
     )
 
     visible = {t.name for t in ts.tools}
-    assert visible == {"mcp__s1__search", "mcp__s2__search"}
+    assert visible == {
+        _canonical_mcp_tool_name(server_a, tool_name),
+        _canonical_mcp_tool_name(server_b, tool_name),
+    }
+
+
+def test_canonical_mcp_tool_name_is_bounded_and_stable():
+    server_name = "very.long/server-name with spaces and punctuation"
+    tool_name = "extremely-long-tool-name with spaces and punctuation and a trailing suffix"
+
+    canonical = _canonical_mcp_tool_name(server_name, tool_name)
+
+    assert canonical.startswith("mcp__")
+    assert len(canonical) <= 64
+    assert canonical == _canonical_mcp_tool_name(server_name, tool_name)
+
+
+def test_canonical_mcp_tool_name_avoids_normalization_collisions():
+    tool_name = "search"
+    first = _canonical_mcp_tool_name("server.one", tool_name)
+    second = _canonical_mcp_tool_name("server_one", tool_name)
+
+    assert first != second


### PR DESCRIPTION
## Related Issue

Resolve #2096

## Description

This PR adds guardrails for MCP tools exposed to the model, preventing large MCP tool lists from making the initial chat request fail when an MCP server exposes many tools or large input schemas.

The fix keeps all MCP tools registered internally, but limits which MCP tool schemas are exposed to the LLM request.

Changes include:

- Add MCP client configuration for tool exposure limits:
  - `max_tool_description_chars`
  - `max_total_tool_schema_bytes`
  - `max_total_mcp_tool_schema_bytes`
  - `max_visible_tools_per_server`
- Truncate long MCP tool descriptions while preserving the original `inputSchema`.
- Apply per-server MCP schema budget and per-server visible tool count limits.
- Apply a global MCP schema budget across all visible MCP tools before sending tools to the model.
- Namespace exposed MCP tool names by server to avoid cross-server name collisions.
- Add bounded canonical MCP tool names with a short hash suffix to avoid overlong names and normalization collisions.
- Preserve the original MCP tool name for the actual `client.call_tool(...)` call and user-facing description.
- Show warnings/toasts when tools are hidden due to MCP tool budget limits.
- Add tests covering:
  - description truncation without schema mutation
  - per-server schema budget
  - global MCP schema budget
  - MCP tool namespace isolation
  - canonical name stability and length bound
  - normalization collision avoidance
  - hidden MCP tools remaining registered but not exposed to the model

This is intended as a short-term mitigation for large MCP tool lists. A future lazy exposure / activation design could further improve MCP usability for very large servers, but is intentionally kept out of this focused bugfix.

Validation run locally:

- `uv run ruff check src/kimi_cli/config.py src/kimi_cli/soul/toolset.py tests/core/test_config.py tests/core/test_toolset.py`
- `uv run pytest tests/core/test_config.py tests/core/test_toolset.py -q`
- `uv run pyright src/kimi_cli/config.py src/kimi_cli/soul/toolset.py tests/core/test_config.py tests/core/test_toolset.py`

Results:

- Ruff passed
- Pyright passed with 0 errors
- Pytest passed: 37 passed, with one third-party dependency deprecation warning

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
