### PR TITLE
chore(release): bump kimi-cli to 1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+## 1.41.0 (2026-04-30)
+
+- Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources
 - Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
 
 ## 1.40.0 (2026-04-28)

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,9 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+## 1.41.0 (2026-04-30)
+
+- Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources
 - Shell: Enable clipboard image paste on headless Linux over SSH — when pyperclip is unavailable (e.g. DISPLAY is not set), Ctrl-V now falls back to xclip or wl-paste so remote clipboard bridges can still inject images; also prevents a UI crash from built-in clipboard shortcuts when pyperclip is broken
 
 ## 1.40.0 (2026-04-28)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,9 @@
 
 ## 未发布
 
+## 1.41.0 (2026-04-30)
+
+- Plugin：支持直接从 `.zip` URL 安装插件——`kimi plugin install` 现在可以接受以 `.zip` 结尾的 HTTP(S) URL（例如 GitHub/GitLab 的 archive 链接 `.../archive/refs/heads/main.zip`），下载后解压再解析 `plugin.json`，与原有的 git URL、本地目录、本地 zip 文件三种来源并列
 - Shell：在无显示环境的 Linux（如 SSH 远程）上启用剪贴板图片粘贴——当 pyperclip 不可用（例如 DISPLAY 未设置）时，Ctrl-V 现在会回退到 xclip 或 wl-paste，使远程剪贴板桥接仍能注入图片；同时防止 pyperclip 失效时内置剪贴板快捷键造成 UI 崩溃
 
 ## 1.40.0 (2026-04-28)

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.40.0"
+version = "1.41.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.40.0"]
+dependencies = ["kimi-cli==1.41.0"]
 
 [project.scripts]
 kimi-code = "kimi_cli.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.40.0"
+version = "1.41.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.40.0"
+version = "1.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1300,7 +1300,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.40.0"
+version = "1.41.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },


### PR DESCRIPTION
## Summary

Bump root `kimi-cli` and `packages/kimi-code` from 1.40.0 to 1.41.0. No changes to kosong / pykaos / kimi-sdk this round.

## Changes included in 1.41.0

- Plugin: Support installing plugins directly from a `.zip` URL (#2126)
- Shell: Enable clipboard image paste on headless Linux over SSH (#2115)

## Files changed

- `pyproject.toml` — version bump
- `packages/kimi-code/pyproject.toml` — version bump + sync `kimi-cli==1.41.0` dep
- `CHANGELOG.md` — add 1.41.0 section, keep `## Unreleased` empty
- `docs/en/release-notes/changelog.md` — synced via `sync-changelog.mjs`
- `docs/zh/release-notes/changelog.md` — translated 1.41.0 entries
- `uv.lock` — refreshed

## Test plan

- [ ] CI green
- [ ] After merge: `git tag 1.41.0 && git push --tags` to trigger release-kimi-cli workflow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
