### PR TITLE
fix(hooks): publish permission prompt notifications

### DIFF
--- a/src/kimi_cli/approval_runtime/runtime.py
+++ b/src/kimi_cli/approval_runtime/runtime.py
@@ -19,6 +19,7 @@ from .models import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from kimi_cli.notifications import NotificationManager
     from kimi_cli.wire.root_hub import RootWireHub
     from kimi_cli.wire.types import DisplayBlock
 
@@ -52,11 +53,17 @@ class ApprovalRuntime:
         self._waiter_counts: dict[str, int] = {}
         self._subscribers: dict[str, Callable[[ApprovalRuntimeEvent], None]] = {}
         self._root_wire_hub: RootWireHub | None = None
+        self._notification_manager: NotificationManager | None = None
 
     def bind_root_wire_hub(self, root_wire_hub: RootWireHub) -> None:
         if self._root_wire_hub is root_wire_hub:
             return
         self._root_wire_hub = root_wire_hub
+
+    def bind_notification_manager(self, notification_manager: NotificationManager) -> None:
+        if self._notification_manager is notification_manager:
+            return
+        self._notification_manager = notification_manager
 
     def create_request(
         self,
@@ -81,6 +88,7 @@ class ApprovalRuntime:
         self._requests[request.id] = request
         self._publish_event(ApprovalRuntimeEvent(kind="request_created", request=request))
         self._publish_wire_request(request)
+        self._publish_notification_request(request)
         return request
 
     async def wait_for_response(
@@ -218,6 +226,36 @@ class ApprovalRuntime:
                 source_id=request.source.id,
                 agent_id=request.source.agent_id,
                 subagent_type=request.source.subagent_type,
+            )
+        )
+
+    def _publish_notification_request(self, request: ApprovalRequestRecord) -> None:
+        if self._notification_manager is None:
+            return
+        from kimi_cli.notifications import NotificationEvent
+
+        self._notification_manager.publish(
+            NotificationEvent(
+                id=self._notification_manager.new_id(),
+                category="system",
+                type="permission_prompt",
+                source_kind="approval",
+                source_id=request.id,
+                title=f"Permission requested: {request.sender}",
+                body=request.description,
+                severity="warning",
+                payload={
+                    "request_id": request.id,
+                    "tool_call_id": request.tool_call_id,
+                    "sender": request.sender,
+                    "action": request.action,
+                    "source_kind": request.source.kind,
+                    "source_id": request.source.id,
+                    "agent_id": request.source.agent_id,
+                    "subagent_type": request.source.subagent_type,
+                },
+                targets=["llm", "wire", "shell"],
+                dedupe_key=f"approval:{request.id}:permission_prompt",
             )
         )
 

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -205,6 +205,7 @@ class Runtime:
         if self.approval_runtime is None:
             self.approval_runtime = ApprovalRuntime()
         self.approval_runtime.bind_root_wire_hub(self.root_wire_hub)
+        self.approval_runtime.bind_notification_manager(self.notifications)
         self.approval.set_runtime(self.approval_runtime)
         self.background_tasks.bind_runtime(self)
 

--- a/tests/core/test_approval_runtime.py
+++ b/tests/core/test_approval_runtime.py
@@ -289,6 +289,36 @@ def test_approval_runtime_publishes_to_root_wire_hub() -> None:
     assert msg.response == "reject"
 
 
+def test_runtime_approval_request_publishes_permission_prompt_notification(runtime) -> None:
+    assert runtime.approval_runtime is not None
+
+    request = runtime.approval_runtime.create_request(
+        request_id="req-notify",
+        tool_call_id="call-notify",
+        sender="Shell",
+        action="run command",
+        description="pwd",
+        display=[],
+        source=ApprovalSource(kind="foreground_turn", id="turn-notify"),
+    )
+
+    views = runtime.notifications.store.list_views()
+    assert len(views) == 1
+    event = views[0].event
+    assert event.type == "permission_prompt"
+    assert event.category == "system"
+    assert event.source_kind == "approval"
+    assert event.source_id == request.id
+    assert event.title == "Permission requested: Shell"
+    assert event.body == "pwd"
+    assert event.severity == "warning"
+    assert event.payload["request_id"] == request.id
+    assert event.payload["tool_call_id"] == "call-notify"
+    assert event.payload["sender"] == "Shell"
+    assert event.payload["action"] == "run command"
+    assert event.targets == ["llm", "wire", "shell"]
+
+
 async def _drain_ui_messages(wire: Wire) -> None:
     wire_ui = wire.ui_side(merge=True)
     while True:


### PR DESCRIPTION
## Summary
- bind the approval runtime to the session notification manager
- publish a `permission_prompt` notification whenever a manual approval request is created
- add regression coverage for approval-created notification metadata and targets

## Tests
- `uv run pytest tests\core\test_approval_runtime.py -q`
- `uv run ruff check src\kimi_cli\approval_runtime\runtime.py src\kimi_cli\soul\agent.py tests\core\test_approval_runtime.py`
- `uv run ruff format --check src\kimi_cli\approval_runtime\runtime.py src\kimi_cli\soul\agent.py tests\core\test_approval_runtime.py`
- `uv run pyright src\kimi_cli\approval_runtime\runtime.py src\kimi_cli\soul\agent.py tests\core\test_approval_runtime.py`

Fixes #2048
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
