### PR TITLE
fix(plugin): support installing from .zip URL

### DIFF
--- a/docs/en/customization/plugins.md
+++ b/docs/en/customization/plugins.md
@@ -34,7 +34,12 @@ kimi plugin install /path/to/my-plugin
 **Install from a ZIP file**
 
 ```sh
+# Local ZIP file
 kimi plugin install my-plugin.zip
+
+# Remote ZIP URL (including GitHub/GitLab archive download links)
+kimi plugin install https://example.com/my-plugin.zip
+kimi plugin install https://github.com/user/repo/archive/refs/heads/main.zip
 ```
 
 **Install from a Git repository**

--- a/docs/zh/customization/plugins.md
+++ b/docs/zh/customization/plugins.md
@@ -34,7 +34,12 @@ kimi plugin install /path/to/my-plugin
 **从 ZIP 文件安装**
 
 ```sh
+# 本地 ZIP 文件
 kimi plugin install my-plugin.zip
+
+# 远程 ZIP 链接（含 GitHub/GitLab 归档下载链接）
+kimi plugin install https://example.com/my-plugin.zip
+kimi plugin install https://github.com/user/repo/archive/refs/heads/main.zip
 ```
 
 **从 Git 仓库安装**

--- a/src/kimi_cli/cli/plugin.py
+++ b/src/kimi_cli/cli/plugin.py
@@ -108,9 +108,7 @@ def _resolve_source(target: str) -> tuple[Path, Path | None]:
         zip_path = tmp / "_download.zip"
         typer.echo(f"Downloading {target}...")
         try:
-            with httpx.stream(
-                "GET", target, follow_redirects=True, timeout=60.0
-            ) as resp:
+            with httpx.stream("GET", target, follow_redirects=True, timeout=60.0) as resp:
                 resp.raise_for_status()
                 with zip_path.open("wb") as f:
                     for chunk in resp.iter_bytes():

--- a/src/kimi_cli/cli/plugin.py
+++ b/src/kimi_cli/cli/plugin.py
@@ -56,6 +56,37 @@ def _parse_git_url(target: str) -> tuple[str, str | None, str | None]:
     return clone_url, subpath, branch
 
 
+def _extract_zip_to_plugin(zip_path: Path, tmp: Path) -> tuple[Path, Path]:
+    """Extract zip_path into tmp and locate the plugin directory.
+
+    Returns ``(plugin_dir, tmp)`` for cleanup by the caller. Rejects zip
+    members whose paths escape ``tmp``. Searches the extraction root and
+    one level deep for ``plugin.json``.
+    """
+    import shutil
+    import zipfile
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        for member in zf.namelist():
+            member_path = (tmp / member).resolve()
+            if not member_path.is_relative_to(tmp.resolve()):
+                shutil.rmtree(tmp, ignore_errors=True)
+                typer.echo(f"Error: zip contains unsafe path: {member}", err=True)
+                raise typer.Exit(1)
+        zf.extractall(tmp)
+
+    for candidate in [tmp] + sorted(tmp.iterdir()):
+        if candidate.is_dir() and (candidate / "plugin.json").exists():
+            return candidate, tmp
+    dirs = [d for d in tmp.iterdir() if d.is_dir() and not d.name.startswith("_")]
+    if len(dirs) == 1 and (dirs[0] / "plugin.json").exists():
+        return dirs[0], tmp
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    typer.echo("Error: No plugin.json found in zip", err=True)
+    raise typer.Exit(1)
+
+
 def _resolve_source(target: str) -> tuple[Path, Path | None]:
     """Resolve plugin source to (local_dir, tmp_to_cleanup).
 
@@ -64,6 +95,32 @@ def _resolve_source(target: str) -> tuple[Path, Path | None]:
     """
     import shutil
     import tempfile
+    from urllib.parse import urlparse
+
+    # HTTP(S) URL pointing to a .zip — download then extract.
+    # Checked before the git-URL branch so GitHub/GitLab archive links
+    # like .../archive/refs/heads/main.zip take this path.
+    parsed = urlparse(target)
+    if parsed.scheme in ("http", "https") and parsed.path.lower().endswith(".zip"):
+        import httpx
+
+        tmp = Path(tempfile.mkdtemp(prefix="kimi-plugin-"))
+        zip_path = tmp / "_download.zip"
+        typer.echo(f"Downloading {target}...")
+        try:
+            with httpx.stream(
+                "GET", target, follow_redirects=True, timeout=60.0
+            ) as resp:
+                resp.raise_for_status()
+                with zip_path.open("wb") as f:
+                    for chunk in resp.iter_bytes():
+                        f.write(chunk)
+        except httpx.HTTPError as exc:
+            shutil.rmtree(tmp, ignore_errors=True)
+            typer.echo(f"Error: download failed: {exc}", err=True)
+            raise typer.Exit(1) from exc
+
+        return _extract_zip_to_plugin(zip_path, tmp)
 
     # Git URL
     if target.startswith(("https://", "git@", "http://")) and (
@@ -150,42 +207,27 @@ def _resolve_source(target: str) -> tuple[Path, Path | None]:
 
     # Zip file
     if p.is_file() and p.suffix == ".zip":
-        import zipfile
-
         tmp = Path(tempfile.mkdtemp(prefix="kimi-plugin-"))
         typer.echo(f"Extracting {p.name}...")
-        with zipfile.ZipFile(p, "r") as zf:
-            # Reject zip members that escape the extraction directory
-            for member in zf.namelist():
-                member_path = (tmp / member).resolve()
-                if not member_path.is_relative_to(tmp.resolve()):
-                    shutil.rmtree(tmp, ignore_errors=True)
-                    typer.echo(f"Error: zip contains unsafe path: {member}", err=True)
-                    raise typer.Exit(1)
-            zf.extractall(tmp)
-        # Find the directory containing plugin.json (may be nested one level)
-        for candidate in [tmp] + sorted(tmp.iterdir()):
-            if candidate.is_dir() and (candidate / "plugin.json").exists():
-                return candidate, tmp
-        # Check for __MACOSX and similar artifacts
-        dirs = [d for d in tmp.iterdir() if d.is_dir() and not d.name.startswith("_")]
-        if len(dirs) == 1 and (dirs[0] / "plugin.json").exists():
-            return dirs[0], tmp
-        shutil.rmtree(tmp, ignore_errors=True)
-        typer.echo("Error: No plugin.json found in zip", err=True)
-        raise typer.Exit(1)
+        return _extract_zip_to_plugin(p, tmp)
 
     # Local directory
     if p.is_dir():
         return p, None
 
-    typer.echo(f"Error: {target} is not a directory, zip file, or git URL", err=True)
+    typer.echo(
+        f"Error: {target} is not a directory, zip file, zip URL, or git URL",
+        err=True,
+    )
     raise typer.Exit(1)
 
 
 @cli.command("install")
 def install_cmd(
-    target: Annotated[str, typer.Argument(help="Plugin source: directory, .zip, or git URL")],
+    target: Annotated[
+        str,
+        typer.Argument(help="Plugin source: directory, .zip file, .zip URL, or git URL"),
+    ],
 ) -> None:
     """Install a plugin and inject host configuration."""
     import shutil

--- a/src/kimi_cli/cli/plugin.py
+++ b/src/kimi_cli/cli/plugin.py
@@ -66,14 +66,19 @@ def _extract_zip_to_plugin(zip_path: Path, tmp: Path) -> tuple[Path, Path]:
     import shutil
     import zipfile
 
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        for member in zf.namelist():
-            member_path = (tmp / member).resolve()
-            if not member_path.is_relative_to(tmp.resolve()):
-                shutil.rmtree(tmp, ignore_errors=True)
-                typer.echo(f"Error: zip contains unsafe path: {member}", err=True)
-                raise typer.Exit(1)
-        zf.extractall(tmp)
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            for member in zf.namelist():
+                member_path = (tmp / member).resolve()
+                if not member_path.is_relative_to(tmp.resolve()):
+                    shutil.rmtree(tmp, ignore_errors=True)
+                    typer.echo(f"Error: zip contains unsafe path: {member}", err=True)
+                    raise typer.Exit(1)
+            zf.extractall(tmp)
+    except zipfile.BadZipFile as exc:
+        shutil.rmtree(tmp, ignore_errors=True)
+        typer.echo(f"Error: invalid zip archive: {exc}", err=True)
+        raise typer.Exit(1) from exc
 
     for candidate in [tmp] + sorted(tmp.iterdir()):
         if candidate.is_dir() and (candidate / "plugin.json").exists():

--- a/tests/core/test_plugin.py
+++ b/tests/core/test_plugin.py
@@ -640,3 +640,14 @@ def test_resolve_source_zip_url_download_failure(tmp_path: Path, monkeypatch: py
     with pytest.raises(typer.Exit):
         _resolve_source("https://example.com/missing.zip")
     assert not (tmp_path / "tmp").exists()
+
+
+def test_resolve_source_zip_url_invalid_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Non-ZIP body (e.g. HTML 200) should exit cleanly and clean up tmp."""
+    monkeypatch.setattr("tempfile.mkdtemp", lambda **kw: str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    _patch_httpx_stream(monkeypatch, b"<html>not a zip</html>")
+
+    with pytest.raises(typer.Exit):
+        _resolve_source("https://example.com/broken.zip")
+    assert not (tmp_path / "tmp").exists()

--- a/tests/core/test_plugin.py
+++ b/tests/core/test_plugin.py
@@ -543,3 +543,106 @@ def test_resolve_source_git_no_branch_omits_flag(tmp_path: Path, monkeypatch: py
         _resolve_source("https://github.com/org/repo.git/my-plugin")
     cmd = mock_run.call_args[0][0]
     assert "--branch" not in cmd
+
+
+# --- _resolve_source zip URL tests ---
+
+
+def _build_plugin_zip(plugin_name: str = "my-plugin") -> bytes:
+    """Build an in-memory zip containing a single plugin directory."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            f"{plugin_name}/plugin.json",
+            json.dumps({"name": plugin_name, "version": "1.0.0"}),
+        )
+    return buf.getvalue()
+
+
+def _patch_httpx_stream(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> None:
+    """Replace httpx.stream so it yields ``payload`` from a fake response."""
+    import httpx
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield payload
+
+    class _FakeStream:
+        def __enter__(self):
+            return _FakeResponse()
+
+        def __exit__(self, *exc_info):
+            return False
+
+    monkeypatch.setattr(httpx, "stream", lambda *a, **kw: _FakeStream())
+
+
+def test_resolve_source_zip_url_downloads_and_extracts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """HTTP URL ending with .zip should download and extract."""
+    monkeypatch.setattr("tempfile.mkdtemp", lambda **kw: str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    _patch_httpx_stream(monkeypatch, _build_plugin_zip("my-plugin"))
+
+    source, tmp_dir = _resolve_source("https://example.com/my-plugin.zip")
+    assert source.name == "my-plugin"
+    assert (source / "plugin.json").exists()
+    assert tmp_dir is not None
+
+
+def test_resolve_source_zip_url_with_query_string(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """URL path ending in .zip is detected even with a query string."""
+    monkeypatch.setattr("tempfile.mkdtemp", lambda **kw: str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    _patch_httpx_stream(monkeypatch, _build_plugin_zip("plug"))
+
+    source, _ = _resolve_source("https://example.com/plug.zip?token=abc")
+    assert source.name == "plug"
+
+
+def test_resolve_source_github_archive_zip_takes_zip_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """GitHub archive .zip URLs should download, not be treated as git clone."""
+    monkeypatch.setattr("tempfile.mkdtemp", lambda **kw: str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    _patch_httpx_stream(monkeypatch, _build_plugin_zip("repo-main"))
+
+    with patch("subprocess.run") as mock_run:
+        source, _ = _resolve_source(
+            "https://github.com/org/repo/archive/refs/heads/main.zip"
+        )
+    mock_run.assert_not_called()
+    assert (source / "plugin.json").exists()
+
+
+def test_resolve_source_zip_url_download_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """HTTP error during download should exit cleanly and clean up tmp."""
+    import httpx
+
+    monkeypatch.setattr("tempfile.mkdtemp", lambda **kw: str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+
+    class _FailingStream:
+        def __enter__(self):
+            raise httpx.ConnectError("boom")
+
+        def __exit__(self, *exc_info):
+            return False
+
+    monkeypatch.setattr(httpx, "stream", lambda *a, **kw: _FailingStream())
+
+    with pytest.raises(typer.Exit):
+        _resolve_source("https://example.com/missing.zip")
+    assert not (tmp_path / "tmp").exists()

--- a/tests/core/test_plugin.py
+++ b/tests/core/test_plugin.py
@@ -597,9 +597,7 @@ def test_resolve_source_zip_url_downloads_and_extracts(
     assert tmp_dir is not None
 
 
-def test_resolve_source_zip_url_with_query_string(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_resolve_source_zip_url_with_query_string(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """URL path ending in .zip is detected even with a query string."""
     monkeypatch.setattr("tempfile.mkdtemp", lambda **kw: str(tmp_path / "tmp"))
     (tmp_path / "tmp").mkdir()
@@ -618,16 +616,12 @@ def test_resolve_source_github_archive_zip_takes_zip_path(
     _patch_httpx_stream(monkeypatch, _build_plugin_zip("repo-main"))
 
     with patch("subprocess.run") as mock_run:
-        source, _ = _resolve_source(
-            "https://github.com/org/repo/archive/refs/heads/main.zip"
-        )
+        source, _ = _resolve_source("https://github.com/org/repo/archive/refs/heads/main.zip")
     mock_run.assert_not_called()
     assert (source / "plugin.json").exists()
 
 
-def test_resolve_source_zip_url_download_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_resolve_source_zip_url_download_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """HTTP error during download should exit cleanly and clean up tmp."""
     import httpx
 


### PR DESCRIPTION
## Summary
- `kimi plugin install` now accepts http(s) URLs that point to a `.zip` archive — the file is streamed to a temp dir via `httpx` and then runs through the existing extraction path.
- The zip URL branch is checked **before** the git-URL heuristic, so GitHub/GitLab archive links such as `https://github.com/owner/repo/archive/refs/heads/main.zip` no longer get misrouted into `git clone`.
- Zip extraction (path-traversal guard + `plugin.json` discovery) is factored into a shared helper so local `.zip` files and remote `.zip` URLs go through the same code.
- Help text and the en/zh plugin docs updated with the new usage.

## Test plan
- [x] `uv run pytest tests/core/test_plugin.py` — 47 passed (4 new cases: happy path, query string, GitHub archive URL skips git clone, download failure cleans up tmp).
- [x] End-to-end: `kimi plugin install https://cdn.kimi.com/kimi-code-plugins/kimi-datasource.zip` on a clean `~/.kimi/plugins/` installs `kimi-datasource v2.0.0`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
