### PR TITLE
fix(agent): include AGENTS.md for custom prompts

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -512,8 +512,39 @@ def _load_system_prompt(
     )
     try:
         template = env.from_string(system_prompt)
-        return template.render(asdict(builtin_args), **args)
+        rendered = template.render(asdict(builtin_args), **args)
+        return _ensure_agents_md_in_system_prompt(rendered, builtin_args)
     except UndefinedError as exc:
         raise SystemPromptTemplateError(f"Missing system prompt arg in {path}: {exc}") from exc
     except TemplateError as exc:
         raise SystemPromptTemplateError(f"Invalid system prompt template: {path}: {exc}") from exc
+
+
+def _ensure_agents_md_in_system_prompt(
+    system_prompt: str, builtin_args: BuiltinSystemPromptArgs
+) -> str:
+    agents_md = builtin_args.KIMI_AGENTS_MD.strip()
+    if not agents_md or agents_md in system_prompt:
+        return system_prompt
+
+    agents_guidance = (
+        "`AGENTS.md` files can appear at any level of the project directory tree, "
+        "including inside `.kimi/` directories. Each file governs the directory it "
+        "resides in and all subdirectories beneath it. When multiple `AGENTS.md` files "
+        "apply to a file you are modifying, instructions in deeper directories take "
+        "precedence over those in parent directories. User instructions given directly "
+        "in the conversation always take the highest precedence."
+    )
+
+    return f"""{system_prompt}
+
+# Project Information
+
+The `AGENTS.md` instructions (merged from all applicable directories):
+
+`````````
+{agents_md}
+`````````
+
+{agents_guidance}
+"""

--- a/tests/core/test_load_agent.py
+++ b/tests/core/test_load_agent.py
@@ -48,6 +48,7 @@ def test_system_prompt_contains_platform_info(builtin_args: BuiltinSystemPromptA
     # System prompt must include OS kind and shell info
     assert builtin_args.KIMI_OS in prompt
     assert builtin_args.KIMI_SHELL in prompt
+    assert prompt.count(builtin_args.KIMI_AGENTS_MD) == 1
 
 
 @pytest.mark.parametrize(
@@ -85,6 +86,21 @@ def test_system_prompt_platform_warning(temp_work_dir, os_kind, shell, expect_wi
         assert "Many common Unix commands are not available" in prompt
     else:
         assert "Many common Unix commands are not available" not in prompt
+
+
+def test_load_system_prompt_appends_agents_md_for_custom_prompt(
+    builtin_args: BuiltinSystemPromptArgs,
+):
+    """Custom prompts should still receive project instructions from AGENTS.md."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        system_md = tmpdir / "system.md"
+        system_md.write_text("You are a custom agent.")
+        prompt = _load_system_prompt(system_md, {}, builtin_args)
+
+    assert "You are a custom agent." in prompt
+    assert "The `AGENTS.md` instructions" in prompt
+    assert builtin_args.KIMI_AGENTS_MD in prompt
 
 
 def test_load_system_prompt_allows_literal_dollar(builtin_args: BuiltinSystemPromptArgs):


### PR DESCRIPTION
## Summary
- ensure custom agent prompts receive merged AGENTS.md instructions even when they do not reference KIMI_AGENTS_MD
- avoid duplicating AGENTS.md when the prompt already includes it
- add coverage for custom prompts and the default prompt path

## Tests
- uv run pytest tests\core\test_load_agents_md.py tests\core\test_load_agent.py -q
- uv run ruff check src\kimi_cli\soul\agent.py tests\core\test_load_agent.py
- uv run ruff format --check src\kimi_cli\soul\agent.py tests\core\test_load_agent.py
- uv run pyright src\kimi_cli\soul\agent.py tests\core\test_load_agent.py

Fixes #2058
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
