### PR TITLE
fix(shell): ignore xterm focus events

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -35,6 +35,7 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Condition, has_completions, has_focus, is_done
 from prompt_toolkit.formatted_text import AnyFormattedText, FormattedText, to_formatted_text
 from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout.containers import (
@@ -1168,6 +1169,13 @@ def _build_toolbar_tips(clipboard_available: bool) -> list[str]:
 
 
 _TIP_SEPARATOR = " | "
+_XTERM_FOCUS_EVENT_SEQUENCES = ("\x1b[I", "\x1b[O")
+
+
+def _register_xterm_focus_event_sequences() -> None:
+    """Consume xterm focus in/out reports instead of inserting "[I"/"[O"."""
+    for sequence in _XTERM_FOCUS_EVENT_SEQUENCES:
+        ANSI_SEQUENCES.setdefault(sequence, Keys.Ignore)
 
 
 class CustomPromptSession:
@@ -1217,6 +1225,7 @@ class CustomPromptSession:
         self._suspended_buffer_document: Document | None = None
         clipboard_available = is_clipboard_available()
         media_clipboard_available = is_media_clipboard_available()
+        _register_xterm_focus_event_sequences()
         self._tips = _build_toolbar_tips(clipboard_available or media_clipboard_available)
         self._tip_rotation_index: int = random.randrange(len(self._tips)) if self._tips else 0
 

--- a/tests/ui_and_conv/test_prompt_focus_events.py
+++ b/tests/ui_and_conv/test_prompt_focus_events.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.key_binding.key_processor import KeyPress
+from prompt_toolkit.keys import Keys
+
+from kimi_cli.ui.shell.prompt import _register_xterm_focus_event_sequences
+
+
+def _parse_vt100(data: str) -> list[KeyPress]:
+    key_presses: list[KeyPress] = []
+    parser = Vt100Parser(key_presses.append)
+    parser.feed(data)
+    parser.flush()
+    return key_presses
+
+
+def test_xterm_focus_event_sequences_are_ignored():
+    """xterm focus in/out reports should not leak into the prompt buffer."""
+    _register_xterm_focus_event_sequences()
+
+    for sequence in ("\x1b[I", "\x1b[O"):
+        key_presses = _parse_vt100(sequence)
+
+        assert len(key_presses) == 1
+        assert key_presses[0].key == Keys.Ignore


### PR DESCRIPTION
## Summary
- register xterm focus-in/focus-out reports (`ESC [ I` / `ESC [ O`) as `Keys.Ignore` before creating the shell prompt
- add parser coverage to ensure focus reports are consumed instead of leaking `[I` / `[O` into input

## Tests
- uv run pytest tests\ui_and_conv\test_prompt_focus_events.py -q
- uv run ruff check src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_focus_events.py
- uv run ruff format --check src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_focus_events.py
- uv run pyright src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_focus_events.py

Note: I also ran `uv run pytest tests\ui_and_conv\test_prompt_focus_events.py tests\ui_and_conv\test_prompt_clipboard.py -q` on Windows. The new focus-event test passed, while two existing clipboard tests failed because they assert POSIX `/tmp/...` path strings that `Path` renders with backslashes on Windows.

Fixes #2107
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
