### PR TITLE
fix(mcp): preserve structured content and sanitize refs

### DIFF
--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -7,10 +7,11 @@ import inspect
 import json
 import time
 from contextvars import ContextVar
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from kosong.tooling import (
     CallableTool,
@@ -574,7 +575,7 @@ class MCPTool[T: ClientTransport](CallableTool):
                 f"This is an MCP (Model Context Protocol) tool from MCP server `{server_name}`.\n\n"
                 f"{mcp_tool.description or 'No description provided.'}"
             ),
-            parameters=mcp_tool.inputSchema,
+            parameters=sanitize_mcp_input_schema(mcp_tool.inputSchema),
             **kwargs,
         )
         self._mcp_tool = mcp_tool
@@ -677,6 +678,29 @@ class WireExternalTool(CallableTool):
 MCP_MAX_OUTPUT_CHARS = 100_000
 
 
+def sanitize_mcp_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a provider-compatible copy of an MCP tool input schema."""
+
+    def _sanitize(value: Any) -> Any:
+        if isinstance(value, dict):
+            mapping = cast(dict[str, Any], value)
+            if "$ref" in mapping:
+                # Moonshot's schema validator rejects metadata siblings after
+                # expanding $ref nodes, even though newer JSON Schema drafts
+                # allow them. Keep only the reference and definition tables.
+                sanitized_ref: dict[str, Any] = {"$ref": mapping["$ref"]}
+                for definitions_key in ("$defs", "definitions"):
+                    if definitions_key in mapping:
+                        sanitized_ref[definitions_key] = _sanitize(mapping[definitions_key])
+                return sanitized_ref
+            return {key: _sanitize(item) for key, item in mapping.items()}
+        if isinstance(value, list):
+            return [_sanitize(item) for item in cast(list[Any], value)]
+        return value
+
+    return _sanitize(deepcopy(schema))
+
+
 def _media_part_size(part: ContentPart) -> int | None:
     """Return the payload size of a media part, or ``None`` for non-media parts."""
     if isinstance(part, ImageURLPart):
@@ -686,6 +710,33 @@ def _media_part_size(part: ContentPart) -> int | None:
     if isinstance(part, VideoURLPart):
         return len(part.video_url.url)
     return None
+
+
+def _append_text_with_budget(
+    content: list[ContentPart],
+    text: str,
+    char_budget: int,
+) -> tuple[int, bool]:
+    if char_budget <= 0:
+        return char_budget, True
+    truncated = False
+    if len(text) > char_budget:
+        text = text[:char_budget]
+        truncated = True
+    content.append(TextPart(text=text))
+    return char_budget - len(text), truncated
+
+
+def _structured_content_part(result: CallToolResult) -> str | None:
+    structured_content = getattr(result, "structured_content", None)
+    if not isinstance(structured_content, dict):
+        return None
+    return "Structured content:\n" + json.dumps(
+        structured_content,
+        ensure_ascii=False,
+        indent=2,
+        default=str,
+    )
 
 
 def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
@@ -715,14 +766,12 @@ def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
 
         # --- budget enforcement (text) ---
         if isinstance(converted, TextPart):
-            if char_budget <= 0:
-                truncated = True
-                continue
-            if len(converted.text) > char_budget:
-                converted = TextPart(text=converted.text[:char_budget])
-                truncated = True
-            char_budget -= len(converted.text)
-            content.append(converted)
+            char_budget, text_truncated = _append_text_with_budget(
+                content,
+                converted.text,
+                char_budget,
+            )
+            truncated = truncated or text_truncated
             continue
 
         # --- budget enforcement (media: image / audio / video) ---
@@ -737,6 +786,15 @@ def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
 
         # Unknown ContentPart subclass — pass through without budget impact
         content.append(converted)
+
+    structured_text = _structured_content_part(result)
+    if structured_text is not None:
+        char_budget, structured_truncated = _append_text_with_budget(
+            content,
+            structured_text,
+            char_budget,
+        )
+        truncated = truncated or structured_truncated
 
     if truncated:
         content.append(

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -677,6 +677,17 @@ class WireExternalTool(CallableTool):
 # prevent context overflow from tools like Playwright that return full DOMs.
 MCP_MAX_OUTPUT_CHARS = 100_000
 
+_REF_ANNOTATION_SIBLING_KEYS = {
+    "$comment",
+    "default",
+    "deprecated",
+    "description",
+    "examples",
+    "readOnly",
+    "title",
+    "writeOnly",
+}
+
 
 def sanitize_mcp_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Return a provider-compatible copy of an MCP tool input schema."""
@@ -687,12 +698,28 @@ def sanitize_mcp_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
             if "$ref" in mapping:
                 # Moonshot's schema validator rejects metadata siblings after
                 # expanding $ref nodes, even though newer JSON Schema drafts
-                # allow them. Keep only the reference and definition tables.
+                # allow them. Drop annotations, but preserve validation
+                # siblings by applying them alongside the referenced schema.
                 sanitized_ref: dict[str, Any] = {"$ref": mapping["$ref"]}
+                sanitized_defs: dict[str, Any] = {}
+                validation_siblings: dict[str, Any] = {}
                 for definitions_key in ("$defs", "definitions"):
                     if definitions_key in mapping:
-                        sanitized_ref[definitions_key] = _sanitize(mapping[definitions_key])
-                return sanitized_ref
+                        sanitized_defs[definitions_key] = _sanitize(mapping[definitions_key])
+                for key, item in mapping.items():
+                    if (
+                        key == "$ref"
+                        or key in sanitized_defs
+                        or key in _REF_ANNOTATION_SIBLING_KEYS
+                    ):
+                        continue
+                    validation_siblings[key] = _sanitize(item)
+                if not validation_siblings:
+                    return sanitized_ref | sanitized_defs
+                all_of = validation_siblings.pop("allOf", [])
+                if not isinstance(all_of, list):
+                    all_of = [all_of]
+                return sanitized_defs | validation_siblings | {"allOf": [sanitized_ref, *all_of]}
             return {key: _sanitize(item) for key, item in mapping.items()}
         if isinstance(value, list):
             return [_sanitize(item) for item in cast(list[Any], value)]
@@ -725,6 +752,25 @@ def _append_text_with_budget(
         truncated = True
     content.append(TextPart(text=text))
     return char_budget - len(text), truncated
+
+
+def _append_structured_text_with_budget(
+    content: list[ContentPart],
+    text: str,
+    char_budget: int,
+) -> tuple[int, bool]:
+    if len(text) <= char_budget:
+        content.append(TextPart(text=text))
+        return char_budget - len(text), False
+    content.append(
+        TextPart(
+            text=(
+                "[Structured content omitted: exceeded remaining MCP output budget. "
+                "Use pagination or a narrower query to retrieve it.]"
+            )
+        )
+    )
+    return 0, True
 
 
 def _structured_content_part(result: CallToolResult) -> str | None:
@@ -789,7 +835,7 @@ def convert_mcp_tool_result(result: CallToolResult) -> ToolReturnValue:
 
     structured_text = _structured_content_part(result)
     if structured_text is not None:
-        char_budget, structured_truncated = _append_text_with_budget(
+        char_budget, structured_truncated = _append_structured_text_with_budget(
             content,
             structured_text,
             char_budget,

--- a/tests/tools/test_mcp_tool_result.py
+++ b/tests/tools/test_mcp_tool_result.py
@@ -11,13 +11,23 @@ from kosong.message import ImageURLPart, TextPart
 from kosong.tooling import ToolError, ToolOk
 from pydantic import AnyUrl
 
-from kimi_cli.soul.toolset import MCP_MAX_OUTPUT_CHARS, convert_mcp_tool_result
+from kimi_cli.soul.toolset import (
+    MCP_MAX_OUTPUT_CHARS,
+    convert_mcp_tool_result,
+    sanitize_mcp_input_schema,
+)
 
 
-def _make_result(content: Sequence[mcp.types.ContentBlock], *, is_error: bool = False) -> MagicMock:
+def _make_result(
+    content: Sequence[mcp.types.ContentBlock],
+    *,
+    is_error: bool = False,
+    structured_content: dict[str, object] | None = None,
+) -> MagicMock:
     r = MagicMock()
     r.content = content
     r.is_error = is_error
+    r.structured_content = structured_content
     return r
 
 
@@ -34,6 +44,25 @@ class TestMCPTruncation:
         assert isinstance(out, ToolOk)
         assert len(out.output) == 1
         assert _text(out.output[0]) == "hello"
+
+    def test_structured_content_is_appended_as_json_text(self):
+        result = _make_result(
+            [mcp.types.TextContent(type="text", text="Loaded 3 messages")],
+            structured_content={
+                "items": [{"id": 1, "text": "hello"}, {"id": 2, "text": "world"}],
+                "hasMore": True,
+            },
+        )
+
+        out = convert_mcp_tool_result(result)
+
+        assert isinstance(out, ToolOk)
+        assert len(out.output) == 2
+        assert _text(out.output[0]) == "Loaded 3 messages"
+        structured = _text(out.output[1])
+        assert structured.startswith("Structured content:\n")
+        assert '"items"' in structured
+        assert '"hasMore": true' in structured
 
     def test_text_truncated_at_budget(self):
         big_text = "x" * (MCP_MAX_OUTPUT_CHARS + 5000)
@@ -191,3 +220,41 @@ class TestMCPUnsupportedContent:
         assert len(out.output) == 2
         assert _text(out.output[0]) == "valid"
         assert "unsupported" in _text(out.output[1]).lower()
+
+
+class TestMCPSchemaSanitizer:
+    def test_ref_siblings_are_removed_without_mutating_original(self):
+        schema = {
+            "type": "object",
+            "$defs": {"AssetRef": {"type": "object"}},
+            "properties": {
+                "assetRef": {
+                    "$ref": "#/$defs/AssetRef",
+                    "description": "Unity asset reference",
+                    "title": "Asset reference",
+                }
+            },
+        }
+
+        sanitized = sanitize_mcp_input_schema(schema)
+
+        assert sanitized["properties"]["assetRef"] == {"$ref": "#/$defs/AssetRef"}
+        assert "description" in schema["properties"]["assetRef"]
+
+    def test_nested_ref_siblings_are_sanitized_in_arrays(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/AssetRef",
+                        "description": "Unity asset reference",
+                    },
+                }
+            },
+        }
+
+        sanitized = sanitize_mcp_input_schema(schema)
+
+        assert sanitized["properties"]["refs"]["items"] == {"$ref": "#/$defs/AssetRef"}

--- a/tests/tools/test_mcp_tool_result.py
+++ b/tests/tools/test_mcp_tool_result.py
@@ -64,6 +64,20 @@ class TestMCPTruncation:
         assert '"items"' in structured
         assert '"hasMore": true' in structured
 
+    def test_oversized_structured_content_is_omitted_instead_of_truncated(self):
+        result = _make_result(
+            [mcp.types.TextContent(type="text", text="x" * (MCP_MAX_OUTPUT_CHARS - 10))],
+            structured_content={"items": ["y" * 100]},
+        )
+
+        out = convert_mcp_tool_result(result)
+
+        assert isinstance(out, ToolOk)
+        texts = [_text(part) for part in out.output if isinstance(part, TextPart)]
+        assert not any(text.startswith("Structured content:\n") for text in texts[1:])
+        assert any("structured content omitted" in text.lower() for text in texts)
+        assert any("truncated" in text.lower() for text in texts)
+
     def test_text_truncated_at_budget(self):
         big_text = "x" * (MCP_MAX_OUTPUT_CHARS + 5000)
         result = _make_result([mcp.types.TextContent(type="text", text=big_text)])
@@ -240,6 +254,46 @@ class TestMCPSchemaSanitizer:
 
         assert sanitized["properties"]["assetRef"] == {"$ref": "#/$defs/AssetRef"}
         assert "description" in schema["properties"]["assetRef"]
+
+    def test_ref_validation_siblings_are_preserved_via_all_of(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "assetRef": {
+                    "$ref": "#/$defs/AssetRef",
+                    "description": "Unity asset reference",
+                    "enum": ["a", "b"],
+                    "const": "a",
+                }
+            },
+        }
+
+        sanitized = sanitize_mcp_input_schema(schema)
+
+        assert sanitized["properties"]["assetRef"] == {
+            "enum": ["a", "b"],
+            "const": "a",
+            "allOf": [{"$ref": "#/$defs/AssetRef"}],
+        }
+
+    def test_ref_existing_all_of_is_combined_with_reference(self):
+        schema = {
+            "properties": {
+                "assetRef": {
+                    "$ref": "#/$defs/AssetRef",
+                    "allOf": [{"type": "object", "required": ["id"]}],
+                }
+            }
+        }
+
+        sanitized = sanitize_mcp_input_schema(schema)
+
+        assert sanitized["properties"]["assetRef"] == {
+            "allOf": [
+                {"$ref": "#/$defs/AssetRef"},
+                {"type": "object", "required": ["id"]},
+            ]
+        }
 
     def test_nested_ref_siblings_are_sanitized_in_arrays(self):
         schema = {


### PR DESCRIPTION
## Summary
- append MCP `structured_content` as JSON text so tool results do not drop machine-readable payloads
- sanitize MCP input schemas before exposing them to the model by removing metadata siblings from `$ref` nodes
- add regression tests for structured MCP output and `$ref` sibling cleanup without mutating the original schema

## Tests
- `uv run pytest tests\tools\test_mcp_tool_result.py -q`
- `uv run ruff check src\kimi_cli\soul\toolset.py tests\tools\test_mcp_tool_result.py`
- `uv run ruff format --check src\kimi_cli\soul\toolset.py tests\tools\test_mcp_tool_result.py`
- `uv run pyright src\kimi_cli\soul\toolset.py tests\tools\test_mcp_tool_result.py`

Fixes #1919
Fixes #2061
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
