### PR TITLE
fix: respect model display_name for kimi-for-coding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Fix model display name for `kimi-for-coding` and `kimi-code` — remove the hardcoded fallback that always returned `"kimi-for-coding"` for both model IDs; the function now preserves the original model ID when the provider does not supply a `display_name`
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Fix model display name for `kimi-for-coding` and `kimi-code` — remove the hardcoded fallback that always returned `"kimi-for-coding"` for both model IDs; the function now preserves the original model ID when the provider does not supply a `display_name`
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin: Support installing plugins directly from a `.zip` URL — `kimi plugin install` now accepts HTTP(S) URLs ending in `.zip` (e.g. GitHub/GitLab archive links like `.../archive/refs/heads/main.zip`) and downloads + extracts them before resolving `plugin.json`, in addition to the existing git URL, local directory, and local zip-file sources

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Core：修复 `kimi-for-coding` 和 `kimi-code` 的模型显示名称问题——移除将两者都固定返回为 `"kimi-for-coding"` 的硬编码回退；当 provider 未提供 `display_name` 时，函数现在保留原始模型 ID
+
 ## 1.41.0 (2026-04-30)
 
 - Plugin：支持直接从 `.zip` URL 安装插件——`kimi plugin install` 现在可以接受以 `.zip` 结尾的 HTTP(S) URL（例如 GitHub/GitLab 的 archive 链接 `.../archive/refs/heads/main.zip`），下载后解压再解析 `plugin.json`，与原有的 git URL、本地目录、本地 zip 文件三种来源并列

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -51,8 +51,6 @@ def model_display_name(model_name: str | None, model: LLMModel | None = None) ->
         return model.display_name
     if not model_name:
         return ""
-    if model_name in ("kimi-for-coding", "kimi-code"):
-        return "kimi-for-coding"
     return model_name
 
 


### PR DESCRIPTION
## Related Issue

Resolve #2175

## Description

Removes the hardcoded override in `model_display_name()` that forced "kimi-for-coding" and "kimi-code" to always display as "kimi-for-coding", ignoring the `display_name` provided by the backend (e.g. "Kimi-k2.6"). The backend already returns the correct display name via the /models endpoint, and it is correctly persisted in the config file — this fix simply allows the UI to actually show it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.