### PR TITLE
fix(skill): skip invalid skill encodings

### DIFF
--- a/src/kimi_cli/skill/__init__.py
+++ b/src/kimi_cli/skill/__init__.py
@@ -393,7 +393,7 @@ async def read_skill_text(skill: Skill) -> str | None:
     """Read the SKILL.md contents for a skill."""
     try:
         return (await skill.skill_md_file.read_text(encoding="utf-8")).strip()
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         logger.warning(
             "Failed to read skill file {path}: {error}",
             path=skill.skill_md_file,
@@ -469,7 +469,7 @@ async def discover_skills(
                 if not await skill_md.is_file():
                     continue
                 content = await skill_md.read_text(encoding="utf-8")
-            except OSError as exc:
+            except (OSError, UnicodeDecodeError) as exc:
                 logger.info(
                     "Skipping unreadable skill entry {path}: {error}",
                     path=entry,

--- a/tests/core/test_skill.py
+++ b/tests/core/test_skill.py
@@ -15,6 +15,7 @@ from kimi_cli.skill import (
     find_project_skills_dirs,
     find_user_skills_dirs,
     get_builtin_skills_dir,
+    read_skill_text,
     resolve_skills_roots,
 )
 
@@ -1426,6 +1427,41 @@ async def test_discover_skills_permission_denied_returns_empty(monkeypatch, tmp_
 
     skills = await skill_mod.discover_skills(root_kp, scope="extra")
     assert skills == []
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_skips_invalid_utf8_subdir_skill(tmp_path):
+    root = tmp_path / "skills"
+    root.mkdir()
+    broken = root / "broken"
+    broken.mkdir()
+    (broken / "SKILL.md").write_bytes(b"---\nname: broken\ndescription: \xcf\n---\n")
+    _write_skill(
+        root / "valid",
+        "---\nname: valid\ndescription: Valid skill\n---\n",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+
+    assert [skill.name for skill in skills] == ["valid"]
+
+
+@pytest.mark.asyncio
+async def test_read_skill_text_returns_none_for_invalid_utf8(tmp_path):
+    root = tmp_path / "skills"
+    broken = root / "broken"
+    broken.mkdir(parents=True)
+    skill_md = broken / "SKILL.md"
+    skill_md.write_bytes(b"\xcf")
+    skill = Skill(
+        name="broken",
+        description="Broken skill",
+        dir=KaosPath.unsafe_from_local_path(broken),
+        skill_md_file=KaosPath.unsafe_from_local_path(skill_md),
+        scope="user",
+    )
+
+    assert await read_skill_text(skill) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Skip invalid UTF-8 subdirectory skills during discovery instead of crashing startup.
- Return None when a skill body cannot be decoded during slash skill loading.
- Add regression tests for invalid UTF-8 SKILL.md files.

Fixes #2070

## Tests
- uv run pytest tests\core\test_skill.py::test_discover_skills_skips_invalid_utf8_subdir_skill tests\core\test_skill.py::test_read_skill_text_returns_none_for_invalid_utf8 -q
- uv run ruff check src\kimi_cli\skill\__init__.py tests\core\test_skill.py
- uv run ruff format --check src\kimi_cli\skill\__init__.py tests\core\test_skill.py
- uv run pyright src\kimi_cli\skill\__init__.py tests\core\test_skill.py

Note: uv run pytest tests\core\test_skill.py -q still has existing Windows-local failures in symlink privilege and tilde-expansion tests unrelated to this change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
