### PR TITLE
fix(acp): wrap shell command in `bash -c` for `terminal/create`

### DIFF
--- a/src/kimi_cli/acp/tools.py
+++ b/src/kimi_cli/acp/tools.py
@@ -56,6 +56,7 @@ class Terminal(CallableTool2[ShellParams]):
         # Use the `name`, `description`, and `params` from the existing Shell tool,
         # so that when this is added to the toolset, it replaces the original Shell tool.
         super().__init__(shell_tool.name, shell_tool.description, shell_tool.params)
+        self._shell_tool = shell_tool
         self._acp_conn = acp_conn
         self._acp_session_id = acp_session_id
         self._approval = approval
@@ -88,8 +89,15 @@ class Terminal(CallableTool2[ShellParams]):
         timed_out = False
 
         try:
+            # Wrap in `bash -c` (or `pwsh -command`) so the ACP client exec()s
+            # the same way the local Shell tool does. Without this, the client
+            # follows the ACP spec — `Command::new(command).args(args)` — and
+            # tries to spawn a binary literally named `<full shell line>`,
+            # which fails for any multi-token / piped / redirected command.
+            argv = self._shell_tool.shell_argv(params.command)
             resp = await self._acp_conn.create_terminal(
-                command=params.command,
+                command=argv[0],
+                args=list(argv[1:]),
                 session_id=self._acp_session_id,
                 output_byte_limit=builder.max_chars,
             )

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -255,5 +255,8 @@ class Shell(CallableTool2[Params]):
             return (str(self._shell_path), "-command", command)
         return (str(self._shell_path), "-c", command)
 
-    # Backwards-compat alias kept until external callers (if any) migrate.
-    _shell_args = shell_argv
+    def _shell_args(self, command: str) -> tuple[str, ...]:
+        # Back-compat wrapper, kept until external callers (if any) migrate.
+        # A wrapper (rather than a static alias) preserves dynamic dispatch:
+        # a subclass overriding `shell_argv` is honored on `_shell_args` calls.
+        return self.shell_argv(command)

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -245,7 +245,15 @@ class Shell(CallableTool2[Params]):
             await process.kill()
             raise
 
-    def _shell_args(self, command: str) -> tuple[str, ...]:
+    def shell_argv(self, command: str) -> tuple[str, ...]:
+        """Return the argv (program + flag + script) needed to run `command`
+        through this Shell tool's host shell. Public so the ACP `Terminal`
+        wrapper can build a spec-compliant `terminal/create` payload that
+        exec()s the same way as the local Shell tool.
+        """
         if self._is_powershell:
             return (str(self._shell_path), "-command", command)
         return (str(self._shell_path), "-c", command)
+
+    # Backwards-compat alias kept until external callers (if any) migrate.
+    _shell_args = shell_argv

--- a/tests/acp/test_terminal_wrapper.py
+++ b/tests/acp/test_terminal_wrapper.py
@@ -1,0 +1,160 @@
+"""Tests for the ACP `Terminal` wrapper that replaces the local `Shell` tool.
+
+The wrapper must build a spec-compliant `terminal/create` payload — the shell
+line cannot be passed as the bare `command` field. ACP clients exec the
+request as `Command::new(req.command).args(req.args)`, so packing a multi-
+token line into `command` produces a "No such file or directory" failure
+when the client looks up a binary literally named `<full shell line>`.
+
+This test locks the contract: `Terminal` must wrap the raw command in
+`bash -c` (or `pwsh -command`) the same way the local `Shell` tool does
+when running locally — so the same shell-line semantics apply over ACP.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kimi_cli.acp.tools import Terminal
+from kimi_cli.soul.approval import Approval
+from kimi_cli.tools.shell import Params, Shell
+from tests.conftest import tool_call_context
+
+pytestmark = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Argv split mirrors local Shell; on POSIX uses `bash -c`. "
+    "PowerShell branch covered by `test_shell_powershell.py`-style fixtures.",
+)
+
+
+def _approve_always() -> AsyncMock:
+    """Approval mock that always allows."""
+
+    class _OK:
+        def __bool__(self) -> bool:
+            return True
+
+        def rejection_error(self) -> Any:
+            return None
+
+    return AsyncMock(return_value=_OK())
+
+
+def _terminal_response(terminal_id: str = "term-001") -> MagicMock:
+    resp = MagicMock()
+    resp.terminal_id = terminal_id
+    return resp
+
+
+def _exit_response(exit_code: int = 0) -> MagicMock:
+    exit_status = MagicMock()
+    exit_status.exit_code = exit_code
+    exit_status.signal = None
+    return exit_status
+
+
+def _output_response(output: str = "", truncated: bool = False) -> MagicMock:
+    out = MagicMock()
+    out.output = output
+    out.truncated = truncated
+    out.exit_status = _exit_response()
+    return out
+
+
+def _make_acp_conn() -> MagicMock:
+    """Mock acp.Client capturing every method we exercise."""
+    conn = MagicMock()
+    conn.create_terminal = AsyncMock(return_value=_terminal_response())
+    conn.session_update = AsyncMock(return_value=None)
+    conn.wait_for_terminal_exit = AsyncMock(return_value=_exit_response())
+    conn.terminal_output = AsyncMock(return_value=_output_response())
+    conn.release_terminal = AsyncMock(return_value=None)
+    return conn
+
+
+async def _invoke_terminal(
+    shell_tool: Shell, command: str, *, monkeypatch: pytest.MonkeyPatch
+) -> tuple[MagicMock, Any]:
+    # Patch `get_current_acp_tool_call_id_or_none` to return a deterministic id
+    # so the assertion in `Terminal.__call__` succeeds.
+    import kimi_cli.acp.session as acp_session
+
+    monkeypatch.setattr(
+        acp_session,
+        "get_current_acp_tool_call_id_or_none",
+        lambda: "test-tool-call-id",
+    )
+
+    approval = MagicMock(spec=Approval)
+    approval.request = _approve_always()
+
+    conn = _make_acp_conn()
+    terminal = Terminal(
+        shell_tool=shell_tool,
+        acp_conn=cast(Any, conn),
+        acp_session_id="test-session",
+        approval=approval,
+    )
+    with tool_call_context("Shell"):
+        result = await terminal(Params(command=command))
+    return conn, result
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git rev-parse --short HEAD",
+        'python3 -c "print(7*8)"',
+        "cat README.md | head -5",
+        "echo hello",
+        "pwd",
+    ],
+    ids=["multi-token", "quoted", "piped", "two-token", "single-token"],
+)
+async def test_terminal_wraps_command_in_shell(
+    shell_tool: Shell,
+    command: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`Terminal` must hand off the raw shell line to bash/pwsh, not to the
+    client's exec.
+
+    Without the wrap, `Command::new("git rev-parse --short HEAD")` on the
+    client side fails because no binary by that literal name exists. With
+    the wrap, the same command string is interpreted by the user's shell —
+    matching the local Shell tool's behavior.
+    """
+    conn, _ = await _invoke_terminal(shell_tool, command, monkeypatch=monkeypatch)
+
+    conn.create_terminal.assert_awaited_once()
+    call_kwargs = conn.create_terminal.await_args.kwargs
+
+    # `command` must be the shell binary path (e.g. /bin/bash), NOT the raw
+    # shell line. This is the regression guard: any change that re-routes
+    # `params.command` directly into the `command` field will fail here.
+    assert call_kwargs["command"] == str(shell_tool._shell_path)
+
+    # `args` must be the shell-eval pair: ["-c", "<full shell line>"] on
+    # POSIX (the PowerShell branch is "-command", covered by the local
+    # Shell tool's powershell-only test path).
+    assert call_kwargs["args"] == ["-c", command]
+
+
+async def test_shell_argv_helper_matches_local_run(shell_tool: Shell) -> None:
+    """`Shell.shell_argv` is the public seam the ACP `Terminal` reuses;
+    its output must match what the local Shell tool actually exec()s, so
+    behavior is identical across modes. If this drifts, the ACP and local
+    paths will diverge silently.
+    """
+    cmd = 'echo "spaces and quotes"'
+    argv = shell_tool.shell_argv(cmd)
+    assert argv[0] == str(shell_tool._shell_path)
+    if shell_tool._is_powershell:
+        assert argv[1] == "-command"
+    else:
+        assert argv[1] == "-c"
+    assert argv[2] == cmd

--- a/tests/acp/test_terminal_wrapper.py
+++ b/tests/acp/test_terminal_wrapper.py
@@ -26,8 +26,10 @@ from tests.conftest import tool_call_context
 
 pytestmark = pytest.mark.skipif(
     platform.system() == "Windows",
-    reason="Argv split mirrors local Shell; on POSIX uses `bash -c`. "
-    "PowerShell branch covered by `test_shell_powershell.py`-style fixtures.",
+    reason="POSIX-only — exercises the `bash -c` branch end-to-end. "
+    "PowerShell argv build is verified separately by "
+    "`test_terminal_wraps_powershell_branch_argv` below, which runs "
+    "on every platform.",
 )
 
 
@@ -158,3 +160,43 @@ async def test_shell_argv_helper_matches_local_run(shell_tool: Shell) -> None:
     else:
         assert argv[1] == "-c"
     assert argv[2] == cmd
+
+
+# ─── PowerShell-branch coverage (runs on every platform) ───────────────────
+#
+# The parametrized POSIX cases above can't reach the `is_powershell` branch
+# even when run on Windows, because the `shell_tool` fixture in
+# `tests/conftest.py` is environment-derived. We flip the flag explicitly so
+# the `-command` argv build is verified end-to-end through the same
+# `Terminal.__call__` path the parametrized cases exercise — without spinning
+# up a real PowerShell process. Lock this; without it, a future regression
+# that sends `params.command` raw on the PowerShell branch would slip
+# through CI.
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason=(
+        "`shell_tool` fixture builds a Bash Shell on POSIX; we monkey-patch "
+        "_is_powershell to exercise the `-command` argv branch. On Windows "
+        "the fixture already builds a PowerShell Shell and the parametrized "
+        "POSIX cases don't run, so this test would be redundant."
+    ),
+)
+async def test_terminal_wraps_powershell_branch_argv(
+    shell_tool: Shell,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ACP `Terminal` must use `pwsh -command <line>` (not `bash -c`) when
+    the underlying Shell tool reports a PowerShell host. Same wrap shape as
+    POSIX, different flag — the ACP client still sees a proper
+    program/argv split."""
+    monkeypatch.setattr(shell_tool, "_is_powershell", True)
+    cmd = 'Get-ChildItem | Select-Object -First 3'
+
+    conn, _ = await _invoke_terminal(shell_tool, cmd, monkeypatch=monkeypatch)
+
+    conn.create_terminal.assert_awaited_once()
+    call_kwargs = conn.create_terminal.await_args.kwargs
+    assert call_kwargs["command"] == str(shell_tool._shell_path)
+    # Critical: `-command`, not `-c`.
+    assert call_kwargs["args"] == ["-command", cmd]


### PR DESCRIPTION
## Summary

When `kimi acp` is connected to a client that advertises terminal capability, the `Terminal` ACP wrapper at `src/kimi_cli/acp/tools.py` replaces the local `Shell` tool and forwards every shell-tool call to the client over `terminal/create`. It currently does this:

```python
# kimi_cli/acp/tools.py — current
resp = await self._acp_conn.create_terminal(
    command=params.command,                    # e.g. "git rev-parse --short HEAD"
    session_id=self._acp_session_id,
    output_byte_limit=builder.max_chars,
)                                               # `args=` not passed
```

The ACP `CreateTerminalRequest` spec defines `command: string` as a program path and `args: string[]` as a separate argv vector. Conformant clients run the request as the equivalent of `Command::new(req.command).args(req.args)`. So when this wrapper packs the LLM's full shell line into `command` and omits `args`, the client tries to spawn a binary literally named `<full shell line>` and fails with `No such file or directory`.

This affects every multi-token, quoted, piped, or redirected command — i.e. essentially every real-world shell invocation. Single-token commands like `pwd` happen to work by coincidence because `command="pwd"` resolves to a real binary path; everything else fails on the first attempt.

## Root cause: asymmetry with the local `Shell` tool

The local `Shell` tool at `src/kimi_cli/tools/shell/__init__.py` already does the right thing:

```python
def _shell_args(self, command: str) -> tuple[str, ...]:
    if self._is_powershell:
        return (str(self._shell_path), "-command", command)
    return (str(self._shell_path), "-c", command)

# called as:
process = await kaos.exec(*self._shell_args(command), ...)
```

So locally, kimi exec()s `bash -c <full shell line>` (or `pwsh -command …`), and the user's host shell parses pipes, quotes, redirects, `&&`, `;`, etc. The ACP wrapper diverged from this path — same LLM input, same `Shell` tool name and schema, but a different (broken) execution model.

## Fix

Have the ACP `Terminal` reuse the local `Shell`'s argv-build logic, then split program/argv into the spec-compliant fields:

```python
# kimi_cli/acp/tools.py — fixed
argv = self._shell_tool.shell_argv(params.command)
resp = await self._acp_conn.create_terminal(
    command=argv[0],
    args=list(argv[1:]),
    session_id=self._acp_session_id,
    output_byte_limit=builder.max_chars,
)
```

Now the client sees `Command::new("/bin/bash").args(["-c", "<shell-line>"])` — semantically identical to the local Shell tool. Pipes, quotes, redirects, `&&`, `;` all work the same way they do under `kimi` interactive.

To make the seam explicit and avoid reaching across private attributes, the existing `_shell_args` is renamed to public `shell_argv` (with a back-compat wrapper method retained for one cycle). The wrapper preserves dynamic dispatch — a subclass overriding `shell_argv` will be honored via the legacy `_shell_args` call too.

## Empirical reproduction

Tested against an external ACP client that follows the spec strictly (`Command::new(req.command).args(req.args)`):

| Shell command | Before | After |
|---|---|---|
| `pwd` | ✅ works (single token = valid binary) | ✅ works |
| `echo hello` | ❌ "No such file or directory" | ✅ works |
| `git rev-parse --short HEAD` | ❌ same | ✅ works |
| `python3 -c "print(7*8)"` | ❌ same | ✅ works |
| `cat README.md \| head -5` | ❌ same (and pipes!) | ✅ works |

Pre-fix: ~3 retries per shell call, all fail, kimi reports "Internal error". Post-fix: same call shape that already worked under `kimi` interactive now works identically over ACP.

### Reproduction recipe (for maintainers)

A minimal Python ACP client that demonstrates the bug pre-fix and confirms the fix post-fix:

```python
# probe_kimi_acp.py — reproduction harness, no extra deps beyond stdlib
import json, subprocess, threading, uuid
proc = subprocess.Popen(["kimi", "-y", "--afk", "acp"],
    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
    text=True, bufsize=1)
def send(o): proc.stdin.write(json.dumps(o)+"\n"); proc.stdin.flush()
def reader():
    for line in proc.stdout:
        m = json.loads(line)
        if m.get("method") == "terminal/create":
            print("PAYLOAD:", json.dumps(m["params"]))
            send({"jsonrpc":"2.0","id":m["id"],
                "error":{"code":-32601,"message":"unimplemented (probe)"}})
        elif m.get("method") == "session/request_permission":
            send({"jsonrpc":"2.0","id":m["id"],
                "result":{"outcome":{"outcome":"selected","optionId":"approve_for_session"}}})
threading.Thread(target=reader, daemon=True).start()
send({"jsonrpc":"2.0","id":0,"method":"initialize",
    "params":{"protocolVersion":1,"clientInfo":{"name":"probe","version":"0"},
        "clientCapabilities":{"terminal":True,"fs":{"readTextFile":True,"writeTextFile":True}}}})
sid = str(uuid.uuid4())
send({"jsonrpc":"2.0","id":1,"method":"session/new",
    "params":{"sessionId":sid,"cwd":".","mcpServers":[]}})
send({"jsonrpc":"2.0","id":2,"method":"session/prompt",
    "params":{"sessionId":sid,"prompt":[{"type":"text",
        "text":'Use the shell tool to run "git rev-parse --short HEAD".'}]}})
import time; time.sleep(60)
```

**Pre-fix output:** `PAYLOAD: {"command": "git rev-parse --short HEAD", ...}` — bare shell line, no `args`.
**Post-fix output:** `PAYLOAD: {"command": "/bin/bash", "args": ["-c", "git rev-parse --short HEAD"], ...}` — proper program/argv split.

## Test plan

- [x] `pytest tests/tools/test_shell_bash.py` — 20 passed (no regression in local Shell behavior)
- [x] `pytest tests/tools/test_shell_powershell.py` — local Shell PowerShell branch unchanged
- [x] `pytest tests/acp/` — 21 existing + 7 new passed
- [x] `pytest tests/acp/test_terminal_wrapper.py` — 7 new tests:
  - 5 parametrized POSIX cases (single-token, two-token, multi-token-with-args, quoted, piped) verify the wrap is applied uniformly
  - `test_shell_argv_helper_matches_local_run` asserts ACP and local paths build identical argv (so they can't drift silently)
  - `test_terminal_wraps_powershell_branch_argv` covers the `-command` branch end-to-end via `Terminal.__call__` (monkey-patches `_is_powershell` so it runs on every platform without needing a real pwsh)
- [x] Manual end-to-end probe against an external spec-compliant ACP client (recipe above): every command shape that previously failed now executes and returns expected stdout

## Risks / out of scope

- **Behavior change for clients with workarounds**: any client implementing a `sh -c req.command` workaround will now see proper argv split. Net effect is *strictly safer*: the workaround was a security hazard (turns ACP's per-program permission model into shell-string semantics). Note that double-wrapping is benign — `Command::new("/bin/bash").args(["-c", "<line>"])` invoked under a `sh -c` workaround becomes `sh -c "/bin/bash -c '<line>'"`, which still evaluates correctly because `bash -c` is itself idempotent under reentry. No quoting hazards introduced.
- **PowerShell branch**: handled by the same `shell_argv` (returns `(<pwsh>, "-command", cmd)`); now covered end-to-end through `Terminal.__call__` by `test_terminal_wraps_powershell_branch_argv`.
- **Backwards compat**: `_shell_args` retained as a wrapper method (not a static alias) so dynamic dispatch is preserved if a subclass overrides `shell_argv`. Can be removed in a future cycle once any internal callers migrate.
- **Working-directory and env**: unchanged — the existing `create_terminal` call already accepts `cwd` and `env` kwargs from the ACP schema; this PR doesn't touch those code paths.