### PR TITLE
fix(acp): allow API-key based auth to bypass forced OAuth login

### DIFF
--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -74,26 +74,35 @@ class ACPServer:
         terminal_args = args + ["login"]
 
         # Build and cache auth methods for reuse in AUTH_REQUIRED errors
-        self._auth_methods = [
-            acp.schema.AuthMethod(
-                id="login",
-                name="Login with Kimi account",
-                description=(
-                    "Run `kimi login` command in the terminal, "
-                    "then follow the instructions to finish login."
+        # Skip login method if user already has API-key based auth configured
+        config = load_config()
+        has_api_key = any(
+            provider.api_key and provider.api_key.get_secret_value()
+            for provider in config.providers.values()
+        )
+        if has_api_key or self._check_token_usable() is None:
+            self._auth_methods = []
+        else:
+            self._auth_methods = [
+                acp.schema.AuthMethod(
+                    id="login",
+                    name="Login with Kimi account",
+                    description=(
+                        "Run `kimi login` command in the terminal, "
+                        "then follow the instructions to finish login."
+                    ),
+                    # Store auth data in field_meta for building AUTH_REQUIRED error
+                    field_meta={
+                        "terminal-auth": {
+                            "command": command,
+                            "args": terminal_args,
+                            "label": "Kimi Code Login",
+                            "env": {},
+                            "type": "terminal",
+                        }
+                    },
                 ),
-                # Store auth data in field_meta for building AUTH_REQUIRED error
-                field_meta={
-                    "terminal-auth": {
-                        "command": command,
-                        "args": terminal_args,
-                        "label": "Kimi Code Login",
-                        "env": {},
-                        "type": "terminal",
-                    }
-                },
-            ),
-        ]
+            ]
 
         return acp.InitializeResponse(
             protocol_version=self.negotiated_version.protocol_version,
@@ -129,6 +138,15 @@ class ACPServer:
         """Check if Kimi Code authentication is complete. Raise AUTH_REQUIRED if not."""
         reason = self._check_token_usable()
         if reason:
+            # Allow API-key based authentication as an alternative to OAuth
+            config = load_config()
+            has_api_key = any(
+                provider.api_key and provider.api_key.get_secret_value()
+                for provider in config.providers.values()
+            )
+            if has_api_key:
+                return
+
             auth_methods_data: list[dict[str, Any]] = []
             for m in self._auth_methods:
                 if m.field_meta and "terminal-auth" in m.field_meta:


### PR DESCRIPTION
## Problem

When using Kimi Code CLI via ACP (e.g., JetBrains IDE), the server forces OAuth authentication even when the user has already configured a provider with `api_key` in `config.toml`.

In the terminal, `kimi` works fine because it directly uses the configured provider + API key. But through ACP (`kimi acp`), the IDE pops up a **"Login with Kimi account"** dialog with only a web/OAuth login option, leaving API-key users no way to proceed.

## Reproduction Steps

1. Configure a provider with `api_key` in `~/.kimi/config.toml` (do **not** run `kimi login`):
   ```toml
   [providers.moonshot]
   type = "openai"
   base_url = "https://api.moonshot.cn/v1"
   api_key = "sk-..."
   ```
2. Confirm terminal mode works: `kimi --prompt "hello"`
3. Configure the ACP agent in JetBrains IDE (`~/.jetbrains/acp.json`):
   ```json
   {
     "agent_servers": {
       "Kimi Code CLI": {
         "command": "kimi",
         "args": ["acp"]
       }
     }
   }
   ```
4. Open AI Chat in JetBrains and select Kimi Code CLI.
5. **Observed**: A "Login with Kimi account" dialog appears immediately, with no option to skip or use the configured API key.

## Root Cause

There are **two places** in `kimi_cli/acp/server.py` that together create this forced-login behavior:

### 1. `_check_auth()` only checks OAuth token

```python
def _check_auth(self) -> None:
    reason = self._check_token_usable()   # Only checks OAuth token
    if reason:
        raise acp.RequestError.auth_required({"authMethods": ...})
```

It completely ignores valid `api_key` configurations in `config.providers`.

### 2. `initialize()` unconditionally advertises `login` auth method

```python
self._auth_methods = [
    acp.schema.AuthMethod(id="login", name="Login with Kimi account", ...),
]
```

Even if the user has an API key, the ACP server tells the client during `initialize()` that the only available auth method is OAuth login. Some ACP clients (e.g., JetBrains AI Assistant) proactively show an authentication UI when `auth_methods` is non-empty, **before** any session is created.

## Changes

### `initialize()` — Dynamic `auth_methods`

```python
config = load_config()
has_api_key = any(
    provider.api_key and provider.api_key.get_secret_value()
    for provider in config.providers.values()
)
if has_api_key or self._check_token_usable() is None:
    self._auth_methods = []
else:
    self._auth_methods = [login_method]
```

- If the user already has API-key auth or valid OAuth → `auth_methods` is empty, preventing proactive auth UI popups.
- Otherwise → keep the existing OAuth login flow.

### `_check_auth()` — API-key fallback

```python
reason = self._check_token_usable()
if reason:
    config = load_config()
    has_api_key = any(
        provider.api_key and provider.api_key.get_secret_value()
        for provider in config.providers.values()
    )
    if has_api_key:
        return
    # ... existing AUTH_REQUIRED error
```

- When OAuth token is unavailable, check if any provider has a non-empty `api_key`.
- If so, treat the user as authenticated and do not raise `AUTH_REQUIRED`.

## Relation to PR #1445

PR #1445 removes the `_check_auth()` gate from `new_session` and `load_session`, which addresses part of this issue. However, it does **not** modify `initialize()`, so clients that react to `auth_methods` may still force a login prompt at connection time.

This PR complements PR #1445 by also fixing the `initialize()` side:
- **PR #1445** removes the session-operation-time auth barrier.
- **This PR** ensures the connection-time `auth_methods` advertisement is accurate.

Together they provide a complete fix for API-key-based ACP usage.

## Compatibility

- **OAuth users**: Behavior unchanged. Valid OAuth token → `auth_methods=[]` and `_check_auth()` passes.
- **API-key users**: No longer forced into OAuth login. Both `initialize()` and session operations work seamlessly.
- **Unauthenticated users**: Still get the `login` auth method in `initialize()` and `AUTH_REQUIRED` on session creation, preserving the existing onboarding flow.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->