### PR TITLE
fix(shell): throttle toolbar git metadata

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -876,6 +876,7 @@ _RUNNING_REFRESH_INTERVAL = 0.1
 
 _GIT_BRANCH_TTL = 5.0
 _GIT_STATUS_TTL = 15.0
+_TOOLBAR_GIT_REFRESH_INTERVAL = 1.0
 _TIP_ROTATE_INTERVAL = 30.0
 _MAX_CWD_COLS = 30
 _MAX_BRANCH_COLS = 22
@@ -895,6 +896,14 @@ class _GitStatusState:
     ahead: int = 0
     behind: int = 0
     proc: subprocess.Popen[str] | None = None
+
+
+@dataclass
+class _ToolbarGitState:
+    timestamp: float = 0.0
+    cwd: str | None = None
+    branch: str | None = None
+    status: tuple[bool, int, int] = (False, 0, 0)
 
 
 _git_branch_state = _GitBranchState()
@@ -1215,6 +1224,7 @@ class CustomPromptSession:
         self._prompt_buffer_container: ConditionalContainer | None = None
         self._last_ui_state: PromptUIState = PromptUIState.NORMAL_INPUT
         self._suspended_buffer_document: Document | None = None
+        self._toolbar_git_state = _ToolbarGitState()
         clipboard_available = is_clipboard_available()
         media_clipboard_available = is_media_clipboard_available()
         self._tips = _build_toolbar_tips(clipboard_available or media_clipboard_available)
@@ -1836,6 +1846,24 @@ class CustomPromptSession:
             return FormattedText([])
         return to_formatted_text(block)
 
+    def _get_toolbar_git_metadata(self, cwd: str) -> tuple[str | None, tuple[bool, int, int]]:
+        state = getattr(self, "_toolbar_git_state", None)
+        if state is None:
+            state = _ToolbarGitState()
+            self._toolbar_git_state = state
+
+        now = time.monotonic()
+        if state.cwd == cwd and now - state.timestamp < _TOOLBAR_GIT_REFRESH_INTERVAL:
+            return state.branch, state.status
+
+        branch = _get_git_branch()
+        status = _get_git_status() if branch else (False, 0, 0)
+        state.cwd = cwd
+        state.timestamp = now
+        state.branch = branch
+        state.status = status
+        return branch, status
+
     def _render_agent_prompt_label(self) -> FormattedText:
         """Render the prompt label (empty — cursor starts at column 0)."""
         return FormattedText([("", "  ")])
@@ -2145,7 +2173,8 @@ class CustomPromptSession:
         # CWD (truncated from left) + git branch with status badge
         # Degrade gracefully on narrow terminals: full → cwd-only → truncated cwd → skip
         try:
-            cwd = _truncate_left(_shorten_cwd(str(KaosPath.cwd())), _MAX_CWD_COLS)
+            cwd_path = str(KaosPath.cwd())
+            cwd = _truncate_left(_shorten_cwd(cwd_path), _MAX_CWD_COLS)
         except OSError:
             # CWD no longer exists (e.g. external drive unplugged).  Ask
             # prompt_toolkit to exit; the raised exception will propagate out
@@ -2153,9 +2182,9 @@ class CustomPromptSession:
             # crash report with session info and exits cleanly.
             app.exit(exception=CwdLostError())
             return FormattedText([])
-        branch = _get_git_branch()
+        branch, git_status = self._get_toolbar_git_metadata(cwd_path)
         if branch:
-            dirty, ahead, behind = _get_git_status()
+            dirty, ahead, behind = git_status
             branch = _truncate_right(branch, _MAX_BRANCH_COLS)
             badge = _format_git_badge(branch, dirty, ahead, behind)
             cwd_text = f"{cwd}  {badge}"

--- a/tests/ui_and_conv/test_prompt_tips.py
+++ b/tests/ui_and_conv/test_prompt_tips.py
@@ -13,6 +13,7 @@ from kimi_cli.soul import StatusSnapshot
 from kimi_cli.ui.shell import prompt as shell_prompt
 from kimi_cli.ui.shell.prompt import (
     _GIT_STATUS_TTL,
+    _TOOLBAR_GIT_REFRESH_INTERVAL,
     PROMPT_SYMBOL,
     BgTaskCounts,
     CustomPromptSession,
@@ -578,6 +579,77 @@ def test_git_status_not_called_when_branch_is_none(monkeypatch: Any) -> None:
     prompt_session._render_bottom_toolbar()
 
     assert status_call_count == 0, "_get_git_status must not be called when branch is None"
+
+
+def test_bottom_toolbar_throttles_git_metadata_between_renders(monkeypatch: Any) -> None:
+    branch_call_count = 0
+    status_call_count = 0
+
+    def _fake_branch() -> str:
+        nonlocal branch_call_count
+        branch_call_count += 1
+        return "main"
+
+    def _fake_status() -> tuple[bool, int, int]:
+        nonlocal status_call_count
+        status_call_count += 1
+        return (False, 0, 0)
+
+    class _DummyOutput:
+        @staticmethod
+        def get_size() -> Any:
+            return SimpleNamespace(columns=80)
+
+    monkeypatch.setattr(
+        shell_prompt, "get_app_or_none", lambda: SimpleNamespace(output=_DummyOutput())
+    )
+    monkeypatch.setattr(shell_prompt, "_get_git_branch", _fake_branch)
+    monkeypatch.setattr(shell_prompt, "_get_git_status", _fake_status)
+    monkeypatch.setattr(shell_prompt, "_shorten_cwd", lambda _: "~/proj")
+    monkeypatch.setattr(shell_prompt.time, "monotonic", lambda: 100.0)
+    _toast_queues["left"].clear()
+    _toast_queues["right"].clear()
+
+    prompt_session = _make_toolbar_session()
+
+    prompt_session._render_bottom_toolbar()
+    prompt_session._render_bottom_toolbar()
+
+    assert branch_call_count == 1
+    assert status_call_count == 1
+
+
+def test_bottom_toolbar_refreshes_git_metadata_after_throttle(monkeypatch: Any) -> None:
+    branch_call_count = 0
+    now = 100.0
+
+    def _fake_branch() -> str:
+        nonlocal branch_call_count
+        branch_call_count += 1
+        return "main"
+
+    class _DummyOutput:
+        @staticmethod
+        def get_size() -> Any:
+            return SimpleNamespace(columns=80)
+
+    monkeypatch.setattr(
+        shell_prompt, "get_app_or_none", lambda: SimpleNamespace(output=_DummyOutput())
+    )
+    monkeypatch.setattr(shell_prompt, "_get_git_branch", _fake_branch)
+    monkeypatch.setattr(shell_prompt, "_get_git_status", lambda: (False, 0, 0))
+    monkeypatch.setattr(shell_prompt, "_shorten_cwd", lambda _: "~/proj")
+    monkeypatch.setattr(shell_prompt.time, "monotonic", lambda: now)
+    _toast_queues["left"].clear()
+    _toast_queues["right"].clear()
+
+    prompt_session = _make_toolbar_session()
+
+    prompt_session._render_bottom_toolbar()
+    now += _TOOLBAR_GIT_REFRESH_INTERVAL + 0.1
+    prompt_session._render_bottom_toolbar()
+
+    assert branch_call_count == 2
 
 
 # ── Prompt layout (separator, running/idle message) ───────────────────────────


### PR DESCRIPTION
## Summary
- cache toolbar git branch/status metadata per prompt session for a short interval
- keep `_render_bottom_toolbar()` from polling git subprocess state on every keystroke redraw
- add regression coverage for repeated toolbar renders and refresh after the throttle interval

## Tests
- uv run pytest tests\ui_and_conv\test_prompt_tips.py -q -k "git_metadata or git_status_not_called or git_branch_change or git_status_stuck or git_status_recent"
- uv run ruff check src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_tips.py
- uv run ruff format --check src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_tips.py
- uv run pyright src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_tips.py

Note: I also ran the full `uv run pytest tests\ui_and_conv\test_prompt_tips.py -q` on Windows. The git toolbar tests passed, but existing Windows/non-console-sensitive tests failed: one `_shorten_cwd` assertion expects POSIX separators, and several tests construct a real `PromptSession` without a Win32 console buffer in this environment.

Fixes #2038

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
