### PR TITLE
feat: add user-customizable color skins via YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Add user-customizable color skins — describe a complete color palette in `~/.kimi/skins/<name>.yaml` and activate it with `/skin <name>` at runtime or `skin = "<name>"` in your config file; all color tokens (diff highlights, task browser, prompt completion menu, bottom toolbar, MCP status indicators) can be overridden per-skin with hex values, and missing tokens fall back to the dark defaults; the built-in `dark` and `light` themes are unchanged and the legacy `/theme` command continues to work
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -97,14 +97,14 @@ colors:
   mcp_connected: "#56d364"
   # ... any subset of the ~50 color tokens
 branding:
-  prompt_symbol: "❯"   # optional; replaces the default prompt character
-  welcome: "Hello"      # optional; shown at startup
-  goodbye: "Goodbye"    # optional; shown at exit
+  prompt_symbol: "❯"   # optional; stored and accessible via the skin API
 font:
-  primary: "Fira Code"  # optional hint; displayed in /skin output
+  primary: "Fira Code"  # optional; stored and accessible via the skin API
 ```
 
-Any color token omitted from the file falls back to the dark-theme default. The built-in `dark` and `light` skins are always available. After switching, the skin name is saved to `config.toml` as `skin = "<name>"` and the shell reloads automatically. You can also set `skin = "<name>"` directly in your config file. See [Config files](../configuration/config-files.md) for details.
+Any color token omitted from the file falls back to the dark-theme default. The built-in `dark` and `light` skins are always available and cannot be overridden by a YAML file with the same name. After switching, the skin name is saved to `config.toml` as `skin = "<name>"` and the shell reloads automatically. You can also set `skin = "<name>"` directly in your config file. See [Config files](../configuration/config-files.md) for details.
+
+If `skin` is set in your config but the skin file cannot be found or parsed, the shell silently falls back to the `theme` setting.
 
 ::: tip
 `/skin` and `/theme` are independent. When a custom skin is active, `/theme` output still reflects `dark` or `light` for backwards compatibility, but the active skin's colors take effect.

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -3,7 +3,7 @@
 Slash commands are built-in commands for Kimi Code CLI, used to control sessions, configuration, and debugging. Enter a command starting with `/` in the input box to trigger.
 
 ::: tip Shell mode
-Some slash commands are also available in shell mode, including `/help`, `/exit`, `/version`, `/editor`, `/theme`, `/changelog`, `/feedback`, `/export`, `/import`, and `/task`.
+Some slash commands are also available in shell mode, including `/help`, `/exit`, `/version`, `/editor`, `/theme`, `/skin`, `/changelog`, `/feedback`, `/export`, `/import`, and `/task`.
 :::
 
 ## Help and info
@@ -76,6 +76,39 @@ Usage:
 - `/theme light`: Switch to light theme
 
 After switching, the configuration is saved to `config.toml` and the shell reloads automatically. The light theme adjusts colors for diff highlights, the task browser, the prompt completion menu, the bottom toolbar, and MCP status indicators to work well on light terminal backgrounds. You can also set `theme = "light"` directly in your config file — see [Config files](../configuration/config-files.md).
+
+### `/skin`
+
+Switch to a custom color skin. Skins are YAML files stored in `~/.kimi/skins/<name>.yaml` and can override every color token used by the UI.
+
+Usage:
+
+- `/skin`: Show the current skin and list all available skins
+- `/skin <name>`: Switch to the named skin
+
+A skin file uses the following structure:
+
+```yaml
+name: my-skin
+description: My custom dark skin
+colors:
+  diff_add_bg: "#12261e"
+  diff_del_bg: "#2d1214"
+  mcp_connected: "#56d364"
+  # ... any subset of the ~50 color tokens
+branding:
+  prompt_symbol: "❯"   # optional; replaces the default prompt character
+  welcome: "Hello"      # optional; shown at startup
+  goodbye: "Goodbye"    # optional; shown at exit
+font:
+  primary: "Fira Code"  # optional hint; displayed in /skin output
+```
+
+Any color token omitted from the file falls back to the dark-theme default. The built-in `dark` and `light` skins are always available. After switching, the skin name is saved to `config.toml` as `skin = "<name>"` and the shell reloads automatically. You can also set `skin = "<name>"` directly in your config file. See [Config files](../configuration/config-files.md) for details.
+
+::: tip
+`/skin` and `/theme` are independent. When a custom skin is active, `/theme` output still reflects `dark` or `light` for backwards compatibility, but the active skin's colors take effect.
+:::
 
 ### `/reload`
 

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -97,14 +97,14 @@ colors:
   mcp_connected: "#56d364"
   # ... 约 50 个颜色 token 中的任意子集
 branding:
-  prompt_symbol: "❯"   # 可选；替换默认提示符字符
-  welcome: "你好"       # 可选；启动时显示
-  goodbye: "再见"       # 可选；退出时显示
+  prompt_symbol: "❯"   # 可选；通过皮肤 API 存储和访问
 font:
-  primary: "Fira Code"  # 可选提示；显示在 /skin 输出中
+  primary: "Fira Code"  # 可选；通过皮肤 API 存储和访问
 ```
 
-文件中省略的颜色 token 会回退到深色主题默认值。内置的 `dark` 和 `light` 皮肤始终可用。切换后皮肤名会以 `skin = "<name>"` 的形式保存到 `config.toml` 并自动重新加载。也可以直接在配置文件中设置 `skin = "<name>"`，详见 [配置文件](../configuration/config-files.md)。
+文件中省略的颜色 token 会回退到深色主题默认值。内置的 `dark` 和 `light` 皮肤始终可用，同名的 YAML 文件无法覆盖它们。切换后皮肤名会以 `skin = "<name>"` 的形式保存到 `config.toml` 并自动重新加载。也可以直接在配置文件中设置 `skin = "<name>"`，详见 [配置文件](../configuration/config-files.md)。
+
+如果配置中设置了 `skin` 但对应皮肤文件不存在或解析失败，Shell 会静默回退到 `theme` 设置。
 
 ::: tip 提示
 `/skin` 与 `/theme` 相互独立。当自定义皮肤激活时，`/theme` 的输出仍会显示 `dark` 或 `light`（向后兼容），但实际生效的是当前皮肤的颜色。

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -3,7 +3,7 @@
 斜杠命令是 Kimi Code CLI 的内置命令，用于控制会话、配置和调试。在输入框中输入 `/` 开头的命令即可触发。
 
 ::: tip Shell 模式
-部分斜杠命令在 Shell 模式下也可以使用，包括 `/help`、`/exit`、`/version`、`/editor`、`/theme`、`/changelog`、`/feedback`、`/export`、`/import` 和 `/task`。
+部分斜杠命令在 Shell 模式下也可以使用，包括 `/help`、`/exit`、`/version`、`/editor`、`/theme`、`/skin`、`/changelog`、`/feedback`、`/export`、`/import` 和 `/task`。
 :::
 
 ## 帮助与信息
@@ -76,6 +76,39 @@
 - `/theme light`：切换到浅色主题
 
 切换后配置会保存到 `config.toml` 并自动重新加载。浅色主题会调整 Diff 高亮、任务浏览器、提示符补全菜单、底部工具栏和 MCP 状态等所有 UI 组件的颜色，以适配浅色终端背景。也可以直接在配置文件中设置 `theme = "light"`，详见 [配置文件](../configuration/config-files.md)。
+
+### `/skin`
+
+切换到自定义配色皮肤。皮肤为存放在 `~/.kimi/skins/<name>.yaml` 中的 YAML 文件，可覆盖 UI 中所有颜色 token。
+
+用法：
+
+- `/skin`：显示当前皮肤并列出所有可用皮肤
+- `/skin <name>`：切换到指定名称的皮肤
+
+皮肤文件格式如下：
+
+```yaml
+name: my-skin
+description: 我的自定义深色皮肤
+colors:
+  diff_add_bg: "#12261e"
+  diff_del_bg: "#2d1214"
+  mcp_connected: "#56d364"
+  # ... 约 50 个颜色 token 中的任意子集
+branding:
+  prompt_symbol: "❯"   # 可选；替换默认提示符字符
+  welcome: "你好"       # 可选；启动时显示
+  goodbye: "再见"       # 可选；退出时显示
+font:
+  primary: "Fira Code"  # 可选提示；显示在 /skin 输出中
+```
+
+文件中省略的颜色 token 会回退到深色主题默认值。内置的 `dark` 和 `light` 皮肤始终可用。切换后皮肤名会以 `skin = "<name>"` 的形式保存到 `config.toml` 并自动重新加载。也可以直接在配置文件中设置 `skin = "<name>"`，详见 [配置文件](../configuration/config-files.md)。
+
+::: tip 提示
+`/skin` 与 `/theme` 相互独立。当自定义皮肤激活时，`/theme` 的输出仍会显示 `dark` 或 `light`（向后兼容），但实际生效的是当前皮肤的颜色。
+:::
 
 ### `/reload`
 

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -215,6 +215,10 @@ class Config(BaseModel):
         default="dark",
         description="Terminal color theme. Use 'light' for light terminal backgrounds.",
     )
+    skin: str = Field(
+        default="",
+        description="Custom terminal skin name. Loads from ~/.kimi/skins/<skin>.yaml. Overrides theme when set.",
+    )
     show_thinking_stream: bool = Field(
         default=True,
         description=(

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -363,8 +363,8 @@ class Shell:
             from kimi_cli.ui.theme import set_active_skin, set_active_theme
 
             config = self.soul.runtime.config
-            if getattr(config, "skin", ""):
-                set_active_skin(config.skin)
+            if getattr(config, "skin", "") and set_active_skin(config.skin):
+                pass  # custom skin applied
             else:
                 set_active_theme(config.theme)
 

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -358,11 +358,15 @@ class Shell:
     async def run(self, command: str | None = None) -> bool:
         _run_start_time = time.monotonic()
 
-        # Initialize theme from config
+        # Initialize theme/skin from config
         if isinstance(self.soul, KimiSoul):
-            from kimi_cli.ui.theme import set_active_theme
+            from kimi_cli.ui.theme import set_active_skin, set_active_theme
 
-            set_active_theme(self.soul.runtime.config.theme)
+            config = self.soul.runtime.config
+            if getattr(config, "skin", ""):
+                set_active_skin(config.skin)
+            else:
+                set_active_theme(config.theme)
 
         if command is not None:
             # run single command and exit

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1160,6 +1160,7 @@ def _build_toolbar_tips(clipboard_available: bool) -> list[str]:
         "ctrl-j: newline",
         "/feedback: send feedback",
         "/theme: switch dark/light",
+        "/skin: switch terminal skin",
     ]
     if clipboard_available:
         tips.append("ctrl-v: paste clipboard")

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -682,11 +682,13 @@ def skin(app: Shell, args: str):
         return
 
     arg_lower = arg.lower()
-    if not set_active_skin(arg_lower):
+
+    # Validate existence without mutating active-skin state
+    available_names = {name for name, _ in list_skins()}
+    if arg_lower not in available_names:
         console.print(f"[red]Unknown skin: {arg}.[/red]")
-        available = [name for name, _ in list_skins()]
-        if available:
-            console.print(f"[grey50]Available: {', '.join(available)}[/grey50]")
+        if available_names:
+            console.print(f"[grey50]Available: {', '.join(sorted(available_names))}[/grey50]")
         return
 
     if arg_lower == current:
@@ -701,16 +703,16 @@ def skin(app: Shell, args: str):
         )
         return
 
+    # Persist to disk first — only update in-memory state after success
     try:
         config_for_save = load_config(config_file)
         config_for_save.skin = arg_lower
-        # Also clear theme so skin takes precedence
-        if hasattr(config_for_save, "theme"):
-            config_for_save.theme = "dark"
         save_config(config_for_save, config_file)
     except (ConfigError, OSError) as exc:
         console.print(f"[red]Failed to save config: {exc}[/red]")
         return
+
+    set_active_skin(arg_lower)
 
     from kimi_cli.telemetry import track
 

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -659,6 +659,67 @@ def theme(app: Shell, args: str):
 
 
 @registry.command
+@shell_mode_registry.command
+def skin(app: Shell, args: str):
+    """Switch terminal skin (built-in or from ~/.kimi/skins/*.yaml)"""
+    from kimi_cli.ui.theme import get_active_skin_name, list_skins, set_active_skin
+
+    soul = ensure_kimi_soul(app)
+    if soul is None:
+        return
+
+    current = get_active_skin_name()
+    arg = args.strip()
+
+    if not arg:
+        console.print(f"Current skin: [bold]{current}[/bold]")
+        available = list_skins()
+        console.print("[grey50]Available skins:[/grey50]")
+        for name, desc in available:
+            marker = " → " if name == current else "   "
+            console.print(f"{marker}[cyan]{name}[/cyan]  {desc}")
+        console.print("[grey50]Usage: /skin <name>[/grey50]")
+        return
+
+    arg_lower = arg.lower()
+    if not set_active_skin(arg_lower):
+        console.print(f"[red]Unknown skin: {arg}.[/red]")
+        available = [name for name, _ in list_skins()]
+        if available:
+            console.print(f"[grey50]Available: {', '.join(available)}[/grey50]")
+        return
+
+    if arg_lower == current:
+        console.print(f"[yellow]Already using {arg} skin.[/yellow]")
+        return
+
+    config_file = soul.runtime.config.source_file
+    if config_file is None:
+        console.print(
+            "[yellow]Skin switching requires a config file; "
+            "restart without --config to persist this setting.[/yellow]"
+        )
+        return
+
+    try:
+        config_for_save = load_config(config_file)
+        config_for_save.skin = arg_lower
+        # Also clear theme so skin takes precedence
+        if hasattr(config_for_save, "theme"):
+            config_for_save.theme = "dark"
+        save_config(config_for_save, config_file)
+    except (ConfigError, OSError) as exc:
+        console.print(f"[red]Failed to save config: {exc}[/red]")
+        return
+
+    from kimi_cli.telemetry import track
+
+    track("skin_switch", skin=arg_lower)
+    console.print(f"[green]Switched to {arg_lower} skin. Reloading...[/green]")
+    raise Reload(session_id=soul.runtime.session.id)
+
+
+@registry.command
 def web(app: Shell, args: str):
     """Open Kimi Code Web UI in browser"""
     from kimi_cli.telemetry import track

--- a/src/kimi_cli/ui/theme.py
+++ b/src/kimi_cli/ui/theme.py
@@ -1,18 +1,370 @@
-"""Centralized terminal color theme definitions.
+"""Centralized terminal color theme definitions with custom skin support.
 
-All UI-facing colors live here so that switching between dark and light
-terminal themes only requires changing the active ``ThemeName``.
+Built-in themes: dark, light.
+Custom skins: load from ~/.kimi/skins/<name>.yaml (Hermes-compatible format).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Literal
 
 from prompt_toolkit.styles import Style as PTKStyle
 from rich.style import Style as RichStyle
 
+# Optional YAML support
+try:
+    import yaml
+
+    _HAS_YAML = True
+except Exception:  # pragma: no cover
+    _HAS_YAML = False
+
 type ThemeName = Literal["dark", "light"]
+
+
+# ---------------------------------------------------------------------------
+# Skin dataclass — mirrors Hermes skin format
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SkinColors:
+    """Color palette for a skin."""
+
+    # Diff colors
+    diff_add_bg: str = "#12261e"
+    diff_add_hl: str = "#1a4a2e"
+    diff_del_bg: str = "#2d1214"
+    diff_del_hl: str = "#5c1a1d"
+
+    # Task browser
+    tb_header_bg: str = "#1f2937"
+    tb_header_fg: str = "#e5e7eb"
+    tb_header_title: str = "#67e8f9"
+    tb_header_meta: str = "#9ca3af"
+    tb_status_running: str = "#86efac"
+    tb_status_success: str = "#86efac"
+    tb_status_warning: str = "#fbbf24"
+    tb_status_error: str = "#fca5a5"
+    tb_status_info: str = "#93c5fd"
+    tb_task_list_bg: str = "#111827"
+    tb_task_list_fg: str = "#d1d5db"
+    tb_task_list_checked_bg: str = "#164e63"
+    tb_task_list_checked_fg: str = "#ecfeff"
+    tb_frame_border: str = "#155e75"
+    tb_frame_label_bg: str = "#0f172a"
+    tb_frame_label_fg: str = "#67e8f9"
+    tb_footer_bg: str = "#0f172a"
+    tb_footer_fg: str = "#cbd5e1"
+    tb_footer_key: str = "#67e8f9"
+    tb_footer_warning_bg: str = "#7f1d1d"
+    tb_footer_warning_fg: str = "#fecaca"
+    tb_footer_meta: str = "#94a3b8"
+
+    # Prompt / completion menu
+    prompt_placeholder: str = "#7c8594"
+    prompt_separator: str = "#4a5568"
+    completion_separator: str = "#4a5568"
+    completion_marker: str = "#4a5568"
+    completion_marker_current: str = "#4f9fff"
+    completion_command: str = "#a6adba"
+    completion_meta: str = "#7c8594"
+    completion_command_current: str = "#6fb7ff"
+    completion_meta_current: str = "#56a4ff"
+
+    # Toolbar
+    toolbar_separator: str = "#4d4d4d"
+    toolbar_yolo: str = "#ffff00"
+    toolbar_afk: str = "#ff8800"
+    toolbar_plan: str = "#00aaff"
+    toolbar_cwd: str = "#666666"
+    toolbar_bg_tasks: str = "#888888"
+    toolbar_tip: str = "#555555"
+
+    # MCP status
+    mcp_text: str = "#d4d4d4"
+    mcp_detail: str = "#7c8594"
+    mcp_connected: str = "#56d364"
+    mcp_connecting: str = "#56a4ff"
+    mcp_pending: str = "#f2cc60"
+    mcp_failed: str = "#ff7b72"
+
+
+@dataclass(frozen=True, slots=True)
+class SkinBranding:
+    """Optional branding strings (inspired by Hermes)."""
+
+    welcome: str = ""
+    goodbye: str = ""
+    prompt_symbol: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Skin:
+    """A complete terminal skin definition."""
+
+    name: str
+    description: str = ""
+    colors: SkinColors = field(default_factory=SkinColors)
+    branding: SkinBranding = field(default_factory=SkinBranding)
+    font_hint: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Built-in skins
+# ---------------------------------------------------------------------------
+
+_DARK_COLORS = SkinColors()
+
+_LIGHT_COLORS = SkinColors(
+    diff_add_bg="#dafbe1",
+    diff_add_hl="#aff5b4",
+    diff_del_bg="#ffebe9",
+    diff_del_hl="#ffc1c0",
+    tb_header_bg="#e5e7eb",
+    tb_header_fg="#1f2937",
+    tb_header_title="#0e7490",
+    tb_header_meta="#6b7280",
+    tb_status_running="#166534",
+    tb_status_success="#166534",
+    tb_status_warning="#92400e",
+    tb_status_error="#991b1b",
+    tb_status_info="#1e40af",
+    tb_task_list_bg="#f9fafb",
+    tb_task_list_fg="#374151",
+    tb_task_list_checked_bg="#cffafe",
+    tb_task_list_checked_fg="#164e63",
+    tb_frame_border="#0e7490",
+    tb_frame_label_bg="#f1f5f9",
+    tb_frame_label_fg="#0e7490",
+    tb_footer_bg="#f1f5f9",
+    tb_footer_fg="#475569",
+    tb_footer_key="#0e7490",
+    tb_footer_warning_bg="#fee2e2",
+    tb_footer_warning_fg="#991b1b",
+    tb_footer_meta="#64748b",
+    prompt_placeholder="#6b7280",
+    prompt_separator="#d1d5db",
+    completion_separator="#d1d5db",
+    completion_marker="#9ca3af",
+    completion_marker_current="#2563eb",
+    completion_command="#4b5563",
+    completion_meta="#6b7280",
+    completion_command_current="#1d4ed8",
+    completion_meta_current="#2563eb",
+    toolbar_separator="#d1d5db",
+    toolbar_yolo="#b45309",
+    toolbar_afk="#c2410c",
+    toolbar_plan="#2563eb",
+    toolbar_cwd="#6b7280",
+    toolbar_bg_tasks="#4b5563",
+    toolbar_tip="#9ca3af",
+    mcp_text="#374151",
+    mcp_detail="#6b7280",
+    mcp_connected="#166534",
+    mcp_connecting="#1d4ed8",
+    mcp_pending="#92400e",
+    mcp_failed="#dc2626",
+)
+
+_BUILTIN_SKINS: dict[str, Skin] = {
+    "dark": Skin(name="dark", description="Default dark terminal theme", colors=_DARK_COLORS),
+    "light": Skin(name="light", description="Default light terminal theme", colors=_LIGHT_COLORS),
+}
+
+
+# ---------------------------------------------------------------------------
+# Custom skin loading (Hermes-compatible YAML)
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml_skin(path: Path) -> Skin | None:
+    """Load a skin from a Hermes-compatible YAML file."""
+    if not _HAS_YAML:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not data or not isinstance(data, dict):
+            return None
+
+        raw_colors = data.get("colors", {})
+        colors = SkinColors(
+            diff_add_bg=raw_colors.get("diff_add_bg", _DARK_COLORS.diff_add_bg),
+            diff_add_hl=raw_colors.get("diff_add_hl", _DARK_COLORS.diff_add_hl),
+            diff_del_bg=raw_colors.get("diff_del_bg", _DARK_COLORS.diff_del_bg),
+            diff_del_hl=raw_colors.get("diff_del_hl", _DARK_COLORS.diff_del_hl),
+            tb_header_bg=raw_colors.get("tb_header_bg", _DARK_COLORS.tb_header_bg),
+            tb_header_fg=raw_colors.get("tb_header_fg", _DARK_COLORS.tb_header_fg),
+            tb_header_title=raw_colors.get("tb_header_title", _DARK_COLORS.tb_header_title),
+            tb_header_meta=raw_colors.get("tb_header_meta", _DARK_COLORS.tb_header_meta),
+            tb_status_running=raw_colors.get("tb_status_running", _DARK_COLORS.tb_status_running),
+            tb_status_success=raw_colors.get("tb_status_success", _DARK_COLORS.tb_status_success),
+            tb_status_warning=raw_colors.get("tb_status_warning", _DARK_COLORS.tb_status_warning),
+            tb_status_error=raw_colors.get("tb_status_error", _DARK_COLORS.tb_status_error),
+            tb_status_info=raw_colors.get("tb_status_info", _DARK_COLORS.tb_status_info),
+            tb_task_list_bg=raw_colors.get("tb_task_list_bg", _DARK_COLORS.tb_task_list_bg),
+            tb_task_list_fg=raw_colors.get("tb_task_list_fg", _DARK_COLORS.tb_task_list_fg),
+            tb_task_list_checked_bg=raw_colors.get(
+                "tb_task_list_checked_bg", _DARK_COLORS.tb_task_list_checked_bg
+            ),
+            tb_task_list_checked_fg=raw_colors.get(
+                "tb_task_list_checked_fg", _DARK_COLORS.tb_task_list_checked_fg
+            ),
+            tb_frame_border=raw_colors.get("tb_frame_border", _DARK_COLORS.tb_frame_border),
+            tb_frame_label_bg=raw_colors.get("tb_frame_label_bg", _DARK_COLORS.tb_frame_label_bg),
+            tb_frame_label_fg=raw_colors.get("tb_frame_label_fg", _DARK_COLORS.tb_frame_label_fg),
+            tb_footer_bg=raw_colors.get("tb_footer_bg", _DARK_COLORS.tb_footer_bg),
+            tb_footer_fg=raw_colors.get("tb_footer_fg", _DARK_COLORS.tb_footer_fg),
+            tb_footer_key=raw_colors.get("tb_footer_key", _DARK_COLORS.tb_footer_key),
+            tb_footer_warning_bg=raw_colors.get(
+                "tb_footer_warning_bg", _DARK_COLORS.tb_footer_warning_bg
+            ),
+            tb_footer_warning_fg=raw_colors.get(
+                "tb_footer_warning_fg", _DARK_COLORS.tb_footer_warning_fg
+            ),
+            tb_footer_meta=raw_colors.get("tb_footer_meta", _DARK_COLORS.tb_footer_meta),
+            prompt_placeholder=raw_colors.get("prompt_placeholder", _DARK_COLORS.prompt_placeholder),
+            prompt_separator=raw_colors.get("prompt_separator", _DARK_COLORS.prompt_separator),
+            completion_separator=raw_colors.get(
+                "completion_separator", _DARK_COLORS.completion_separator
+            ),
+            completion_marker=raw_colors.get("completion_marker", _DARK_COLORS.completion_marker),
+            completion_marker_current=raw_colors.get(
+                "completion_marker_current", _DARK_COLORS.completion_marker_current
+            ),
+            completion_command=raw_colors.get("completion_command", _DARK_COLORS.completion_command),
+            completion_meta=raw_colors.get("completion_meta", _DARK_COLORS.completion_meta),
+            completion_command_current=raw_colors.get(
+                "completion_command_current", _DARK_COLORS.completion_command_current
+            ),
+            completion_meta_current=raw_colors.get(
+                "completion_meta_current", _DARK_COLORS.completion_meta_current
+            ),
+            toolbar_separator=raw_colors.get("toolbar_separator", _DARK_COLORS.toolbar_separator),
+            toolbar_yolo=raw_colors.get("toolbar_yolo", _DARK_COLORS.toolbar_yolo),
+            toolbar_afk=raw_colors.get("toolbar_afk", _DARK_COLORS.toolbar_afk),
+            toolbar_plan=raw_colors.get("toolbar_plan", _DARK_COLORS.toolbar_plan),
+            toolbar_cwd=raw_colors.get("toolbar_cwd", _DARK_COLORS.toolbar_cwd),
+            toolbar_bg_tasks=raw_colors.get("toolbar_bg_tasks", _DARK_COLORS.toolbar_bg_tasks),
+            toolbar_tip=raw_colors.get("toolbar_tip", _DARK_COLORS.toolbar_tip),
+            mcp_text=raw_colors.get("mcp_text", _DARK_COLORS.mcp_text),
+            mcp_detail=raw_colors.get("mcp_detail", _DARK_COLORS.mcp_detail),
+            mcp_connected=raw_colors.get("mcp_connected", _DARK_COLORS.mcp_connected),
+            mcp_connecting=raw_colors.get("mcp_connecting", _DARK_COLORS.mcp_connecting),
+            mcp_pending=raw_colors.get("mcp_pending", _DARK_COLORS.mcp_pending),
+            mcp_failed=raw_colors.get("mcp_failed", _DARK_COLORS.mcp_failed),
+        )
+
+        raw_branding = data.get("branding", {})
+        branding = SkinBranding(
+            welcome=raw_branding.get("welcome", ""),
+            goodbye=raw_branding.get("goodbye", ""),
+            prompt_symbol=raw_branding.get("prompt_symbol", ""),
+        )
+
+        return Skin(
+            name=data.get("name", path.stem),
+            description=data.get("description", ""),
+            colors=colors,
+            branding=branding,
+            font_hint=data.get("font", {}).get("primary", "") if isinstance(data.get("font"), dict) else "",
+        )
+    except Exception:
+        return None
+
+
+def _discover_custom_skins() -> dict[str, Skin]:
+    """Discover skins in ~/.kimi/skins/*.yaml."""
+    skins: dict[str, Skin] = {}
+    skins_dir = Path.home() / ".kimi" / "skins"
+    if not skins_dir.exists():
+        return skins
+    for path in skins_dir.glob("*.yaml"):
+        skin = _load_yaml_skin(path)
+        if skin:
+            skins[skin.name] = skin
+    return skins
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_active_skin_name: str = "dark"
+_custom_skins: dict[str, Skin] = {}
+
+
+def _all_skins() -> dict[str, Skin]:
+    """Return built-in + discovered custom skins."""
+    global _custom_skins
+    # Re-discover on each call so new files are picked up without restart
+    _custom_skins = _discover_custom_skins()
+    return {**_BUILTIN_SKINS, **_custom_skins}
+
+
+def set_active_skin(name: str) -> bool:
+    """Activate a skin by name. Returns True if found."""
+    global _active_skin_name
+    all_skins = _all_skins()
+    if name not in all_skins:
+        return False
+    _active_skin_name = name
+    return True
+
+
+def get_active_skin() -> Skin:
+    """Return the currently active skin."""
+    all_skins = _all_skins()
+    return all_skins.get(_active_skin_name, _BUILTIN_SKINS["dark"])
+
+
+def get_active_skin_name() -> str:
+    """Return the name of the currently active skin."""
+    return _active_skin_name
+
+
+def list_skins() -> list[tuple[str, str]]:
+    """List all available skins as (name, description) tuples."""
+    return [(s.name, s.description) for s in _all_skins().values()]
+
+
+def get_skin_branding() -> SkinBranding:
+    """Return branding for the active skin (if any)."""
+    return get_active_skin().branding
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility: theme → skin mapping
+# ---------------------------------------------------------------------------
+
+
+def set_active_theme(theme: ThemeName) -> None:
+    """Legacy API: set theme by name."""
+    global _active_skin_name
+    _active_skin_name = theme
+
+
+def get_active_theme() -> ThemeName:
+    """Legacy API: return 'dark' or 'light'."""
+    name = _active_skin_name
+    if name in ("dark", "light"):
+        return name  # type: ignore[return-value]
+    # Custom skins default to dark behavior for legacy callers
+    return "dark"
+
+
+# ---------------------------------------------------------------------------
+# Color resolvers (skin-aware)
+# ---------------------------------------------------------------------------
+
+
+def _c() -> SkinColors:
+    """Shorthand for active skin colors."""
+    return get_active_skin().colors
 
 
 # ---------------------------------------------------------------------------
@@ -28,19 +380,14 @@ class DiffColors:
     del_hl: RichStyle
 
 
-_DIFF_DARK = DiffColors(
-    add_bg=RichStyle(bgcolor="#12261e"),
-    del_bg=RichStyle(bgcolor="#2d1214"),
-    add_hl=RichStyle(bgcolor="#1a4a2e"),
-    del_hl=RichStyle(bgcolor="#5c1a1d"),
-)
-
-_DIFF_LIGHT = DiffColors(
-    add_bg=RichStyle(bgcolor="#dafbe1"),
-    del_bg=RichStyle(bgcolor="#ffebe9"),
-    add_hl=RichStyle(bgcolor="#aff5b4"),
-    del_hl=RichStyle(bgcolor="#ffc1c0"),
-)
+def get_diff_colors() -> DiffColors:
+    c = _c()
+    return DiffColors(
+        add_bg=RichStyle(bgcolor=c.diff_add_bg),
+        del_bg=RichStyle(bgcolor=c.diff_del_bg),
+        add_hl=RichStyle(bgcolor=c.diff_add_hl),
+        del_hl=RichStyle(bgcolor=c.diff_del_hl),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -48,50 +395,27 @@ _DIFF_LIGHT = DiffColors(
 # ---------------------------------------------------------------------------
 
 
-def _task_browser_style_dark() -> PTKStyle:
+def get_task_browser_style() -> PTKStyle:
+    c = _c()
     return PTKStyle.from_dict(
         {
-            "header": "bg:#1f2937 #e5e7eb",
-            "header.title": "bg:#1f2937 #67e8f9 bold",
-            "header.meta": "bg:#1f2937 #9ca3af",
-            "status.running": "bg:#1f2937 #86efac bold",
-            "status.success": "bg:#1f2937 #86efac",
-            "status.warning": "bg:#1f2937 #fbbf24",
-            "status.error": "bg:#1f2937 #fca5a5",
-            "status.info": "bg:#1f2937 #93c5fd",
-            "task-list": "bg:#111827 #d1d5db",
-            "task-list.checked": "bg:#164e63 #ecfeff bold",
-            "frame.border": "#155e75",
-            "frame.label": "bg:#0f172a #67e8f9 bold",
-            "footer": "bg:#0f172a #cbd5e1",
-            "footer.key": "bg:#0f172a #67e8f9 bold",
-            "footer.text": "bg:#0f172a #cbd5e1",
-            "footer.warning": "bg:#7f1d1d #fecaca bold",
-            "footer.meta": "bg:#0f172a #94a3b8",
-        }
-    )
-
-
-def _task_browser_style_light() -> PTKStyle:
-    return PTKStyle.from_dict(
-        {
-            "header": "bg:#e5e7eb #1f2937",
-            "header.title": "bg:#e5e7eb #0e7490 bold",
-            "header.meta": "bg:#e5e7eb #6b7280",
-            "status.running": "bg:#e5e7eb #166534 bold",
-            "status.success": "bg:#e5e7eb #166534",
-            "status.warning": "bg:#e5e7eb #92400e",
-            "status.error": "bg:#e5e7eb #991b1b",
-            "status.info": "bg:#e5e7eb #1e40af",
-            "task-list": "bg:#f9fafb #374151",
-            "task-list.checked": "bg:#cffafe #164e63 bold",
-            "frame.border": "#0e7490",
-            "frame.label": "bg:#f1f5f9 #0e7490 bold",
-            "footer": "bg:#f1f5f9 #475569",
-            "footer.key": "bg:#f1f5f9 #0e7490 bold",
-            "footer.text": "bg:#f1f5f9 #475569",
-            "footer.warning": "bg:#fee2e2 #991b1b bold",
-            "footer.meta": "bg:#f1f5f9 #64748b",
+            "header": f"bg:{c.tb_header_bg} {c.tb_header_fg}",
+            "header.title": f"bg:{c.tb_header_bg} {c.tb_header_title} bold",
+            "header.meta": f"bg:{c.tb_header_bg} {c.tb_header_meta}",
+            "status.running": f"bg:{c.tb_header_bg} {c.tb_status_running} bold",
+            "status.success": f"bg:{c.tb_header_bg} {c.tb_status_success}",
+            "status.warning": f"bg:{c.tb_header_bg} {c.tb_status_warning}",
+            "status.error": f"bg:{c.tb_header_bg} {c.tb_status_error}",
+            "status.info": f"bg:{c.tb_header_bg} {c.tb_status_info}",
+            "task-list": f"bg:{c.tb_task_list_bg} {c.tb_task_list_fg}",
+            "task-list.checked": f"bg:{c.tb_task_list_checked_bg} {c.tb_task_list_checked_fg} bold",
+            "frame.border": c.tb_frame_border,
+            "frame.label": f"bg:{c.tb_frame_label_bg} {c.tb_frame_label_fg} bold",
+            "footer": f"bg:{c.tb_footer_bg} {c.tb_footer_fg}",
+            "footer.key": f"bg:{c.tb_footer_bg} {c.tb_footer_key} bold",
+            "footer.text": f"bg:{c.tb_footer_bg} {c.tb_footer_fg}",
+            "footer.warning": f"bg:{c.tb_footer_warning_bg} {c.tb_footer_warning_fg} bold",
+            "footer.meta": f"bg:{c.tb_footer_bg} {c.tb_footer_meta}",
         }
     )
 
@@ -101,33 +425,22 @@ def _task_browser_style_light() -> PTKStyle:
 # ---------------------------------------------------------------------------
 
 
-_PROMPT_STYLE_DARK = {
-    "bottom-toolbar": "noreverse",
-    "running-prompt-placeholder": "fg:#7c8594 italic",
-    "running-prompt-separator": "fg:#4a5568",
-    "slash-completion-menu": "",
-    "slash-completion-menu.separator": "fg:#4a5568",
-    "slash-completion-menu.marker": "fg:#4a5568",
-    "slash-completion-menu.marker.current": "fg:#4f9fff",
-    "slash-completion-menu.command": "fg:#a6adba",
-    "slash-completion-menu.meta": "fg:#7c8594",
-    "slash-completion-menu.command.current": "fg:#6fb7ff bold",
-    "slash-completion-menu.meta.current": "fg:#56a4ff",
-}
-
-_PROMPT_STYLE_LIGHT = {
-    "bottom-toolbar": "noreverse",
-    "running-prompt-placeholder": "fg:#6b7280 italic",
-    "running-prompt-separator": "fg:#d1d5db",
-    "slash-completion-menu": "",
-    "slash-completion-menu.separator": "fg:#d1d5db",
-    "slash-completion-menu.marker": "fg:#9ca3af",
-    "slash-completion-menu.marker.current": "fg:#2563eb",
-    "slash-completion-menu.command": "fg:#4b5563",
-    "slash-completion-menu.meta": "fg:#6b7280",
-    "slash-completion-menu.command.current": "fg:#1d4ed8 bold",
-    "slash-completion-menu.meta.current": "fg:#2563eb",
-}
+def get_prompt_style() -> PTKStyle:
+    c = _c()
+    d = {
+        "bottom-toolbar": "noreverse",
+        "running-prompt-placeholder": f"fg:{c.prompt_placeholder} italic",
+        "running-prompt-separator": f"fg:{c.prompt_separator}",
+        "slash-completion-menu": "",
+        "slash-completion-menu.separator": f"fg:{c.completion_separator}",
+        "slash-completion-menu.marker": f"fg:{c.completion_marker}",
+        "slash-completion-menu.marker.current": f"fg:{c.completion_marker_current}",
+        "slash-completion-menu.command": f"fg:{c.completion_command}",
+        "slash-completion-menu.meta": f"fg:{c.completion_meta}",
+        "slash-completion-menu.command.current": f"fg:{c.completion_command_current} bold",
+        "slash-completion-menu.meta.current": f"fg:{c.completion_meta_current}",
+    }
+    return PTKStyle.from_dict(d)
 
 
 # ---------------------------------------------------------------------------
@@ -147,27 +460,18 @@ class ToolbarColors:
     tip: str
 
 
-_TOOLBAR_DARK = ToolbarColors(
-    separator="fg:#4d4d4d",
-    yolo_label="bold fg:#ffff00",
-    afk_label="bold fg:#ff8800",
-    plan_label="bold fg:#00aaff",
-    plan_prompt="fg:#00aaff",
-    cwd="fg:#666666",
-    bg_tasks="fg:#888888",
-    tip="fg:#555555",
-)
-
-_TOOLBAR_LIGHT = ToolbarColors(
-    separator="fg:#d1d5db",
-    yolo_label="bold fg:#b45309",
-    afk_label="bold fg:#c2410c",
-    plan_label="bold fg:#2563eb",
-    plan_prompt="fg:#2563eb",
-    cwd="fg:#6b7280",
-    bg_tasks="fg:#4b5563",
-    tip="fg:#9ca3af",
-)
+def get_toolbar_colors() -> ToolbarColors:
+    c = _c()
+    return ToolbarColors(
+        separator=f"fg:{c.toolbar_separator}",
+        yolo_label=f"bold fg:{c.toolbar_yolo}",
+        afk_label=f"bold fg:{c.toolbar_afk}",
+        plan_label=f"bold fg:{c.toolbar_plan}",
+        plan_prompt=f"fg:{c.toolbar_plan}",
+        cwd=f"fg:{c.toolbar_cwd}",
+        bg_tasks=f"fg:{c.toolbar_bg_tasks}",
+        tip=f"fg:{c.toolbar_tip}",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -185,57 +489,13 @@ class MCPPromptColors:
     failed: str
 
 
-_MCP_PROMPT_DARK = MCPPromptColors(
-    text="fg:#d4d4d4",
-    detail="fg:#7c8594",
-    connected="fg:#56d364",
-    connecting="fg:#56a4ff",
-    pending="fg:#f2cc60",
-    failed="fg:#ff7b72",
-)
-
-_MCP_PROMPT_LIGHT = MCPPromptColors(
-    text="fg:#374151",
-    detail="fg:#6b7280",
-    connected="fg:#166534",
-    connecting="fg:#1d4ed8",
-    pending="fg:#92400e",
-    failed="fg:#dc2626",
-)
-
-
-# ---------------------------------------------------------------------------
-# Public API — resolve by theme name
-# ---------------------------------------------------------------------------
-
-_active_theme: ThemeName = "dark"
-
-
-def set_active_theme(theme: ThemeName) -> None:
-    global _active_theme
-    _active_theme = theme
-
-
-def get_active_theme() -> ThemeName:
-    return _active_theme
-
-
-def get_diff_colors() -> DiffColors:
-    return _DIFF_LIGHT if _active_theme == "light" else _DIFF_DARK
-
-
-def get_task_browser_style() -> PTKStyle:
-    return _task_browser_style_light() if _active_theme == "light" else _task_browser_style_dark()
-
-
-def get_prompt_style() -> PTKStyle:
-    d = _PROMPT_STYLE_LIGHT if _active_theme == "light" else _PROMPT_STYLE_DARK
-    return PTKStyle.from_dict(d)
-
-
-def get_toolbar_colors() -> ToolbarColors:
-    return _TOOLBAR_LIGHT if _active_theme == "light" else _TOOLBAR_DARK
-
-
 def get_mcp_prompt_colors() -> MCPPromptColors:
-    return _MCP_PROMPT_LIGHT if _active_theme == "light" else _MCP_PROMPT_DARK
+    c = _c()
+    return MCPPromptColors(
+        text=f"fg:{c.mcp_text}",
+        detail=f"fg:{c.mcp_detail}",
+        connected=f"fg:{c.mcp_connected}",
+        connecting=f"fg:{c.mcp_connecting}",
+        pending=f"fg:{c.mcp_pending}",
+        failed=f"fg:{c.mcp_failed}",
+    )

--- a/src/kimi_cli/ui/theme.py
+++ b/src/kimi_cli/ui/theme.py
@@ -6,7 +6,6 @@ Custom skins: load from ~/.kimi/skins/<name>.yaml (Hermes-compatible format).
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -278,14 +277,14 @@ def _load_yaml_skin(path: Path) -> Skin | None:
 
 
 def _discover_custom_skins() -> dict[str, Skin]:
-    """Discover skins in ~/.kimi/skins/*.yaml."""
+    """Discover skins in ~/.kimi/skins/*.yaml, skipping reserved built-in names."""
     skins: dict[str, Skin] = {}
     skins_dir = Path.home() / ".kimi" / "skins"
     if not skins_dir.exists():
         return skins
     for path in skins_dir.glob("*.yaml"):
         skin = _load_yaml_skin(path)
-        if skin:
+        if skin and skin.name not in _BUILTIN_SKINS:
             skins[skin.name] = skin
     return skins
 
@@ -298,19 +297,22 @@ _active_skin_name: str = "dark"
 _custom_skins: dict[str, Skin] = {}
 
 
-def _all_skins() -> dict[str, Skin]:
-    """Return built-in + discovered custom skins."""
+def _refresh_custom_skins() -> None:
+    """Re-scan ~/.kimi/skins and update the cache."""
     global _custom_skins
-    # Re-discover on each call so new files are picked up without restart
     _custom_skins = _discover_custom_skins()
-    return {**_BUILTIN_SKINS, **_custom_skins}
+
+
+def _all_skins() -> dict[str, Skin]:
+    """Return built-in + cached custom skins. Built-ins always take precedence."""
+    return {**_custom_skins, **_BUILTIN_SKINS}
 
 
 def set_active_skin(name: str) -> bool:
-    """Activate a skin by name. Returns True if found."""
+    """Activate a skin by name. Returns True if found. Refreshes custom skin cache first."""
     global _active_skin_name
-    all_skins = _all_skins()
-    if name not in all_skins:
+    _refresh_custom_skins()
+    if name not in _all_skins():
         return False
     _active_skin_name = name
     return True
@@ -318,8 +320,7 @@ def set_active_skin(name: str) -> bool:
 
 def get_active_skin() -> Skin:
     """Return the currently active skin."""
-    all_skins = _all_skins()
-    return all_skins.get(_active_skin_name, _BUILTIN_SKINS["dark"])
+    return _all_skins().get(_active_skin_name, _BUILTIN_SKINS["dark"])
 
 
 def get_active_skin_name() -> str:
@@ -328,7 +329,8 @@ def get_active_skin_name() -> str:
 
 
 def list_skins() -> list[tuple[str, str]]:
-    """List all available skins as (name, description) tuples."""
+    """List all available skins as (name, description) tuples. Refreshes custom skin cache."""
+    _refresh_custom_skins()
     return [(s.name, s.description) for s in _all_skins().values()]
 
 

--- a/tests/ui/test_skin_system.py
+++ b/tests/ui/test_skin_system.py
@@ -1,0 +1,425 @@
+"""Tests for the custom YAML skin system (theme.py)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import kimi_cli.ui.theme as theme_mod
+from kimi_cli.ui.theme import (
+    Skin,
+    SkinBranding,
+    SkinColors,
+    _BUILTIN_SKINS,
+    _DARK_COLORS,
+    _load_yaml_skin,
+    get_active_skin,
+    get_active_skin_name,
+    get_active_theme,
+    get_diff_colors,
+    get_mcp_prompt_colors,
+    get_prompt_style,
+    get_skin_branding,
+    get_task_browser_style,
+    get_toolbar_colors,
+    list_skins,
+    set_active_skin,
+    set_active_theme,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_skin():
+    """Restore module-level skin state after each test."""
+    original_name = theme_mod._active_skin_name
+    original_custom = dict(theme_mod._custom_skins)
+    yield
+    theme_mod._active_skin_name = original_name
+    theme_mod._custom_skins = original_custom
+
+
+class TestSkinDataclasses:
+    """SkinColors, SkinBranding, and Skin are frozen dataclasses."""
+
+    def test_skin_colors_defaults_are_hex_strings(self) -> None:
+        colors = SkinColors()
+        assert colors.diff_add_bg.startswith("#")
+        assert colors.diff_del_bg.startswith("#")
+        assert colors.mcp_connected.startswith("#")
+
+    def test_skin_colors_frozen(self) -> None:
+        colors = SkinColors()
+        with pytest.raises((AttributeError, TypeError)):
+            colors.diff_add_bg = "#000000"  # type: ignore[misc]
+
+    def test_skin_branding_defaults_empty(self) -> None:
+        branding = SkinBranding()
+        assert branding.welcome == ""
+        assert branding.goodbye == ""
+        assert branding.prompt_symbol == ""
+
+    def test_skin_frozen(self) -> None:
+        skin = Skin(name="test")
+        with pytest.raises((AttributeError, TypeError)):
+            skin.name = "other"  # type: ignore[misc]
+
+    def test_skin_default_factory_fields(self) -> None:
+        s1 = Skin(name="a")
+        s2 = Skin(name="b")
+        assert s1.colors is not s2.colors
+
+    def test_skin_custom_colors(self) -> None:
+        custom = SkinColors(diff_add_bg="#aabbcc")
+        skin = Skin(name="custom", colors=custom)
+        assert skin.colors.diff_add_bg == "#aabbcc"
+        assert skin.colors.diff_del_bg == _DARK_COLORS.diff_del_bg
+
+
+class TestBuiltinSkins:
+    """dark and light built-in skins are always available."""
+
+    def test_both_builtins_present(self) -> None:
+        assert "dark" in _BUILTIN_SKINS
+        assert "light" in _BUILTIN_SKINS
+
+    def test_dark_skin_name(self) -> None:
+        assert _BUILTIN_SKINS["dark"].name == "dark"
+
+    def test_light_skin_name(self) -> None:
+        assert _BUILTIN_SKINS["light"].name == "light"
+
+    def test_dark_and_light_colors_differ(self) -> None:
+        dark = _BUILTIN_SKINS["dark"].colors
+        light = _BUILTIN_SKINS["light"].colors
+        assert dark.diff_add_bg != light.diff_add_bg
+        assert dark.tb_header_bg != light.tb_header_bg
+
+
+class TestLoadYamlSkin:
+    """_load_yaml_skin() parses Hermes-compatible YAML files."""
+
+    def test_valid_full_yaml(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "ocean.yaml"
+        yaml_file.write_text(
+            textwrap.dedent("""\
+                name: ocean
+                description: Ocean blue theme
+                colors:
+                  diff_add_bg: "#0a2a1a"
+                  diff_add_hl: "#1a5a3e"
+                branding:
+                  welcome: "Welcome"
+                  goodbye: "Goodbye"
+                  prompt_symbol: "~"
+                font:
+                  primary: "Fira Code"
+            """),
+            encoding="utf-8",
+        )
+        skin = _load_yaml_skin(yaml_file)
+        assert skin is not None
+        assert skin.name == "ocean"
+        assert skin.description == "Ocean blue theme"
+        assert skin.colors.diff_add_bg == "#0a2a1a"
+        assert skin.colors.diff_add_hl == "#1a5a3e"
+        assert skin.branding.welcome == "Welcome"
+        assert skin.branding.prompt_symbol == "~"
+        assert skin.font_hint == "Fira Code"
+
+    def test_partial_yaml_falls_back_to_dark_defaults(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "minimal.yaml"
+        yaml_file.write_text(
+            textwrap.dedent("""\
+                name: minimal
+                colors:
+                  diff_add_bg: "#001100"
+            """),
+            encoding="utf-8",
+        )
+        skin = _load_yaml_skin(yaml_file)
+        assert skin is not None
+        assert skin.colors.diff_add_bg == "#001100"
+        assert skin.colors.diff_del_bg == _DARK_COLORS.diff_del_bg
+        assert skin.colors.mcp_connected == _DARK_COLORS.mcp_connected
+
+    def test_name_falls_back_to_file_stem(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "myskin.yaml"
+        yaml_file.write_text("colors:\n  diff_add_bg: '#112233'\n", encoding="utf-8")
+        skin = _load_yaml_skin(yaml_file)
+        assert skin is not None
+        assert skin.name == "myskin"
+
+    def test_branding_defaults_to_empty_strings(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "no_branding.yaml"
+        yaml_file.write_text("name: nobrand\n", encoding="utf-8")
+        skin = _load_yaml_skin(yaml_file)
+        assert skin is not None
+        assert skin.branding.welcome == ""
+        assert skin.branding.goodbye == ""
+        assert skin.branding.prompt_symbol == ""
+
+    def test_font_hint_empty_when_absent(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "nofont.yaml"
+        yaml_file.write_text("name: nofont\n", encoding="utf-8")
+        skin = _load_yaml_skin(yaml_file)
+        assert skin is not None
+        assert skin.font_hint == ""
+
+    def test_empty_file_returns_none(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "empty.yaml"
+        yaml_file.write_text("", encoding="utf-8")
+        assert _load_yaml_skin(yaml_file) is None
+
+    def test_non_dict_yaml_returns_none(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "list.yaml"
+        yaml_file.write_text("- item1\n- item2\n", encoding="utf-8")
+        assert _load_yaml_skin(yaml_file) is None
+
+    def test_malformed_yaml_returns_none(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "bad.yaml"
+        yaml_file.write_text("name: [unclosed\n", encoding="utf-8")
+        assert _load_yaml_skin(yaml_file) is None
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "nonexistent.yaml"
+        assert _load_yaml_skin(yaml_file) is None
+
+    def test_all_color_fields_overridable(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "full.yaml"
+        colors = {
+            "diff_add_bg": "#aaa001",
+            "diff_add_hl": "#aaa002",
+            "diff_del_bg": "#aaa003",
+            "diff_del_hl": "#aaa004",
+            "tb_header_bg": "#aaa005",
+            "tb_header_fg": "#aaa006",
+            "mcp_text": "#aaa007",
+            "mcp_connected": "#aaa008",
+            "mcp_failed": "#aaa009",
+            "toolbar_yolo": "#aaa010",
+            "prompt_placeholder": "#aaa011",
+        }
+        color_lines = "\n".join(f"  {k}: '{v}'" for k, v in colors.items())
+        yaml_file.write_text(f"name: full\ncolors:\n{color_lines}\n", encoding="utf-8")
+        skin = _load_yaml_skin(yaml_file)
+        assert skin is not None
+        for field, value in colors.items():
+            assert getattr(skin.colors, field) == value, f"{field} not set correctly"
+
+
+class TestDiscoverCustomSkins:
+    """_discover_custom_skins() finds skins in ~/.kimi/skins/."""
+
+    def test_no_skins_dir_returns_empty(self, tmp_path: Path) -> None:
+        with patch.object(Path, "home", return_value=tmp_path):
+            from kimi_cli.ui.theme import _discover_custom_skins
+            result = _discover_custom_skins()
+        assert result == {}
+
+    def test_empty_skins_dir_returns_empty(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        with patch.object(Path, "home", return_value=tmp_path):
+            from kimi_cli.ui.theme import _discover_custom_skins
+            result = _discover_custom_skins()
+        assert result == {}
+
+    def test_valid_yaml_is_discovered(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        (skins_dir / "dracula.yaml").write_text(
+            "name: dracula\ndescription: Dracula theme\n", encoding="utf-8"
+        )
+        with patch.object(Path, "home", return_value=tmp_path):
+            from kimi_cli.ui.theme import _discover_custom_skins
+            result = _discover_custom_skins()
+        assert "dracula" in result
+        assert result["dracula"].description == "Dracula theme"
+
+    def test_invalid_yaml_is_skipped(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        (skins_dir / "broken.yaml").write_text("- bad\n", encoding="utf-8")
+        (skins_dir / "good.yaml").write_text("name: good\n", encoding="utf-8")
+        with patch.object(Path, "home", return_value=tmp_path):
+            from kimi_cli.ui.theme import _discover_custom_skins
+            result = _discover_custom_skins()
+        assert "broken" not in result
+        assert "good" in result
+
+    def test_multiple_skins_discovered(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        for name in ("alpha", "beta", "gamma"):
+            (skins_dir / f"{name}.yaml").write_text(f"name: {name}\n", encoding="utf-8")
+        with patch.object(Path, "home", return_value=tmp_path):
+            from kimi_cli.ui.theme import _discover_custom_skins
+            result = _discover_custom_skins()
+        assert {"alpha", "beta", "gamma"} == set(result.keys())
+
+
+class TestActiveSkinAPI:
+    """set_active_skin / get_active_skin / list_skins public API."""
+
+    def test_default_skin_is_dark(self) -> None:
+        theme_mod._active_skin_name = "dark"
+        assert get_active_skin_name() == "dark"
+
+    def test_set_active_skin_builtin_returns_true(self) -> None:
+        assert set_active_skin("light") is True
+        assert get_active_skin_name() == "light"
+
+    def test_set_active_skin_unknown_returns_false(self) -> None:
+        assert set_active_skin("nonexistent_skin_xyz") is False
+        assert get_active_skin_name() == "dark"
+
+    def test_get_active_skin_returns_skin_object(self) -> None:
+        set_active_skin("light")
+        skin = get_active_skin()
+        assert isinstance(skin, Skin)
+        assert skin.name == "light"
+
+    def test_get_active_skin_dark(self) -> None:
+        set_active_skin("dark")
+        skin = get_active_skin()
+        assert skin.name == "dark"
+
+    def test_list_skins_includes_builtins(self) -> None:
+        names = [name for name, _ in list_skins()]
+        assert "dark" in names
+        assert "light" in names
+
+    def test_list_skins_returns_descriptions(self) -> None:
+        skins = dict(list_skins())
+        assert skins["dark"] != ""
+        assert skins["light"] != ""
+
+    def test_custom_skin_activatable(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        (skins_dir / "retro.yaml").write_text("name: retro\n", encoding="utf-8")
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = set_active_skin("retro")
+        assert result is True
+
+    def test_get_skin_branding_empty_for_builtins(self) -> None:
+        set_active_skin("dark")
+        branding = get_skin_branding()
+        assert branding.welcome == ""
+        assert branding.prompt_symbol == ""
+
+    def test_get_skin_branding_custom(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        (skins_dir / "branded.yaml").write_text(
+            "name: branded\nbranding:\n  welcome: Hello\n  prompt_symbol: '>'\n",
+            encoding="utf-8",
+        )
+        with patch.object(Path, "home", return_value=tmp_path):
+            set_active_skin("branded")
+            branding = get_skin_branding()
+        assert branding.welcome == "Hello"
+        assert branding.prompt_symbol == ">"
+
+
+class TestBackwardsCompatibility:
+    """Legacy set_active_theme / get_active_theme still work."""
+
+    def test_set_active_theme_dark(self) -> None:
+        set_active_theme("dark")
+        assert get_active_theme() == "dark"
+
+    def test_set_active_theme_light(self) -> None:
+        set_active_theme("light")
+        assert get_active_theme() == "light"
+
+    def test_custom_skin_get_active_theme_returns_dark_fallback(self) -> None:
+        theme_mod._active_skin_name = "some_custom_skin"
+        assert get_active_theme() == "dark"
+
+    def test_set_active_skin_dark_theme_readable(self) -> None:
+        set_active_skin("dark")
+        assert get_active_theme() == "dark"
+
+    def test_set_active_skin_light_theme_readable(self) -> None:
+        set_active_skin("light")
+        assert get_active_theme() == "light"
+
+
+class TestColorResolvers:
+    """Color resolver functions return correctly typed objects for active skin."""
+
+    def test_get_diff_colors_returns_rich_styles(self) -> None:
+        from rich.style import Style as RichStyle
+
+        set_active_skin("dark")
+        diff = get_diff_colors()
+        assert isinstance(diff.add_bg, RichStyle)
+        assert isinstance(diff.del_bg, RichStyle)
+        assert isinstance(diff.add_hl, RichStyle)
+        assert isinstance(diff.del_hl, RichStyle)
+
+    def test_get_diff_colors_light_differs_from_dark(self) -> None:
+        set_active_skin("dark")
+        dark_diff = get_diff_colors()
+        set_active_skin("light")
+        light_diff = get_diff_colors()
+        assert dark_diff.add_bg != light_diff.add_bg
+
+    def test_get_task_browser_style_returns_ptk_style(self) -> None:
+        from prompt_toolkit.styles import Style as PTKStyle
+
+        style = get_task_browser_style()
+        assert isinstance(style, PTKStyle)
+
+    def test_get_task_browser_style_has_header_key(self) -> None:
+        style = get_task_browser_style()
+        style_dict = dict(style.style_rules)
+        assert any("header" in rule for rule in style_dict)
+
+    def test_get_prompt_style_returns_ptk_style(self) -> None:
+        from prompt_toolkit.styles import Style as PTKStyle
+
+        style = get_prompt_style()
+        assert isinstance(style, PTKStyle)
+
+    def test_get_toolbar_colors_contains_skin_colors(self) -> None:
+        set_active_skin("dark")
+        dark_colors = get_toolbar_colors()
+        set_active_skin("light")
+        light_colors = get_toolbar_colors()
+        assert dark_colors.yolo_label != light_colors.yolo_label
+
+    def test_get_toolbar_colors_format(self) -> None:
+        tc = get_toolbar_colors()
+        assert "fg:" in tc.separator or "bg:" in tc.separator or "#" in tc.separator
+        assert "fg:" in tc.yolo_label or "bold" in tc.yolo_label
+
+    def test_get_mcp_prompt_colors_returns_dataclass(self) -> None:
+        from kimi_cli.ui.theme import MCPPromptColors
+
+        mcp = get_mcp_prompt_colors()
+        assert isinstance(mcp, MCPPromptColors)
+        assert mcp.connected.startswith("fg:")
+        assert mcp.failed.startswith("fg:")
+
+    def test_get_mcp_prompt_colors_light_differs_from_dark(self) -> None:
+        set_active_skin("dark")
+        dark_mcp = get_mcp_prompt_colors()
+        set_active_skin("light")
+        light_mcp = get_mcp_prompt_colors()
+        assert dark_mcp.connected != light_mcp.connected
+
+    def test_resolvers_reflect_custom_skin(self, tmp_path: Path) -> None:
+        skins_dir = tmp_path / ".kimi" / "skins"
+        skins_dir.mkdir(parents=True)
+        (skins_dir / "mono.yaml").write_text(
+            "name: mono\ncolors:\n  mcp_connected: '#ffffff'\n", encoding="utf-8"
+        )
+        with patch.object(Path, "home", return_value=tmp_path):
+            set_active_skin("mono")
+            mcp = get_mcp_prompt_colors()
+        assert "#ffffff" in mcp.connected


### PR DESCRIPTION
Closes #2171

## Summary

- **New `/skin` slash command** — switch between named skins at runtime; works like `/theme` but for user-defined palettes
- **YAML skin loader** — `~/.kimi/skins/<name>.yaml` files define complete color palettes in a Hermes-compatible format; any omitted token falls back to the dark defaults
- **Backwards-compatible** — `dark` and `light` built-ins are unchanged; `/theme` still works; `get_active_theme()` returns `"dark"` for custom skins so existing callers aren't broken
- **Config integration** — `skin = "<name>"` in `config.toml` activates a skin on startup, same lifecycle as `theme`
- **50 new tests** — cover dataclasses, YAML parsing (valid/partial/bad), filesystem discovery, public API, backwards-compat bridge, and all five color-resolver functions
- **Docs updated** — `/skin` section added to EN and ZH slash-commands reference; CHANGELOG entry under Unreleased

## Example skin file

```yaml
name: dracula
description: Dracula color scheme
colors:
  diff_add_bg: "#1e3a2e"
  diff_del_bg: "#3a1e2e"
  mcp_connected: "#50fa7b"
  toolbar_yolo: "#ff79c6"
branding:
  prompt_symbol: "❯"
font:
  primary: "Fira Code"
```

## Test plan

- [x] All 50 new tests pass (`pytest tests/ui/test_skin_system.py`)
- [x] Existing `test_console_theme.py` unaffected
- [ ] Manual: `mkdir -p ~/.kimi/skins && echo "name: test" > ~/.kimi/skins/test.yaml`, then `/skin test` in kimi shell
- [ ] Manual: verify `/skin` with no args lists available skins
- [ ] Manual: verify `skin = "test"` in config.toml activates on startup
- [ ] Manual: verify `/theme dark` still works after `/skin` switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)