### PR TITLE
fix(shell): reduce hidden modal input latency

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1530,7 +1530,7 @@ class CustomPromptSession:
         def _(buffer: Buffer) -> None:
             self._last_input_activity_time = time.monotonic()
             self._input_activity_event.set()
-            if buffer.complete_while_typing() and not self._suppress_auto_completion:
+            if self._should_start_completion_on_text_change(buffer):
                 buffer.start_completion()
 
         self._status_refresh_task: asyncio.Task[None] | None = None
@@ -1836,6 +1836,18 @@ class CustomPromptSession:
             return FormattedText([])
         return to_formatted_text(block)
 
+    def _should_start_completion_on_text_change(self, buffer: Buffer) -> bool:
+        if self._suppress_auto_completion or not buffer.complete_while_typing():
+            return False
+        delegate = self._active_prompt_delegate()
+        return delegate is None or not delegate.running_prompt_hides_input_buffer()
+
+    def _should_use_running_refresh_interval(self) -> bool:
+        delegate = self._active_prompt_delegate()
+        if delegate is not None and not delegate.running_prompt_hides_input_buffer():
+            return True
+        return self._fast_refresh_provider is not None and self._fast_refresh_provider()
+
     def _render_agent_prompt_label(self) -> FormattedText:
         """Render the prompt label (empty — cursor starts at column 0)."""
         return FormattedText([("", "  ")])
@@ -1860,11 +1872,7 @@ class CustomPromptSession:
 
                     interval = (
                         _RUNNING_REFRESH_INTERVAL
-                        if self._active_prompt_delegate() is not None
-                        or (
-                            self._fast_refresh_provider is not None
-                            and self._fast_refresh_provider()
-                        )
+                        if self._should_use_running_refresh_interval()
                         else _IDLE_REFRESH_INTERVAL
                     )
                     await asyncio.sleep(interval)

--- a/tests/ui_and_conv/test_prompt_tips.py
+++ b/tests/ui_and_conv/test_prompt_tips.py
@@ -85,6 +85,14 @@ class _DummyReadOnlyModal:
         raise AssertionError("Should not be called in this test")
 
 
+class _DummyBuffer:
+    def __init__(self, *, complete_while_typing: bool = True) -> None:
+        self._complete_while_typing = complete_while_typing
+
+    def complete_while_typing(self) -> bool:
+        return self._complete_while_typing
+
+
 def _make_toolbar_session(*, model_name: str | None = None, tips: list[str] | None = None) -> Any:
     """Build a minimal CustomPromptSession for toolbar rendering tests."""
     prompt_session = object.__new__(CustomPromptSession)
@@ -733,6 +741,51 @@ def test_modal_prompt_suspends_and_restores_existing_draft_when_input_is_hidden(
 
     assert prompt_session._session.default_buffer.text == "keep this draft"
     assert prompt_session._suspended_buffer_document is None
+
+
+def test_hidden_modal_text_change_skips_completion() -> None:
+    prompt_session = object.__new__(CustomPromptSession)
+    prompt_session._suppress_auto_completion = False
+    prompt_session._running_prompt_delegate = None
+    prompt_session._modal_delegates = [_DummyReadOnlyModal()]
+
+    assert not prompt_session._should_start_completion_on_text_change(cast(Any, _DummyBuffer()))
+
+
+def test_visible_prompt_text_change_allows_completion() -> None:
+    prompt_session = object.__new__(CustomPromptSession)
+    prompt_session._suppress_auto_completion = False
+    prompt_session._running_prompt_delegate = _DummyRunningPrompt()
+    prompt_session._modal_delegates = []
+
+    assert prompt_session._should_start_completion_on_text_change(cast(Any, _DummyBuffer()))
+
+
+def test_hidden_modal_uses_idle_refresh_interval() -> None:
+    prompt_session = object.__new__(CustomPromptSession)
+    prompt_session._running_prompt_delegate = None
+    prompt_session._modal_delegates = [_DummyReadOnlyModal()]
+    prompt_session._fast_refresh_provider = lambda: False
+
+    assert not prompt_session._should_use_running_refresh_interval()
+
+
+def test_hidden_modal_keeps_fast_refresh_provider_override() -> None:
+    prompt_session = object.__new__(CustomPromptSession)
+    prompt_session._running_prompt_delegate = None
+    prompt_session._modal_delegates = [_DummyReadOnlyModal()]
+    prompt_session._fast_refresh_provider = lambda: True
+
+    assert prompt_session._should_use_running_refresh_interval()
+
+
+def test_visible_running_prompt_uses_running_refresh_interval() -> None:
+    prompt_session = object.__new__(CustomPromptSession)
+    prompt_session._running_prompt_delegate = _DummyRunningPrompt()
+    prompt_session._modal_delegates = []
+    prompt_session._fast_refresh_provider = lambda: False
+
+    assert prompt_session._should_use_running_refresh_interval()
 
 
 def test_idle_agent_prompt_uses_same_separator_layout(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- skip completion startup when the active prompt delegate hides the input buffer
- let hidden-input modals use the idle refresh interval unless a fast-refresh provider explicitly requests faster redraws
- add focused tests for hidden modal completion suppression and refresh interval selection

## Tests
- uv run pytest tests\ui_and_conv\test_prompt_tips.py -q -k "hidden_modal_text_change or visible_prompt_text_change or hidden_modal_uses_idle or hidden_modal_keeps_fast or visible_running_prompt_uses_running"
- uv run ruff check src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_tips.py
- uv run ruff format --check src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_tips.py
- uv run pyright src\kimi_cli\ui\shell\prompt.py tests\ui_and_conv\test_prompt_tips.py

Improves #2032

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
