### PR TITLE
fix(clipboard): enable clipboard paste on headless Linux over SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
-- Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste via PIL so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
+- Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
 
 ## 1.40.0 (2026-04-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste via PIL so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
+
 ## 1.40.0 (2026-04-28)
 
 - Core: Fix `--yolo` mode unintentionally preventing the model from calling `AskUserQuestion` — yolo used to inject a system reminder telling the model it was in "non-interactive mode" and must not ask, and the ask-user tool auto-dismissed in yolo. Both were wrong: yolo only bypasses permission approvals; it does not mean "the user is gone". Yolo no longer injects model guidance, and the user remains reachable through `AskUserQuestion`

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste via PIL so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
+
 ## 1.40.0 (2026-04-28)
 
 - Core: Fix `--yolo` mode unintentionally preventing the model from calling `AskUserQuestion` — yolo used to inject a system reminder telling the model it was in "non-interactive mode" and must not ask, and the ask-user tool auto-dismissed in yolo. Both were wrong: yolo only bypasses permission approvals; it does not mean "the user is gone". Yolo no longer injects model guidance, and the user remains reachable through `AskUserQuestion`

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,7 +4,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
-- Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste via PIL so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
+- Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
 
 ## 1.40.0 (2026-04-28)
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,7 +4,7 @@
 
 ## 未发布
 
-- Shell：在无显示环境的 Linux（如 SSH 远程）上启用剪贴板图片粘贴——当 pyperclip 不可用（例如 DISPLAY 未设置）时，Ctrl-V 现在会通过 xclip 或 wl-paste 回退到 PIL，使远程剪贴板桥接仍能注入图片；同时防止 pyperclip 失效时内置剪贴板快捷键造成 UI 崩溃
+- Shell：在无显示环境的 Linux（如 SSH 远程）上启用剪贴板图片粘贴——当 pyperclip 不可用（例如 DISPLAY 未设置）时，Ctrl-V 现在会回退到 xclip 或 wl-paste，使远程剪贴板桥接仍能注入图片；同时防止 pyperclip 失效时内置剪贴板快捷键造成 UI 崩溃
 
 ## 1.40.0 (2026-04-28)
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Shell：在无显示环境的 Linux（如 SSH 远程）上启用剪贴板图片粘贴——当 pyperclip 不可用（例如 DISPLAY 未设置）时，Ctrl-V 现在会通过 xclip 或 wl-paste 回退到 PIL，使远程剪贴板桥接仍能注入图片；同时防止 pyperclip 失效时内置剪贴板快捷键造成 UI 崩溃
+
 ## 1.40.0 (2026-04-28)
 
 - Core：修复 `--yolo` 模式意外阻止模型调用 `AskUserQuestion` 的问题——以前 yolo 会注入一段 system reminder，告诉模型当前处于“非交互模式”，不能向用户提问；同时 ask-user 工具在 yolo 下也会自动 dismiss。这两处都是错的：yolo 只绕过权限审批，并不意味着“用户已离开”。现在 yolo 不再向模型注入指导；用户仍可通过 `AskUserQuestion` 触达

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -66,6 +66,7 @@ from kimi_cli.ui.theme import get_prompt_style, get_toolbar_colors
 from kimi_cli.utils.clipboard import (
     grab_media_from_clipboard,
     is_clipboard_available,
+    is_media_clipboard_available,
 )
 from kimi_cli.utils.logging import logger
 from kimi_cli.utils.slashcmd import SlashCommand
@@ -1215,7 +1216,8 @@ class CustomPromptSession:
         self._last_ui_state: PromptUIState = PromptUIState.NORMAL_INPUT
         self._suspended_buffer_document: Document | None = None
         clipboard_available = is_clipboard_available()
-        self._tips = _build_toolbar_tips(clipboard_available)
+        media_clipboard_available = is_media_clipboard_available()
+        self._tips = _build_toolbar_tips(clipboard_available or media_clipboard_available)
         self._tip_rotation_index: int = random.randrange(len(self._tips)) if self._tips else 0
 
         history_entries = _load_history_entries(self._history_file)
@@ -1475,7 +1477,7 @@ class CustomPromptSession:
         def _(event: KeyPressEvent) -> None:
             self._handle_bracketed_paste(event)
 
-        if clipboard_available:
+        if clipboard_available or media_clipboard_available:
 
             @_kb.add("c-v", eager=True)
             def _(event: KeyPressEvent) -> None:
@@ -1484,15 +1486,21 @@ class CustomPromptSession:
                 track("shortcut_paste")
                 if self._try_paste_media(event):
                     return
-                clipboard_data = event.app.clipboard.get_data()
-                if clipboard_data is None:  # type: ignore[reportUnnecessaryComparison]
-                    return
-                self._insert_pasted_text(event.current_buffer, clipboard_data.text)
-                event.app.invalidate()
+                if clipboard_available:
+                    try:
+                        clipboard_data = event.app.clipboard.get_data()
+                    except Exception:
+                        return
+                    if clipboard_data is None:  # type: ignore[reportUnnecessaryComparison]
+                        return
+                    self._insert_pasted_text(event.current_buffer, clipboard_data.text)
+                    event.app.invalidate()
 
-            clipboard = PyperclipClipboard()
-        else:
-            clipboard = None
+        # Only use PyperclipClipboard when pyperclip actually works.
+        # PromptSession built-in keybindings (ctrl-k, ctrl-w, ctrl-y)
+        # use clipboard without error handling, so a broken clipboard
+        # object would crash the UI.
+        clipboard = PyperclipClipboard() if clipboard_available else None
 
         self._session = PromptSession[str](
             message=self._render_message,
@@ -1901,7 +1909,13 @@ class CustomPromptSession:
         image files are cached and inserted as placeholders.
         Returns True if any media content was inserted.
         """
-        result = grab_media_from_clipboard()
+        try:
+            result = grab_media_from_clipboard()
+        except Exception:
+            # ImageGrab.grabclipboard() may fail on headless Linux if the
+            # real xclip cannot connect to an X server. Silently ignore so
+            # that the text-paste fallback can still be attempted.
+            return False
         if result is None:
             return False
 

--- a/src/kimi_cli/utils/clipboard.py
+++ b/src/kimi_cli/utils/clipboard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import shutil
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -30,12 +31,26 @@ class ClipboardResult:
 
 
 def is_clipboard_available() -> bool:
-    """Check if the Pyperclip clipboard is available."""
+    """Check if the Pyperclip text clipboard is available."""
     try:
         pyperclip.paste()
         return True
     except Exception:
         return False
+
+
+def is_media_clipboard_available() -> bool:
+    """Check if the media clipboard (PIL -> xclip/wl-paste) is available.
+
+    On headless Linux (e.g. SSH remote), pyperclip may fail because
+    DISPLAY is not set, but PIL's ImageGrab.grabclipboard() can still
+    read images through xclip or wl-paste (e.g. via clipboard bridging
+    tools like cc-clip that shim xclip over an SSH tunnel).
+    """
+    if sys.platform == "linux":
+        return shutil.which("xclip") is not None or shutil.which("wl-paste") is not None
+    # macOS and Windows use native APIs that do not require external tools.
+    return True
 
 
 def grab_media_from_clipboard() -> ClipboardResult | None:

--- a/src/kimi_cli/utils/clipboard.py
+++ b/src/kimi_cli/utils/clipboard.py
@@ -120,7 +120,7 @@ def _grab_image_linux() -> Image.Image | None:
     else:  # headless — xclip first for common clipboard bridges
         candidates = (xclip_args, wlpaste_args)
 
-    for args in candidates:
+    for idx, args in enumerate(candidates):
         if shutil.which(args[0]) is None:
             continue
         try:
@@ -146,6 +146,11 @@ def _grab_image_linux() -> Image.Image | None:
             b"no owner for the ",
         ]
         if any(se in err for se in silent_errors):
+            # Trust the session-native tool: if it says "no image", don't
+            # fall back to a different clipboard namespace (e.g. XWayland
+            # vs Wayland) which may contain stale unrelated data.
+            if idx == 0:
+                return None
             continue
         # Otherwise, a real error (e.g. tool broken) — try next candidate.
 

--- a/src/kimi_cli/utils/clipboard.py
+++ b/src/kimi_cli/utils/clipboard.py
@@ -130,7 +130,7 @@ def _grab_image_linux() -> Image.Image | None:
             b"no owner for the ",
         ]
         if any(se in err for se in silent_errors):
-            return None
+            continue
         # Otherwise, a real error (e.g. tool broken) — try next candidate.
 
     return None

--- a/src/kimi_cli/utils/clipboard.py
+++ b/src/kimi_cli/utils/clipboard.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import importlib
+import io
 import os
 import shutil
+import subprocess
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -40,12 +42,12 @@ def is_clipboard_available() -> bool:
 
 
 def is_media_clipboard_available() -> bool:
-    """Check if the media clipboard (PIL -> xclip/wl-paste) is available.
+    """Check if the media clipboard (xclip/wl-paste) is available.
 
     On headless Linux (e.g. SSH remote), pyperclip may fail because
-    DISPLAY is not set, but PIL's ImageGrab.grabclipboard() can still
-    read images through xclip or wl-paste (e.g. via clipboard bridging
-    tools like cc-clip that shim xclip over an SSH tunnel).
+    DISPLAY is not set, but images can still be read through xclip or
+    wl-paste (e.g. via clipboard bridging tools like cc-clip that shim
+    xclip over an SSH tunnel).
     """
     if sys.platform == "linux":
         return shutil.which("xclip") is not None or shutil.which("wl-paste") is not None
@@ -73,10 +75,15 @@ def grab_media_from_clipboard() -> ClipboardResult | None:
                 file_paths=tuple(non_image_paths),
             )
 
-    # 2. Try PIL ImageGrab as fallback.
-    #    - On macOS this uses AppleScript «class furl» for file paths,
-    #      or reads raw image data (TIFF/PNG) from the pasteboard.
-    #    - On other platforms this is the primary clipboard access method.
+    # 2. On Linux, use explicit xclip/wl-paste fallback instead of Pillow's
+    #    opaque internal selection, which may pick a broken tool first.
+    if sys.platform == "linux":
+        image = _grab_image_linux()
+        if image is not None:
+            return ClipboardResult(images=(image,), file_paths=())
+        return None
+
+    # 3. On Windows and other platforms, use Pillow's default implementation.
     payload = ImageGrab.grabclipboard()
     if payload is None:
         return None
@@ -92,6 +99,40 @@ def grab_media_from_clipboard() -> ClipboardResult | None:
             images=tuple(images),
             file_paths=tuple(non_image_paths),
         )
+    return None
+
+
+def _grab_image_linux() -> Image.Image | None:
+    """Read image from Linux clipboard, trying xclip then wl-paste."""
+    for args in (
+        ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
+        ["wl-paste", "-t", "image"],
+    ):
+        if shutil.which(args[0]) is None:
+            continue
+        p = subprocess.run(args, capture_output=True)
+        if p.returncode == 0 and p.stdout:
+            data = io.BytesIO(p.stdout)
+            try:
+                im = Image.open(data)
+                im.load()
+                return im
+            except Exception:
+                continue
+        # Silent errors mean clipboard is empty or has no image.
+        err = p.stderr
+        silent_errors = [
+            b"Nothing is copied",
+            b"No selection",
+            b"No suitable type of content copied",
+            b" not available",
+            b"cannot convert ",
+            b"no owner for the ",
+        ]
+        if any(se in err for se in silent_errors):
+            return None
+        # Otherwise, a real error (e.g. tool broken) — try next candidate.
+
     return None
 
 

--- a/src/kimi_cli/utils/clipboard.py
+++ b/src/kimi_cli/utils/clipboard.py
@@ -103,14 +103,30 @@ def grab_media_from_clipboard() -> ClipboardResult | None:
 
 
 def _grab_image_linux() -> Image.Image | None:
-    """Read image from Linux clipboard, trying xclip then wl-paste."""
-    for args in (
-        ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
-        ["wl-paste", "-t", "image"],
-    ):
+    """Read image from Linux clipboard with session-aware tool fallback.
+
+    Tries the backend matching the current session type first to avoid
+    reading stale data from the wrong clipboard (e.g. XWayland vs
+    Wayland). On headless systems with no session type, xclip is tried
+    first since clipboard bridges (e.g. cc-clip) typically shim xclip.
+    """
+    xclip_args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
+    wlpaste_args = ["wl-paste", "-t", "image"]
+
+    if os.getenv("WAYLAND_DISPLAY"):
+        candidates = (wlpaste_args, xclip_args)
+    elif os.getenv("DISPLAY"):
+        candidates = (xclip_args, wlpaste_args)
+    else:  # headless — xclip first for common clipboard bridges
+        candidates = (xclip_args, wlpaste_args)
+
+    for args in candidates:
         if shutil.which(args[0]) is None:
             continue
-        p = subprocess.run(args, capture_output=True)
+        try:
+            p = subprocess.run(args, capture_output=True, timeout=3)
+        except subprocess.TimeoutExpired:
+            continue
         if p.returncode == 0 and p.stdout:
             data = io.BytesIO(p.stdout)
             try:

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -9,6 +9,7 @@ from PIL import Image
 from kimi_cli.utils.clipboard import (
     _VIDEO_SUFFIXES,
     _classify_file_paths,
+    _grab_image_linux,
     is_media_clipboard_available,
 )
 
@@ -187,9 +188,7 @@ def test_classify_all_video_suffixes(tmp_path: Path) -> None:
 
 def test_media_clipboard_available_linux_with_xclip(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(
-        shutil, "which", lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None
-    )
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None)
     assert is_media_clipboard_available() is True
 
 
@@ -203,9 +202,7 @@ def test_media_clipboard_available_linux_with_wl_paste(monkeypatch) -> None:
 
 def test_media_clipboard_available_linux_with_both_tools(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(
-        shutil, "which", lambda cmd: f"/usr/bin/{cmd}"
-    )
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
     assert is_media_clipboard_available() is True
 
 
@@ -223,3 +220,138 @@ def test_media_clipboard_available_macos(monkeypatch) -> None:
 def test_media_clipboard_available_windows(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "win32")
     assert is_media_clipboard_available() is True
+
+
+# --- _grab_image_linux tests ---
+
+
+def test_grab_image_linux_xclip_falls_back_to_wlpaste(monkeypatch, tmp_path: Path) -> None:
+    """When xclip fails with a real error, fallback to wl-paste."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (2, 2)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode: int
+            stdout: bytes
+            stderr: bytes
+
+        if args[0] == "xclip":
+            r = FakeResult()
+            r.returncode = 1
+            r.stdout = b""
+            r.stderr = b"connection refused"
+            return r
+        r = FakeResult()
+        r.returncode = 0
+        r.stdout = img_bytes
+        r.stderr = b""
+        return r
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (2, 2)
+    assert calls == ["xclip", "wl-paste"]
+
+
+def test_grab_image_linux_xclip_silent_error_no_fallback(monkeypatch) -> None:
+    """When xclip reports a silent error (empty clipboard), do not try wl-paste."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode = 1
+            stdout = b""
+            stderr = b"xclip: Error: There is no owner for the selection"
+
+        return FakeResult()
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is None
+    assert calls == ["xclip"]
+
+
+def test_grab_image_linux_xclip_missing_wlpaste_succeeds(monkeypatch, tmp_path: Path) -> None:
+    """When xclip is not installed, wl-paste is used directly."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd: "/usr/bin/wl-paste" if cmd == "wl-paste" else None
+    )
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (3, 3)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode = 0
+            stdout = img_bytes
+            stderr = b""
+
+        return FakeResult()
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (3, 3)
+    assert calls == ["wl-paste"]
+
+
+def test_grab_image_linux_both_tools_missing(monkeypatch) -> None:
+    """When no clipboard tool is available, return None."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _grab_image_linux()
+    assert result is None
+
+
+def test_grab_image_linux_xclip_succeeds(monkeypatch, tmp_path: Path) -> None:
+    """When xclip succeeds immediately, wl-paste is not tried."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (4, 4)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode = 0
+            stdout = img_bytes
+            stderr = b""
+
+        return FakeResult()
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (4, 4)
+    assert calls == ["xclip"]

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -396,3 +396,124 @@ def test_grab_image_linux_xclip_succeeds(monkeypatch, tmp_path: Path) -> None:
     assert result is not None
     assert result.size == (4, 4)
     assert calls == ["xclip"]
+
+
+def test_grab_image_linux_wayland_prefers_wlpaste(monkeypatch, tmp_path: Path) -> None:
+    """On Wayland, wl-paste is tried first."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (5, 5)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode = 0
+            stdout = img_bytes
+            stderr = b""
+
+        return FakeResult()
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (5, 5)
+    assert calls == ["wl-paste"]
+
+
+def test_grab_image_linux_wayland_wlpaste_falls_back_to_xclip(monkeypatch, tmp_path: Path) -> None:
+    """On Wayland, if wl-paste fails with real error, fallback to xclip."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (6, 6)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode: int
+            stdout: bytes
+            stderr: bytes
+
+        if args[0] == "wl-paste":
+            r = FakeResult()
+            r.returncode = 1
+            r.stdout = b""
+            r.stderr = b"connection refused"
+            return r
+        r = FakeResult()
+        r.returncode = 0
+        r.stdout = img_bytes
+        r.stderr = b""
+        return r
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (6, 6)
+    assert calls == ["wl-paste", "xclip"]
+
+
+def test_grab_image_linux_x11_prefers_xclip(monkeypatch, tmp_path: Path) -> None:
+    """On X11, xclip is tried first."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (7, 7)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode = 0
+            stdout = img_bytes
+            stderr = b""
+
+        return FakeResult()
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (7, 7)
+    assert calls == ["xclip"]
+
+
+def test_grab_image_linux_timeout(monkeypatch) -> None:
+    """When subprocess times out, continue to next backend."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+        import subprocess
+
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=3)
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is None
+    assert calls == ["xclip", "wl-paste"]

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -264,8 +264,49 @@ def test_grab_image_linux_xclip_falls_back_to_wlpaste(monkeypatch, tmp_path: Pat
     assert calls == ["xclip", "wl-paste"]
 
 
-def test_grab_image_linux_xclip_silent_error_no_fallback(monkeypatch) -> None:
-    """When xclip reports a silent error (empty clipboard), do not try wl-paste."""
+def test_grab_image_linux_xclip_silent_error_then_wlpaste_succeeds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """When xclip reports a silent error, fallback to wl-paste."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    img_path = tmp_path / "clipboard.png"
+    Image.new("RGB", (2, 2)).save(img_path)
+    img_bytes = img_path.read_bytes()
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode: int
+            stdout: bytes
+            stderr: bytes
+
+        if args[0] == "xclip":
+            r = FakeResult()
+            r.returncode = 1
+            r.stdout = b""
+            r.stderr = b"xclip: Error: There is no owner for the selection"
+            return r
+        r = FakeResult()
+        r.returncode = 0
+        r.stdout = img_bytes
+        r.stderr = b""
+        return r
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is not None
+    assert result.size == (2, 2)
+    assert calls == ["xclip", "wl-paste"]
+
+
+def test_grab_image_linux_both_tools_silent_error(monkeypatch) -> None:
+    """When both tools report silent errors, return None."""
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
@@ -277,7 +318,7 @@ def test_grab_image_linux_xclip_silent_error_no_fallback(monkeypatch) -> None:
         class FakeResult:
             returncode = 1
             stdout = b""
-            stderr = b"xclip: Error: There is no owner for the selection"
+            stderr = b"No selection"
 
         return FakeResult()
 
@@ -285,7 +326,7 @@ def test_grab_image_linux_xclip_silent_error_no_fallback(monkeypatch) -> None:
 
     result = _grab_image_linux()
     assert result is None
-    assert calls == ["xclip"]
+    assert calls == ["xclip", "wl-paste"]
 
 
 def test_grab_image_linux_xclip_missing_wlpaste_succeeds(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -269,10 +269,10 @@ def test_grab_image_linux_xclip_falls_back_to_wlpaste(monkeypatch, tmp_path: Pat
     assert calls == ["xclip", "wl-paste"]
 
 
-def test_grab_image_linux_xclip_silent_error_then_wlpaste_succeeds(
+def test_grab_image_linux_xclip_real_error_then_wlpaste_succeeds(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """When xclip reports a silent error, fallback to wl-paste."""
+    """When xclip fails with a real error, fallback to wl-paste."""
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
@@ -295,7 +295,7 @@ def test_grab_image_linux_xclip_silent_error_then_wlpaste_succeeds(
             r = FakeResult()
             r.returncode = 1
             r.stdout = b""
-            r.stderr = b"xclip: Error: There is no owner for the selection"
+            r.stderr = b"connection refused"
             return r
         r = FakeResult()
         r.returncode = 0
@@ -333,7 +333,7 @@ def test_grab_image_linux_both_tools_silent_error(monkeypatch) -> None:
 
     result = _grab_image_linux()
     assert result is None
-    assert calls == ["xclip", "wl-paste"]
+    assert calls == ["xclip"]
 
 
 def test_grab_image_linux_xclip_missing_wlpaste_succeeds(monkeypatch, tmp_path: Path) -> None:
@@ -507,6 +507,33 @@ def test_grab_image_linux_x11_prefers_xclip(monkeypatch, tmp_path: Path) -> None
     assert result is not None
     assert result.size == (7, 7)
     assert calls == ["xclip"]
+
+
+def test_grab_image_linux_wayland_wlpaste_silent_error_no_fallback(
+    monkeypatch,
+) -> None:
+    """On Wayland, if wl-paste reports silent error, do not fallback to xclip."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args[0])
+
+        class FakeResult:
+            returncode = 1
+            stdout = b""
+            stderr = b"No suitable type of content copied"
+
+        return FakeResult()
+
+    monkeypatch.setattr("kimi_cli.utils.clipboard.subprocess.run", fake_run)
+
+    result = _grab_image_linux()
+    assert result is None
+    assert calls == ["wl-paste"]
 
 
 def test_grab_image_linux_timeout(monkeypatch) -> None:

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import shutil
+import sys
 from pathlib import Path
 
 from PIL import Image
 
-from kimi_cli.utils.clipboard import _VIDEO_SUFFIXES, _classify_file_paths
+from kimi_cli.utils.clipboard import (
+    _VIDEO_SUFFIXES,
+    _classify_file_paths,
+    is_media_clipboard_available,
+)
 
 
 def test_classify_video_file(tmp_path: Path) -> None:
@@ -174,3 +180,46 @@ def test_classify_all_video_suffixes(tmp_path: Path) -> None:
         images, file_paths = _classify_file_paths([str(f)])
         assert images == [], f"Failed for {suffix}"
         assert file_paths == [f], f"Failed for {suffix}"
+
+
+# --- is_media_clipboard_available tests ---
+
+
+def test_media_clipboard_available_linux_with_xclip(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None
+    )
+    assert is_media_clipboard_available() is True
+
+
+def test_media_clipboard_available_linux_with_wl_paste(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd: "/usr/bin/wl-paste" if cmd == "wl-paste" else None
+    )
+    assert is_media_clipboard_available() is True
+
+
+def test_media_clipboard_available_linux_with_both_tools(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd: f"/usr/bin/{cmd}"
+    )
+    assert is_media_clipboard_available() is True
+
+
+def test_media_clipboard_available_linux_without_tools(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    assert is_media_clipboard_available() is False
+
+
+def test_media_clipboard_available_macos(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert is_media_clipboard_available() is True
+
+
+def test_media_clipboard_available_windows(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert is_media_clipboard_available() is True

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -188,12 +188,14 @@ def test_classify_all_video_suffixes(tmp_path: Path) -> None:
 
 def test_media_clipboard_available_linux_with_xclip(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None)
     assert is_media_clipboard_available() is True
 
 
 def test_media_clipboard_available_linux_with_wl_paste(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(
         shutil, "which", lambda cmd: "/usr/bin/wl-paste" if cmd == "wl-paste" else None
     )
@@ -202,12 +204,14 @@ def test_media_clipboard_available_linux_with_wl_paste(monkeypatch) -> None:
 
 def test_media_clipboard_available_linux_with_both_tools(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
     assert is_media_clipboard_available() is True
 
 
 def test_media_clipboard_available_linux_without_tools(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda _cmd: None)
     assert is_media_clipboard_available() is False
 
@@ -228,6 +232,7 @@ def test_media_clipboard_available_windows(monkeypatch) -> None:
 def test_grab_image_linux_xclip_falls_back_to_wlpaste(monkeypatch, tmp_path: Path) -> None:
     """When xclip fails with a real error, fallback to wl-paste."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
     img_path = tmp_path / "clipboard.png"
@@ -269,6 +274,7 @@ def test_grab_image_linux_xclip_silent_error_then_wlpaste_succeeds(
 ) -> None:
     """When xclip reports a silent error, fallback to wl-paste."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
     img_path = tmp_path / "clipboard.png"
@@ -308,6 +314,7 @@ def test_grab_image_linux_xclip_silent_error_then_wlpaste_succeeds(
 def test_grab_image_linux_both_tools_silent_error(monkeypatch) -> None:
     """When both tools report silent errors, return None."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
     calls = []
@@ -332,6 +339,7 @@ def test_grab_image_linux_both_tools_silent_error(monkeypatch) -> None:
 def test_grab_image_linux_xclip_missing_wlpaste_succeeds(monkeypatch, tmp_path: Path) -> None:
     """When xclip is not installed, wl-paste is used directly."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(
         shutil, "which", lambda cmd: "/usr/bin/wl-paste" if cmd == "wl-paste" else None
     )
@@ -363,6 +371,7 @@ def test_grab_image_linux_xclip_missing_wlpaste_succeeds(monkeypatch, tmp_path: 
 def test_grab_image_linux_both_tools_missing(monkeypatch) -> None:
     """When no clipboard tool is available, return None."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda _cmd: None)
 
     result = _grab_image_linux()
@@ -372,6 +381,7 @@ def test_grab_image_linux_both_tools_missing(monkeypatch) -> None:
 def test_grab_image_linux_xclip_succeeds(monkeypatch, tmp_path: Path) -> None:
     """When xclip succeeds immediately, wl-paste is not tried."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
     img_path = tmp_path / "clipboard.png"
@@ -502,6 +512,7 @@ def test_grab_image_linux_x11_prefers_xclip(monkeypatch, tmp_path: Path) -> None
 def test_grab_image_linux_timeout(monkeypatch) -> None:
     """When subprocess times out, continue to next backend."""
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
     monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
     calls = []


### PR DESCRIPTION
## Problem

When running Kimi CLI on a headless Linux machine (e.g. a remote development server accessed via SSH), the `Ctrl+V` shortcut for pasting clipboard content is completely disabled. This happens because `pyperclip.paste()` fails during initialization when the `DISPLAY` environment variable is not set, causing `is_clipboard_available()` to return `False`.

However, the image paste pipeline in Kimi CLI does **not** actually depend on `pyperclip`. It can read images through `xclip` or `wl-paste` (e.g. via clipboard bridging tools like [cc-clip](https://github.com/ShunmeiCho/cc-clip) that shim `xclip` over an SSH tunnel).

The previous code used a single `is_clipboard_available()` boolean to gate two independent capabilities: (1) binding the `Ctrl+V` keybinding for media paste, and (2) creating a `PyperclipClipboard` for `PromptSession`. The latter is used by prompt_toolkit's built-in emacs keybindings (`ctrl-k`, `ctrl-w`, `ctrl-y`) without error handling, so a broken `PyperclipClipboard` would crash the UI.

Additionally, Pillow's `ImageGrab.grabclipboard()` on Linux has opaque internal tool selection: if both `wl-paste` and `xclip` are present, it may pick `wl-paste` first (even when it's broken), fail, and never fallback to `xclip`. This leaves xclip-bridge users unable to paste images in a common environment.

## Changes

### 1. `src/kimi_cli/utils/clipboard.py`

- Added `import io` and `import subprocess`
- Restored `is_clipboard_available()` to a **strict pyperclip-only check** (as it was before).
- Added `is_media_clipboard_available()` that checks for `xclip` or `wl-paste` on Linux. On macOS and Windows it returns `True`.
- **New**: Added `_grab_image_linux()` that replaces Pillow's opaque `ImageGrab.grabclipboard()` Linux path with explicit xclip/wl-paste calls, ensuring xclip-bridge users are not blocked by a broken `wl-paste`.
  - **Session-aware ordering**: Uses `WAYLAND_DISPLAY`/`DISPLAY` env vars to pick the matching backend first (Wayland → wl-paste; X11 → xclip; headless → xclip), matching Pillow's original behavior.
  - **Silent-error short-circuit**: If the session-native tool reports a silent error (empty clipboard / no image), returns `None` immediately. This prevents reading stale data from a different clipboard namespace (e.g. XWayland vs Wayland). Real errors and timeouts still fall back to the next backend.
  - **Timeout protection**: `subprocess.run(..., timeout=3)` with `TimeoutExpired` handling prevents the TUI from freezing if a clipboard tool blocks.

### 2. `src/kimi_cli/ui/shell/prompt.py`

- Imports the new `is_media_clipboard_available()` function.
- `Ctrl+V` keybinding is registered when **either** text clipboard (pyperclip) or media clipboard (xclip/wl-paste) is available.
- Text paste fallback inside the `Ctrl+V` handler only runs when pyperclip actually works.
- `PyperclipClipboard` is only created when pyperclip works; otherwise `clipboard = None`, letting `PromptSession` safely fall back to `InMemoryClipboard`.

### 3. `tests/test_clipboard.py`

- **6 tests** for `is_media_clipboard_available()` covering all platform/tool combinations.
- **11 tests** for `_grab_image_linux()` covering:
  - xclip real error → fallback to wl-paste
  - xclip silent error → return None (headless, trusted)
  - both tools silent error → return None after first
  - xclip missing, wl-paste succeeds
  - both tools missing → returns None
  - xclip succeeds immediately → wl-paste not tried
  - **Wayland prefers wl-paste**
  - **Wayland wl-paste real error → fallback to xclip**
  - **Wayland wl-paste silent error → no xclip fallback**
  - **X11 prefers xclip**
  - **subprocess timeout → continues to next backend**

## Edge Cases Considered

| Scenario | Behavior |
|----------|----------|
| macOS / Windows local | **No change** — native APIs work as before |
| Linux desktop (X11) | **No change** — xclip tried first, trusted on silent error |
| Linux desktop (Wayland) | **No change / improved** — wl-paste tried first, trusted on silent error; no stale XWayland data |
| Linux headless + cc-clip (xclip bridge) | **Fixed** — xclip tried first; real errors fall back to wl-paste |
| Linux headless + xclip present, no cc-clip | **Safe** — `Ctrl+V` bound, timeout prevents freeze; built-in keybindings use `InMemoryClipboard` |
| Linux headless + no `xclip`/`wl-paste` | **No change** — both checks return `False` |

## Testing

- [x] Verified `is_media_clipboard_available()` returns `True` on a headless Linux server with `xclip` present
- [x] Verified `Ctrl+V` successfully pastes images when cc-clip tunnel is active
- [x] Verified no crash occurs when `xclip` is unavailable or fails
- [x] Verified prompt_toolkit built-in keybindings (ctrl-k, ctrl-w, ctrl-y) do not crash when pyperclip is broken
- [x] Cross-platform impact reviewed — zero regression on macOS/Windows/Wayland/X11
- [x] All tests pass (32 existing + 17 new)
- [x] `pre-commit run --all-files` passed

## Related

This fix enables seamless clipboard image paste for users who run Kimi CLI on remote Linux machines via SSH, particularly when combined with clipboard bridging tools like cc-clip.