### PR TITLE
fix(prompt): align multiline input text by adding prompt continuation

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1603,7 +1603,7 @@ class CustomPromptSession:
         # Agent mode: prompt prefix is "│  " (3 chars inside input panel)
         return 1
 
-    def _render_prompt_continuation(self, width: int, line_number: int, wrap_count: int) -> AnyFormattedText:
+    def _render_prompt_continuation(self, width: int, line_number: int, wrap_count: int) -> AnyFormattedText | None:
         """Render the prefix for continuation lines in multiline input.
 
         Matches the width of the prompt symbol so that text on all lines
@@ -1612,8 +1612,9 @@ class CustomPromptSession:
         if self._mode == PromptMode.SHELL:
             # Shell prompt is "$ " (2 chars). Pad continuation lines to match.
             return " " * get_cwidth(f"{PROMPT_SYMBOL_SHELL} ")
-        # Agent mode uses a panel border; continuation is handled by the panel.
-        return ""
+        # Agent mode: return None to preserve prompt_toolkit's default
+        # behavior (pad to prompt width), keeping continuation lines aligned.
+        return None
 
     def _render_message(self) -> FormattedText:
         if self._mode == PromptMode.SHELL:

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1504,7 +1504,7 @@ class CustomPromptSession:
 
         self._session = PromptSession[str](
             message=self._render_message,
-            # prompt_continuation=FormattedText([("fg:#4d4d4d", "... ")]),
+            prompt_continuation=self._render_prompt_continuation,
             completer=self._agent_mode_completer,
             complete_while_typing=True,
             reserve_space_for_menu=6,
@@ -1602,6 +1602,18 @@ class CustomPromptSession:
             return max(1, get_cwidth(f"{PROMPT_SYMBOL_SHELL} ") - 2)
         # Agent mode: prompt prefix is "│  " (3 chars inside input panel)
         return 1
+
+    def _render_prompt_continuation(self, width: int, line_number: int, wrap_count: int) -> AnyFormattedText:
+        """Render the prefix for continuation lines in multiline input.
+
+        Matches the width of the prompt symbol so that text on all lines
+        is left-aligned.
+        """
+        if self._mode == PromptMode.SHELL:
+            # Shell prompt is "$ " (2 chars). Pad continuation lines to match.
+            return " " * get_cwidth(f"{PROMPT_SYMBOL_SHELL} ")
+        # Agent mode uses a panel border; continuation is handled by the panel.
+        return ""
 
     def _render_message(self) -> FormattedText:
         if self._mode == PromptMode.SHELL:


### PR DESCRIPTION
## Summary

In shell mode, multiline input has misaligned text: the first line appears indented by one character relative to continuation lines.

## Root cause

The shell prompt appends `"$ "` (2 chars) as the message prefix for the first line, but `prompt_continuation` is not set on the `PromptSession` (line 1507 has it commented out). Continuation lines start at column 0, so they appear one character to the left of the first line.

## Fix

Add a `_render_prompt_continuation` callback that returns spaces matching the width of the prompt symbol (`$ `). In agent mode, continuation is handled by the panel border, so it returns empty.

Fixes #2090
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
