### PR TITLE
feat(#1894): recursively discover skills in nested subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Skill: Discover nested skills and skip symlinked intermediate directories for safety — `_discover_subdir_skills` now uses an explicit stack instead of recursion so arbitrarily deep trees are safe, and a `visited` set tracks resolved canonical paths to prevent symlink cycles (e.g. `skills/a -> ..`) from causing infinite loops on local backends. On non-local backends, symlinked intermediate directories are not traversed into (symlinked skill directories are still discovered). A warning is logged when skill discovery takes longer than 3 seconds to help detect symlink loops or unrelated directories in skill paths
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources

--- a/docs/en/customization/skills.md
+++ b/docs/en/customization/skills.md
@@ -111,6 +111,26 @@ Regardless of form (subdirectory or flat), each skill's `description` is resolve
 2. First non-empty line of the body (fallback; truncated at 240 characters)
 3. `"No description provided."` (last resort)
 
+**Nested subdirectories and symlink safety**
+
+Kimi Code CLI recursively walks nested subdirectories under skills roots to discover skills, so you can organise skills by topic or team. When a subdirectory contains `SKILL.md`, it is recognised as a skill and treated as a leaf — no further traversal happens inside it. When a subdirectory does **not** contain `SKILL.md`, the walk continues deeper.
+
+```
+~/.config/agents/skills/
+├── frontend/
+│   ├── react.md          # flat skill: name = "react"
+│   └── vue/
+│       └── SKILL.md      # subdirectory skill: name = "vue"
+└── backend/
+    └── api-design/
+        └── SKILL.md      # subdirectory skill: name = "api-design"
+```
+
+The discovery process handles the following safety boundaries automatically:
+
+- **Symlinked intermediate directories are skipped**: to prevent symlink cycles (e.g. `skills/a -> ..`) from causing infinite traversal, symlinked **intermediate** directories are not entered. However, if a symlinked directory itself directly contains `SKILL.md`, it is still recognised as a skill.
+- **Slow-scan warning**: if recursive scanning under a skills path takes longer than 3 seconds, Kimi Code CLI logs a warning to help you detect symlink loops or oversized unrelated directories in the path.
+
 ::: tip
 Skills paths are independent of [`KIMI_SHARE_DIR`](../configuration/env-vars.md#kimi-share-dir). `KIMI_SHARE_DIR` customizes the storage location for configuration, sessions, logs, and other runtime data, but does not affect Skills search paths. Skills are cross-tool shared capability extensions (compatible with Kimi CLI, Claude, Codex, and others), which is a different type of data from application runtime data. To specify custom skills paths, use the `--skills-dir` flag or `extra_skill_dirs` config.
 :::

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Skill: Discover nested skills and skip symlinked intermediate directories for safety — `_discover_subdir_skills` now uses an explicit stack instead of recursion so arbitrarily deep trees are safe, and a `visited` set tracks resolved canonical paths to prevent symlink cycles (e.g. `skills/a -> ..`) from causing infinite loops on local backends. On non-local backends, symlinked intermediate directories are not traversed into (symlinked skill directories are still discovered). A warning is logged when skill discovery takes longer than 3 seconds to help detect symlink loops or unrelated directories in skill paths
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources

--- a/docs/zh/customization/skills.md
+++ b/docs/zh/customization/skills.md
@@ -111,6 +111,26 @@ extra_skill_dirs = [
 2. 正文第一个非空行（回退；超过 240 字符会被截断）
 3. `"No description provided."`（兜底）
 
+**嵌套子目录与符号链接安全**
+
+Kimi Code CLI 会在 Skills 根目录下递归遍历嵌套子目录以发现 Skill，因此你可以按主题或团队组织 Skill 的存放结构。当某个子目录包含 `SKILL.md` 时，它会被识别为一个 Skill，且该目录被视为叶子节点，不再继续深入遍历；如果子目录不包含 `SKILL.md`，则遍历会继续向更深层展开。
+
+```
+~/.config/agents/skills/
+├── frontend/
+│   ├── react.md          # 扁平 Skill：name = "react"
+│   └── vue/
+│       └── SKILL.md      # 子目录 Skill：name = "vue"
+└── backend/
+    └── api-design/
+        └── SKILL.md      # 子目录 Skill：name = "api-design"
+```
+
+发现过程会自动处理以下安全边界：
+
+- **符号链接中间目录被跳过**：为防止符号链接循环（例如 `skills/a -> ..`）导致无限遍历，符号链接的**中间目录**不会被深入遍历；但如果符号链接目录本身直接包含 `SKILL.md`，它仍会被识别为一个 Skill。
+- **耗时警告**：如果某个 Skills 路径的递归扫描耗时超过 3 秒，Kimi Code CLI 会记录一条警告日志，帮助你排查可能的符号链接循环或路径中包含了过大的无关目录。
+
 ::: tip 提示
 Skills 路径独立于 [`KIMI_SHARE_DIR`](../configuration/env-vars.md#kimi-share-dir)。`KIMI_SHARE_DIR` 用于自定义配置、会话、日志等运行时数据的存储位置，不影响 Skills 的搜索路径。Skills 是跨工具共享的能力扩展（支持 Kimi CLI、Claude、Codex 等多个工具共用），与应用运行时数据是不同类型的数据。如需自定义 Skills 路径，请使用 `--skills-dir` 参数或 `extra_skill_dirs` 配置。
 :::

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Skill：支持在嵌套子目录中发现 Skill，并跳过符号链接中间目录以提升安全性——`_discover_subdir_skills` 现在使用显式栈代替递归，任意深度的目录树都能安全处理；`visited` 集合跟踪解析后的规范路径，防止符号链接循环（例如 `skills/a -> ..`）在本地后端导致无限循环。在非本地后端，符号链接的中间目录不会被遍历（符号链接的 Skill 目录仍会被发现）。当 Skill 发现耗时超过 3 秒时会记录警告，帮助排查符号链接循环或 Skill 路径中的无关目录
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin：支持直接从 `.zip` URL 安装插件——`kimi plugin install` 现在可以接受以 `.zip` 结尾的 HTTP(S) URL（例如 GitHub/GitLab 的 archive 链接 `.../archive/refs/heads/main.zip`），下载后解压再解析 `plugin.json`，与原有的 git URL、本地目录、本地 zip 文件三种来源并列

--- a/src/kimi_cli/skill/__init__.py
+++ b/src/kimi_cli/skill/__init__.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import sys
+import time
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from stat import S_ISDIR, S_ISLNK
 from typing import Literal, cast
 
 from kaos import get_current_kaos
@@ -424,6 +426,148 @@ class Skill(BaseModel):
     model can tell user-scope from project-scope skills."""
 
 
+async def _discover_subdir_skills(
+    skills_dir: KaosPath,
+    scope: SkillScope,
+    skills_by_name: dict[str, Skill],
+) -> None:
+    """Iteratively walk *skills_dir* (and nested subdirectories) looking for
+    ``SKILL.md``.
+
+    When a subdirectory contains ``SKILL.md`` it is parsed as a skill and that
+    directory is treated as a leaf (no further traversal inside it).  When a
+    subdirectory does **not** contain ``SKILL.md``, the walk continues into it.
+
+    An explicit stack is used instead of recursion so that arbitrarily deep
+    trees are safe (no Python recursion-limit or call-stack overflow).  A
+    ``visited`` set tracks resolved canonical paths so symlink cycles
+    (e.g. ``skills/a -> ..``) cannot cause infinite loops on local backends.
+    On non-local backends, symlinked intermediate directories are not traversed
+    into (symlinked skill directories are still discovered).
+    """
+    visited: set[str] = set()
+    stack: list[KaosPath] = [skills_dir]
+
+    while stack:
+        current_dir = stack.pop()
+
+        # Cycle detection: resolve symlinks on local backends, canonicalize on all.
+        # This matches the dedup logic in ``resolve_skills_roots``.
+        resolved = current_dir
+        if get_current_kaos().name == local_kaos.name:
+            try:
+                local_resolved = Path(str(current_dir)).resolve()
+            except OSError:
+                pass
+            else:
+                resolved = KaosPath.unsafe_from_local_path(local_resolved)
+        try:
+            path_key = str(resolved.canonical())
+        except OSError:
+            path_key = str(resolved)
+
+        if path_key in visited:
+            continue
+        visited.add(path_key)
+
+        try:
+            async for entry in current_dir.iterdir():
+                skill_md = entry / "SKILL.md"
+
+                # Try to detect symlinks without following them.  This works on
+                # both local and SSH backends and prevents symlink-cycle
+                # runaway on non-local backends where canonical() cannot resolve
+                # symlinks.
+                try:
+                    st = await entry.stat(follow_symlinks=False)
+                except OSError as exc:
+                    logger.info(
+                        "Cannot stat skill entry {path}: {error}",
+                        path=entry,
+                        error=exc,
+                    )
+                    # Fall back to the safe behaviour: skip unreadable entries.
+                    continue
+
+                if S_ISLNK(st.st_mode):
+                    # Symlinked directory: check if it is a skill leaf, but never
+                    # traverse into it (would risk undetectable cycles on
+                    # non-local backends).
+                    try:
+                        is_skill_dir = await skill_md.is_file()
+                    except OSError:
+                        is_skill_dir = False
+                    if is_skill_dir:
+                        try:
+                            content = await skill_md.read_text(encoding="utf-8")
+                        except OSError as exc:
+                            logger.info(
+                                "Skipping unreadable skill file {path}: {error}",
+                                path=skill_md,
+                                error=exc,
+                            )
+                            continue
+                        try:
+                            skill = parse_skill_text(
+                                content,
+                                dir_path=entry,
+                                skill_md_file=skill_md,
+                                scope=scope,
+                            )
+                        except Exception as exc:
+                            logger.info("Skipping invalid skill at {}: {}", skill_md, exc)
+                            continue
+                        name_key = normalize_skill_name(skill.name)
+                        if name_key not in skills_by_name:
+                            skills_by_name[name_key] = skill
+                    continue
+
+                if not S_ISDIR(st.st_mode):
+                    continue
+
+                try:
+                    is_skill_dir = await skill_md.is_file()
+                except OSError as exc:
+                    logger.info(
+                        "Cannot stat SKILL.md in {path}: {error}",
+                        path=entry,
+                        error=exc,
+                    )
+                    # Traverse anyway — the directory itself may be readable even if
+                    # the specific SKILL.md path is not.
+                    is_skill_dir = False
+
+                if is_skill_dir:
+                    try:
+                        content = await skill_md.read_text(encoding="utf-8")
+                    except OSError as exc:
+                        logger.info(
+                            "Skipping unreadable skill file {path}: {error}",
+                            path=skill_md,
+                            error=exc,
+                        )
+                        continue
+                    try:
+                        skill = parse_skill_text(
+                            content, dir_path=entry, skill_md_file=skill_md, scope=scope
+                        )
+                    except Exception as exc:
+                        logger.info("Skipping invalid skill at {}: {}", skill_md, exc)
+                        continue
+                    name_key = normalize_skill_name(skill.name)
+                    if name_key not in skills_by_name:
+                        skills_by_name[name_key] = skill
+                    # Do NOT push skill directories onto the stack — they are leaves.
+                else:
+                    stack.append(entry)
+        except OSError as exc:
+            logger.warning(
+                "Failed to iterate skills directory {path}: {error}",
+                path=current_dir,
+                error=exc,
+            )
+
+
 async def discover_skills(
     skills_dir: KaosPath,
     *,
@@ -433,10 +577,13 @@ async def discover_skills(
 
     Two layouts are supported side by side:
 
-    1. **Subdirectory**: ``<skills_dir>/<name>/SKILL.md`` — the canonical layout.
+    1. **Subdirectory**: ``<skills_dir>/.../<name>/SKILL.md`` — the canonical
+       layout.  Subdirectories are scanned recursively, so skills may live at
+       any depth.  A directory that contains ``SKILL.md`` is treated as a skill
+       leaf and is not recursed into further.
     2. **Flat**: ``<skills_dir>/<name>.md`` — a single-file skill. Handy for
        users migrating from agent tooling that stores skills as flat markdown
-       files.
+       files.  Flat skills are only looked for at the top level of *skills_dir*.
 
     When both forms share the same normalized name in one directory, the
     subdirectory form wins and a warning is emitted.
@@ -459,38 +606,18 @@ async def discover_skills(
 
     skills_by_name: dict[str, Skill] = {}
 
-    # Pass 1: subdirectory form (canonical).
-    try:
-        async for entry in skills_dir.iterdir():
-            try:
-                if not await entry.is_dir():
-                    continue
-                skill_md = entry / "SKILL.md"
-                if not await skill_md.is_file():
-                    continue
-                content = await skill_md.read_text(encoding="utf-8")
-            except OSError as exc:
-                logger.info(
-                    "Skipping unreadable skill entry {path}: {error}",
-                    path=entry,
-                    error=exc,
-                )
-                continue
-            try:
-                skill = parse_skill_text(
-                    content, dir_path=entry, skill_md_file=skill_md, scope=scope
-                )
-            except Exception as exc:
-                logger.info("Skipping invalid skill at {}: {}", skill_md, exc)
-                continue
-            skills_by_name[normalize_skill_name(skill.name)] = skill
-    except OSError as exc:
+    # Pass 1: subdirectory form (canonical) — recursive.
+    start = time.perf_counter()
+    await _discover_subdir_skills(skills_dir, scope, skills_by_name)
+    elapsed = time.perf_counter() - start
+    if elapsed > 3.0:
         logger.warning(
-            "Failed to iterate skills directory {path}: {error}",
+            "Skill discovery in {path} took {elapsed:.1f}s. "
+            "Check for symlink loops, unrelated directories, or slow mount "
+            "in your skills paths.",
             path=skills_dir,
-            error=exc,
+            elapsed=elapsed,
         )
-        return sorted(skills_by_name.values(), key=lambda s: s.name)
 
     # Pass 2: flat ``.md`` form, skipping names already claimed by a subdir.
     try:

--- a/tests/core/test_skill.py
+++ b/tests/core/test_skill.py
@@ -1839,3 +1839,302 @@ async def test_discover_subdir_skill_malformed_frontmatter_opener_not_used_as_de
     assert len(skills) == 1
     assert skills[0].description != "---"
     assert skills[0].description == "# Heading"
+
+
+# ---------------------------------------------------------------------------
+# Recursive nested skill discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_subdirectory(tmp_path):
+    """Skills nested inside subdirectories are discovered recursively."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Top-level skill
+    _write_skill(root / "top", "---\nname: top\ndescription: Top-level skill\n---\n")
+
+    # Nested skill: .agents/skills/cloudlive/skills/cloudlive-project-layout/SKILL.md
+    nested = root / "cloudlive" / "skills" / "cloudlive-project-layout"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: cloudlive-project-layout\ndescription: Nested layout skill\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="project")
+    names = sorted(s.name for s in skills)
+    assert names == ["cloudlive-project-layout", "top"]
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_deep(tmp_path):
+    """Skills may be nested arbitrarily deep."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    deep = root / "a" / "b" / "c" / "deep-skill"
+    deep.mkdir(parents=True)
+    (deep / "SKILL.md").write_text(
+        "---\nname: deep-skill\ndescription: Very deep\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert len(skills) == 1
+    assert skills[0].name == "deep-skill"
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_no_recurse_into_skill_dir(tmp_path):
+    """A directory containing SKILL.md is a leaf; subdirectories inside it are
+    NOT scanned for additional skills."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    skill_dir = root / "parent-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: parent-skill\ndescription: Parent\n---\n",
+        encoding="utf-8",
+    )
+
+    # This subdir should be ignored because parent-skill is already a skill
+    inner = skill_dir / "child-skill"
+    inner.mkdir()
+    (inner / "SKILL.md").write_text(
+        "---\nname: child-skill\ndescription: Child\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    names = [s.name for s in skills]
+    assert "parent-skill" in names
+    assert "child-skill" not in names
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_and_flat_mixed(tmp_path):
+    """Nested subdir skills and flat .md skills coexist correctly."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Nested skill
+    nested = root / "group" / "nested-skill"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: nested-skill\ndescription: Nested\n---\n",
+        encoding="utf-8",
+    )
+
+    # Flat skill
+    (root / "flat-skill.md").write_text(
+        "---\nname: flat-skill\ndescription: Flat\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    names = sorted(s.name for s in skills)
+    assert names == ["flat-skill", "nested-skill"]
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_name_from_directory(tmp_path):
+    """A nested skill without frontmatter ``name:`` uses its directory name."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    nested = root / "some-group" / "directory-named-skill"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "No frontmatter at all.\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert len(skills) == 1
+    assert skills[0].name == "directory-named-skill"
+    assert skills[0].description == "No frontmatter at all."
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_subdir_wins_over_flat_same_name(tmp_path, caplog):
+    """A nested skill and a flat skill with the same name: subdir wins."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    nested = root / "containers" / "greet"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: greet\ndescription: Nested greet\n---\n",
+        encoding="utf-8",
+    )
+
+    (root / "greet.md").write_text(
+        "---\nname: greet\ndescription: Flat greet\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert len(skills) == 1
+    assert skills[0].description == "Nested greet"
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_skips_empty_intermediate_dirs(tmp_path):
+    """Empty intermediate directories are silently skipped."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Empty dir
+    (root / "empty").mkdir()
+
+    # Skill inside another path
+    skill = root / "has" / "nested-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: nested-skill\ndescription: Found me\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert len(skills) == 1
+    assert skills[0].name == "nested-skill"
+
+
+# ---------------------------------------------------------------------------
+# Symlink cycle safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_skips_symlink_cycle_to_parent(tmp_path):
+    """A symlink pointing back to the skills root must not cause infinite recursion."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Create a real skill
+    _write_skill(root / "real", "---\nname: real\ndescription: Real skill\n---\n")
+
+    # Symlink cycle: skills/cycle -> .. (points back to parent, which is skills root)
+    (root / "cycle").symlink_to(root)
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    names = [s.name for s in skills]
+    assert "real" in names
+    # Should not crash with RecursionError
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_skips_mutual_symlink_cycle(tmp_path):
+    """Mutual symlinks (a -> b, b -> a) must not cause infinite recursion."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    a = root / "a"
+    b = root / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    # Should not crash
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert skills == []
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_follows_symlinked_skill_dir(tmp_path):
+    """A symlinked skill directory is still discovered correctly."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    real_skill = tmp_path / "real_skill"
+    real_skill.mkdir()
+    (real_skill / "SKILL.md").write_text(
+        "---\nname: linked-skill\ndescription: Via symlink\n---\n",
+        encoding="utf-8",
+    )
+
+    (root / "linked-skill").symlink_to(real_skill)
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert len(skills) == 1
+    assert skills[0].name == "linked-skill"
+    assert skills[0].description == "Via symlink"
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_skips_symlinked_intermediate_dir(tmp_path):
+    """Symlinked intermediate directories are NOT traversed into (cycle safety
+    on non-local backends), but symlinked skill directories ARE still found."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    real_group = tmp_path / "real_group"
+    real_group.mkdir()
+    _write_skill(
+        real_group / "nested-skill",
+        "---\nname: nested-skill\ndescription: Inside symlinked group\n---\n",
+    )
+
+    # Symlinked intermediate dir — not traversed into
+    (root / "group").symlink_to(real_group)
+
+    # Symlinked skill dir — still discovered
+    real_skill = tmp_path / "real_skill"
+    real_skill.mkdir()
+    (real_skill / "SKILL.md").write_text(
+        "---\nname: linked-skill\ndescription: Via symlink\n---\n",
+        encoding="utf-8",
+    )
+    (root / "linked-skill").symlink_to(real_skill)
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    names = [s.name for s in skills]
+    # The intermediate symlink is skipped, but the skill symlink is found
+    assert "linked-skill" in names
+    assert "nested-skill" not in names
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_visited_dedups_real_dirs(tmp_path):
+    """The ``visited`` set deduplicates real directories reached through
+    different paths (e.g. bind mounts or the same dir symlinked from
+    multiple places on local backends)."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Create two distinct real sub-trees
+    for name in ("group-a", "group-b"):
+        g = root / name
+        g.mkdir()
+        _write_skill(
+            g / f"skill-{name}",
+            f"---\nname: skill-{name}\ndescription: x\n---\n",
+        )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    # Both skills are found because they are distinct real directories
+    assert len(skills) == 2
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_nested_deep_chain_found(tmp_path):
+    """Skills buried in a chain deeper than the old _MAX_SKILL_DEPTH are still
+    discovered now that the arbitrary depth limit has been removed."""
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    # Build a chain deeper than the old 32-level limit
+    deep = root
+    for i in range(40):
+        deep = deep / f"level-{i}"
+    deep.mkdir(parents=True)
+    (deep / "SKILL.md").write_text(
+        "---\nname: very-deep-skill\ndescription: Found despite depth\n---\n",
+        encoding="utf-8",
+    )
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="user")
+    assert len(skills) == 1
+    assert skills[0].name == "very-deep-skill"


### PR DESCRIPTION
Previously, discover_skills() only scanned the immediate children of a skills root. This meant nested layouts like
.agents/skills/cloudlive/skills/cloudlive-project-layout/SKILL.md were invisible to Kimi CLI, even though Codex supports them. 

Changes:
- Add _discover_subdir_skills() helper that recursively walks subdirectories looking for SKILL.md.
- A directory containing SKILL.md is treated as a skill leaf; no further recursion happens inside it.
- Flat .md skills remain top-level-only (Pass 2 is unchanged).

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

Resolve #1894 

## Description

- Add _discover_subdir_skills() helper that recursively walks subdirectories looking for SKILL.md.
- A directory containing SKILL.md is treated as a skill leaf; no further recursion happens inside it.
- Flat .md skills remain top-level-only (Pass 2 is unchanged).

## Checklist

- [y ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [y ] I have linked the related issue, if any.
- [y ] I have added tests that prove my fix is effective or that my feature works.
- [y ] I have run `make gen-changelog` to update the changelog.
- [y ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->