### PR TITLE
fix(kosong): sanitize malformed history tool calls

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -78,7 +78,7 @@ from kosong.chat_provider import (
     TokenUsage,
     convert_httpx_error,
 )
-from kosong.contrib.chat_provider.common import ToolMessageConversion
+from kosong.contrib.chat_provider.common import ToolMessageConversion, parse_tool_call_arguments
 from kosong.message import (
     ContentPart,
     ImageURLPart,
@@ -485,22 +485,12 @@ class Anthropic:
             else:
                 continue
         for tool_call in message.tool_calls or []:
-            if tool_call.function.arguments:
-                try:
-                    parsed_arguments = json.loads(tool_call.function.arguments, strict=False)
-                except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
-                    raise ChatProviderError("Tool call arguments must be valid JSON.") from exc
-                if not isinstance(parsed_arguments, dict):
-                    raise ChatProviderError("Tool call arguments must be a JSON object.")
-                tool_input = cast(dict[str, object], parsed_arguments)
-            else:
-                tool_input = {}
             blocks.append(
                 ToolUseBlockParam(
                     type="tool_use",
                     id=tool_call.id,
                     name=tool_call.function.name,
-                    input=tool_input,
+                    input=parse_tool_call_arguments(tool_call.function.arguments),
                 )
             )
         return MessageParam(role=role, content=blocks)

--- a/packages/kosong/src/kosong/contrib/chat_provider/common.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/common.py
@@ -1,5 +1,24 @@
 from __future__ import annotations
 
-from typing import Literal
+import json
+from typing import Literal, cast
+
+from kosong.utils.typing import JsonType
 
 type ToolMessageConversion = Literal["extract_text"]
+
+
+def parse_tool_call_arguments(arguments: str | None) -> dict[str, object]:
+    if not arguments:
+        return {}
+    try:
+        parsed: JsonType = json.loads(arguments, strict=False)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return cast(dict[str, object], parsed)
+
+
+def sanitize_tool_call_arguments(arguments: str | None) -> str:
+    return json.dumps(parse_tool_call_arguments(arguments), ensure_ascii=False)

--- a/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
@@ -44,6 +44,7 @@ from kosong.chat_provider import (
     TokenUsage,
     convert_httpx_error,
 )
+from kosong.contrib.chat_provider.common import parse_tool_call_arguments
 from kosong.message import (
     AudioURLPart,
     ContentPart,
@@ -652,20 +653,9 @@ def message_to_google_genai(message: Message) -> Content:
 
     # Handle tool calls for assistant messages
     for tool_call in message.tool_calls or []:
-        if tool_call.function.arguments:
-            try:
-                parsed_arguments = json.loads(tool_call.function.arguments, strict=False)
-            except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
-                raise ChatProviderError("Tool call arguments must be valid JSON.") from exc
-            if not isinstance(parsed_arguments, dict):
-                raise ChatProviderError("Tool call arguments must be a JSON object.")
-            args = cast(dict[str, object], parsed_arguments)
-        else:
-            args = {}
-
         function_call = FunctionCall(
             name=tool_call.function.name,
-            args=args,
+            args=parse_tool_call_arguments(tool_call.function.arguments),
         )
         function_call_part = Part(function_call=function_call)
         # Add thought_signature back to function_call

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -29,7 +29,7 @@ from kosong.chat_provider.openai_common import (
     thinking_effort_to_reasoning_effort,
     tool_to_openai,
 )
-from kosong.contrib.chat_provider.common import ToolMessageConversion
+from kosong.contrib.chat_provider.common import ToolMessageConversion, sanitize_tool_call_arguments
 from kosong.message import ContentPart, Message, TextPart, ThinkPart, ToolCall, ToolCallPart
 from kosong.tooling import Tool
 
@@ -212,6 +212,10 @@ class OpenAILegacy:
             message.content = [TextPart(text=message.extract_text(sep="\n"))]
         else:
             message.content = content
+        for tool_call in message.tool_calls or []:
+            tool_call.function.arguments = sanitize_tool_call_arguments(
+                tool_call.function.arguments
+            )
         dumped_message = message.model_dump(exclude_none=True)
         if reasoning_content and self._reasoning_key:
             dumped_message[self._reasoning_key] = reasoning_content

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
@@ -44,7 +44,10 @@ from kosong.chat_provider.openai_common import (
     reasoning_effort_to_thinking_effort,
     thinking_effort_to_reasoning_effort,
 )
-from kosong.contrib.chat_provider.common import ToolMessageConversion
+from kosong.contrib.chat_provider.common import (
+    ToolMessageConversion,
+    sanitize_tool_call_arguments,
+)
 from kosong.message import (
     AudioURLPart,
     ContentPart,
@@ -330,7 +333,7 @@ class OpenAIResponses:
         for tool_call in message.tool_calls or []:
             result.append(
                 {
-                    "arguments": tool_call.function.arguments or "{}",
+                    "arguments": sanitize_tool_call_arguments(tool_call.function.arguments),
                     "call_id": tool_call.id,
                     "name": tool_call.function.name,
                     "type": "function_call",

--- a/packages/kosong/tests/test_tool_call_argument_sanitizing.py
+++ b/packages/kosong/tests/test_tool_call_argument_sanitizing.py
@@ -1,0 +1,66 @@
+import json
+from typing import cast
+
+from kosong.contrib.chat_provider.common import (
+    parse_tool_call_arguments,
+    sanitize_tool_call_arguments,
+)
+from kosong.contrib.chat_provider.openai_legacy import OpenAILegacy
+from kosong.contrib.chat_provider.openai_responses import OpenAIResponses
+from kosong.message import Message, ToolCall
+
+
+def _assistant_tool_call(arguments: str | None) -> Message:
+    return Message(
+        role="assistant",
+        content=[],
+        tool_calls=[
+            ToolCall(
+                id="call-1",
+                function=ToolCall.FunctionBody(name="run_command", arguments=arguments),
+            )
+        ],
+    )
+
+
+def test_tool_call_arguments_keep_control_chars_parseable() -> None:
+    valid = json.dumps({"command": "printf 'one\ntwo'"})
+    raw_with_literal_newline = valid.replace("\\n", "\n")
+
+    parsed = parse_tool_call_arguments(raw_with_literal_newline)
+    sanitized = sanitize_tool_call_arguments(raw_with_literal_newline)
+
+    assert parsed == {"command": "printf 'one\ntwo'"}
+    assert json.loads(sanitized) == parsed
+
+
+def test_tool_call_arguments_fall_back_for_malformed_history() -> None:
+    arguments = '{"command": "run", description": "missing opening quote"}'
+
+    assert parse_tool_call_arguments(arguments) == {}
+    assert sanitize_tool_call_arguments(arguments) == "{}"
+
+
+def test_openai_responses_sanitizes_malformed_history_tool_call() -> None:
+    provider = OpenAIResponses(model="test-model", api_key="test-key")
+    message = _assistant_tool_call('{"command": "run", description": "bad"}')
+
+    converted = cast(list[dict[str, object]], provider._convert_message(message))
+    function_call = next(item for item in converted if item["type"] == "function_call")
+
+    assert function_call["arguments"] == "{}"
+    assert message.tool_calls is not None
+    assert message.tool_calls[0].function.arguments == '{"command": "run", description": "bad"}'
+
+
+def test_openai_legacy_sanitizes_malformed_history_tool_call() -> None:
+    provider = OpenAILegacy(model="test-model", api_key="test-key")
+    message = _assistant_tool_call('{"command": "run", description": "bad"}')
+
+    converted = cast(dict[str, object], provider._convert_message(message))
+    tool_calls = cast(list[dict[str, object]], converted["tool_calls"])
+    function = cast(dict[str, object], tool_calls[0]["function"])
+
+    assert function["arguments"] == "{}"
+    assert message.tool_calls is not None
+    assert message.tool_calls[0].function.arguments == '{"command": "run", description": "bad"}'


### PR DESCRIPTION
## Summary

Fixes #2165.

Historical tool calls can contain malformed `function.arguments` after a model emits invalid JSON. OpenAI-compatible backends then reject the next request while replaying the session history, so the conversation keeps failing on every turn.

This keeps the fix at the provider boundary:

- parse historical tool call arguments before provider requests are built
- preserve valid JSON objects, including strings with literal control characters accepted by `strict=False`
- fall back malformed or non-object arguments to `{}`
- leave the stored message/history object unchanged

The same helper is used by OpenAI Responses, OpenAI Legacy, Anthropic, and Google GenAI conversions.

## Tests

- `python -m uv run pytest packages\kosong\tests -q`
- `python -m uv run pytest packages\kosong\tests\test_tool_call_argument_sanitizing.py -q`
- `python -m uv run ruff check packages\kosong\src\kosong\contrib\chat_provider\common.py packages\kosong\src\kosong\contrib\chat_provider\openai_responses.py packages\kosong\src\kosong\contrib\chat_provider\openai_legacy.py packages\kosong\src\kosong\contrib\chat_provider\anthropic.py packages\kosong\src\kosong\contrib\chat_provider\google_genai.py packages\kosong\tests\test_tool_call_argument_sanitizing.py`
- `python -m uv run ruff format packages\kosong\src\kosong\contrib\chat_provider\common.py packages\kosong\src\kosong\contrib\chat_provider\openai_responses.py packages\kosong\src\kosong\contrib\chat_provider\openai_legacy.py packages\kosong\src\kosong\contrib\chat_provider\anthropic.py packages\kosong\src\kosong\contrib\chat_provider\google_genai.py packages\kosong\tests\test_tool_call_argument_sanitizing.py --check`
- `python -m uv run pyright packages\kosong\src\kosong\contrib\chat_provider\common.py packages\kosong\src\kosong\contrib\chat_provider\openai_responses.py packages\kosong\src\kosong\contrib\chat_provider\openai_legacy.py packages\kosong\src\kosong\contrib\chat_provider\anthropic.py packages\kosong\src\kosong\contrib\chat_provider\google_genai.py packages\kosong\tests\test_tool_call_argument_sanitizing.py`
- `python -m py_compile packages\kosong\src\kosong\contrib\chat_provider\common.py packages\kosong\src\kosong\contrib\chat_provider\openai_responses.py packages\kosong\src\kosong\contrib\chat_provider\openai_legacy.py packages\kosong\src\kosong\contrib\chat_provider\anthropic.py packages\kosong\src\kosong\contrib\chat_provider\google_genai.py packages\kosong\tests\test_tool_call_argument_sanitizing.py; git diff --check`