### PR TITLE
fix(term): fail cleanly on Windows

### DIFF
--- a/src/kimi_cli/cli/toad.py
+++ b/src/kimi_cli/cli/toad.py
@@ -27,6 +27,14 @@ def _default_toad_command() -> list[str]:
     if sys.version_info < (3, 14):
         typer.echo("`kimi term` requires Python 3.14+ because Toad requires it.", err=True)
         raise typer.Exit(code=1)
+    if sys.platform == "win32":
+        typer.echo(
+            "`kimi term` is not supported on Windows yet because Toad's terminal "
+            "backend requires POSIX-only modules such as fcntl. Use `kimi` or "
+            "`kimi acp` on Windows.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     if importlib.util.find_spec("toad") is None:
         typer.echo(
             "Toad dependency is missing. Install kimi-cli with Python 3.14+ to use `kimi term`.",

--- a/tests/acp/test_toad_cli.py
+++ b/tests/acp/test_toad_cli.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+import typer
+
+from kimi_cli.cli import toad
+
+
+def test_default_toad_command_exits_cleanly_on_windows(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(toad.sys, "platform", "win32")
+    monkeypatch.setattr(toad.sys, "version_info", (3, 14, 0))
+
+    def fail_find_spec(name: str) -> None:
+        raise AssertionError(f"find_spec should not be called for {name}")
+
+    monkeypatch.setattr(toad.importlib.util, "find_spec", fail_find_spec)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        toad._default_toad_command()
+
+    assert exc_info.value.exit_code == 1
+    assert "`kimi term` is not supported on Windows yet" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- make `kimi term` exit before launching Toad on Windows
- explain that Toad's terminal backend currently depends on POSIX-only modules such as `fcntl`
- add regression coverage so the Windows path does not try to import/resolve Toad

Closes #2202

## To verify
- `python -m uv run pytest tests\acp\test_toad_cli.py tests\acp\test_server_initialize.py -q`
- `python -m uv run ruff check src\kimi_cli\cli\toad.py tests\acp\test_toad_cli.py`
- `python -m py_compile src\kimi_cli\cli\toad.py tests\acp\test_toad_cli.py`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->