### PR TITLE
fix(kaos): avoid console windows on Windows exec

### DIFF
--- a/packages/kaos/src/kaos/local.py
+++ b/packages/kaos/src/kaos/local.py
@@ -166,12 +166,19 @@ class LocalKaos:
         if not args:
             raise ValueError("At least one argument (the program to execute) is required.")
 
+        spawn_kwargs: dict[str, object] = {}
+        if os.name == "nt":
+            import subprocess
+
+            spawn_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
         process = await asyncio.create_subprocess_exec(
             *args,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            **spawn_kwargs,
         )
         return self.Process(process)
 

--- a/packages/kaos/tests/test_local_kaos.py
+++ b/packages/kaos/tests/test_local_kaos.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 import sys
 from collections.abc import Generator
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -196,3 +197,61 @@ async def test_exec_wait_timeout(local_kaos: LocalKaos):
         if process.returncode is None:
             await process.kill()
         await process.wait()
+
+
+async def test_exec_uses_create_no_window_on_windows(monkeypatch):
+    calls: list[dict[str, object]] = []
+    create_no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+
+    class FakeProcess:
+        stdin = object()
+        stdout = object()
+        stderr = object()
+        pid = 123
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        def kill(self) -> None:
+            pass
+
+    async def fake_create_subprocess_exec(*args: str, **kwargs: object) -> FakeProcess:
+        calls.append(kwargs)
+        return FakeProcess()
+
+    monkeypatch.setattr("kaos.local.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("kaos.local.os.name", "nt")
+    monkeypatch.setattr(subprocess, "CREATE_NO_WINDOW", create_no_window, raising=False)
+
+    await LocalKaos().exec("cmd.exe", "/c", "echo ok")
+
+    assert calls[0]["creationflags"] == create_no_window
+
+
+async def test_exec_does_not_pass_creationflags_off_windows(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class FakeProcess:
+        stdin = object()
+        stdout = object()
+        stderr = object()
+        pid = 123
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        def kill(self) -> None:
+            pass
+
+    async def fake_create_subprocess_exec(*args: str, **kwargs: object) -> FakeProcess:
+        calls.append(kwargs)
+        return FakeProcess()
+
+    monkeypatch.setattr("kaos.local.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("kaos.local.os.name", "posix")
+
+    await LocalKaos().exec("sh", "-c", "echo ok")
+
+    assert "creationflags" not in calls[0]


### PR DESCRIPTION
﻿## Summary
- avoid creating a separate Windows console window for Kaos local exec subprocesses
- keep non-Windows subprocess spawning unchanged
- cover the Windows-only `CREATE_NO_WINDOW` flag with targeted unit tests

Fixes #2197.

## To verify
- `python -m uv run pytest packages\kaos\tests\test_local_kaos.py::test_exec_uses_create_no_window_on_windows packages\kaos\tests\test_local_kaos.py::test_exec_does_not_pass_creationflags_off_windows packages\kaos\tests\test_local_kaos.py::test_exec_runs_command_and_streams -q`
- `python -m uv run ruff check packages\kaos\src\kaos\local.py packages\kaos\tests\test_local_kaos.py`
- `python -m uv run ruff format packages\kaos\src\kaos\local.py packages\kaos\tests\test_local_kaos.py --check`
- `python -m py_compile packages\kaos\src\kaos\local.py packages\kaos\tests\test_local_kaos.py`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->