### PR TITLE
fix(acp): replay session history on load

### DIFF
--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -265,8 +265,8 @@ class ACPServer:
         # Check authentication before loading session
         self._check_auth()
 
-        await self._setup_session(cwd, session_id, mcp_servers)
-        # TODO: replay session history?
+        acp_session, _ = await self._setup_session(cwd, session_id, mcp_servers)
+        await acp_session.replay_history(acp_session.cli.soul.runtime.session.wire_file)
 
     async def resume_session(
         self, cwd: str, session_id: str, mcp_servers: list[MCPServer] | None = None, **kwargs: Any

--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -19,6 +19,7 @@ from kimi_cli.app import KimiCLI
 from kimi_cli.soul import LLMNotSet, LLMNotSupported, MaxStepsReached, RunCancelled
 from kimi_cli.tools import extract_key_argument
 from kimi_cli.utils.logging import logger
+from kimi_cli.wire.file import WireFile
 from kimi_cli.wire.types import (
     ApprovalRequest,
     ApprovalResponse,
@@ -243,12 +244,95 @@ class ACPSession:
             _current_turn_id.reset(token)
         return acp.PromptResponse(stop_reason="end_turn")
 
+    async def replay_history(self, wire_file: WireFile) -> None:
+        """Replay persisted wire history to an ACP client during session/load."""
+        token = _current_turn_id.set(None)
+        terminal_tool_calls_token = _terminal_tool_call_ids.set(set())
+        try:
+            async for record in wire_file.iter_records():
+                wire_msg = record.to_wire_message()
+                match wire_msg:
+                    case TurnBegin(user_input=user_input) | SteerInput(user_input=user_input):
+                        self._turn_state = _TurnState()
+                        _current_turn_id.set(self._turn_state.id)
+                        await self._send_user_input(user_input)
+                    case TurnEnd() | StepInterrupted():
+                        self._turn_state = None
+                        _current_turn_id.set(None)
+                    case StepBegin():
+                        pass
+                    case CompactionBegin() | CompactionEnd():
+                        pass
+                    case MCPLoadingBegin() | MCPLoadingEnd():
+                        pass
+                    case StatusUpdate():
+                        pass
+                    case Notification():
+                        await self._send_notification(wire_msg)
+                    case ThinkPart(think=think):
+                        await self._send_thinking(think)
+                    case TextPart(text=text):
+                        await self._send_text(text)
+                    case ContentPart():
+                        await self._send_text(f"[{wire_msg.__class__.__name__}]")
+                    case ToolCall():
+                        self._ensure_turn_state()
+                        await self._send_tool_call(wire_msg)
+                    case ToolCallPart():
+                        if self._turn_state is not None:
+                            await self._send_tool_call_part(wire_msg)
+                    case ToolResult():
+                        if self._turn_state is not None:
+                            await self._send_tool_result(wire_msg)
+                    case PlanDisplay():
+                        pass
+                    case ApprovalResponse() | SubagentEvent():
+                        pass
+                    case ApprovalRequest() | ToolCallRequest() | QuestionRequest():
+                        pass
+                    case _:
+                        pass
+        except Exception:
+            logger.exception(
+                "Failed to replay ACP session history from {file}:", file=wire_file.path
+            )
+        finally:
+            self._turn_state = None
+            _terminal_tool_call_ids.reset(terminal_tool_calls_token)
+            _current_turn_id.reset(token)
+
     async def cancel(self) -> None:
         if self._turn_state is None:
             logger.warning("Cancel requested but no prompt is running")
             return
 
         self._turn_state.cancel_event.set()
+
+    def _ensure_turn_state(self) -> None:
+        if self._turn_state is None:
+            self._turn_state = _TurnState()
+            _current_turn_id.set(self._turn_state.id)
+
+    async def _send_user_input(self, user_input: str | list[ContentPart]) -> None:
+        if not self._id or not self._conn:
+            return
+
+        parts = [TextPart(text=user_input)] if isinstance(user_input, str) else user_input
+        for part in parts:
+            if isinstance(part, TextPart):
+                content: ACPContentBlock = acp.schema.TextContentBlock(type="text", text=part.text)
+            else:
+                logger.warning("Unsupported replay user input part: {part}", part=part)
+                content = acp.schema.TextContentBlock(
+                    type="text", text=f"[{part.__class__.__name__}]"
+                )
+            await self._conn.session_update(
+                session_id=self._id,
+                update=acp.schema.UserMessageChunk(
+                    content=content,
+                    session_update="user_message_chunk",
+                ),
+            )
 
     async def _send_thinking(self, think: str):
         """Send thinking content to client."""

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -652,6 +652,7 @@ class KimiCLI:
                     user_input,
                     _ui_loop_fn,
                     run_cancel_event,
+                    self._runtime.session.wire_file,
                     runtime=self._runtime,
                 )
             )

--- a/tests/acp/conftest.py
+++ b/tests/acp/conftest.py
@@ -19,7 +19,9 @@ def _repo_root() -> Path:
 
 def _kimi_bin() -> str:
     """Return the path to the kimi entry-point script inside the venv."""
-    return str(_repo_root() / ".venv" / "bin" / "kimi")
+    script_dir = "Scripts" if os.name == "nt" else "bin"
+    executable = "kimi.exe" if os.name == "nt" else "kimi"
+    return str(_repo_root() / ".venv" / script_dir / executable)
 
 
 class ACPTestClient:

--- a/tests/acp/test_protocol_v1.py
+++ b/tests/acp/test_protocol_v1.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import os
+
 import acp
 import pytest
 
 from kimi_cli.acp.version import CURRENT_VERSION
 
-from .conftest import ACPTestClient
+from .conftest import ACPTestClient, _kimi_bin, _repo_root
 
 pytestmark = pytest.mark.asyncio
 
@@ -146,6 +148,52 @@ async def test_resume_session_not_found(
             cwd=str(work_dir),
             session_id="non-existent-session-id",
         )
+
+
+async def test_load_session_replays_history(acp_share_dir, tmp_path):
+    """session/load should replay persisted messages after the ACP server restarts."""
+    work_dir = tmp_path / "workdir"
+    work_dir.mkdir(exist_ok=True)
+    env = {**os.environ, "KIMI_SHARE_DIR": str(acp_share_dir)}
+
+    client1 = ACPTestClient()
+    async with acp.spawn_agent_process(
+        client1,
+        _kimi_bin(),
+        "acp",
+        env=env,
+        cwd=str(_repo_root()),
+        use_unstable_protocol=True,
+    ) as (conn, _):
+        await conn.initialize(protocol_version=1)
+        session_resp = await conn.new_session(cwd=str(work_dir))
+        await conn.prompt(
+            prompt=[acp.text_block("Hello")],
+            session_id=session_resp.session_id,
+        )
+
+    client2 = ACPTestClient()
+    async with acp.spawn_agent_process(
+        client2,
+        _kimi_bin(),
+        "acp",
+        env=env,
+        cwd=str(_repo_root()),
+        use_unstable_protocol=True,
+    ) as (conn, _):
+        await conn.initialize(protocol_version=1)
+        await conn.load_session(cwd=str(work_dir), session_id=session_resp.session_id)
+
+    update_types = [update.session_update for update in client2.updates]
+    update_texts = [
+        update.content.text
+        for update in client2.updates
+        if hasattr(update, "content") and update.content.type == "text"
+    ]
+    assert "user_message_chunk" in update_types
+    assert "agent_message_chunk" in update_types
+    assert "Hello" in update_texts
+    assert "Hello from scripted echo!" in update_texts
 
 
 async def test_cancel_session(


### PR DESCRIPTION
## Summary
- persist wire history for ACP runs so loaded sessions have replayable events
- replay persisted user, assistant, thought, and tool updates during `session/load`
- fix the ACP test fixture to locate the virtualenv `kimi` entrypoint on Windows

## Tests
- `uv run pytest tests/acp -q`
- `uv run ruff check src\kimi_cli\app.py src\kimi_cli\acp\session.py src\kimi_cli\acp\server.py tests\acp\conftest.py tests\acp\test_protocol_v1.py`
- `uv run ruff format src\kimi_cli\app.py src\kimi_cli\acp\session.py src\kimi_cli\acp\server.py tests\acp\conftest.py tests\acp\test_protocol_v1.py --check`
- `uv run pyright src/kimi_cli/app.py src/kimi_cli/acp/session.py src/kimi_cli/acp/server.py tests/acp/conftest.py tests/acp/test_protocol_v1.py`

Fixes #2127
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
