### PR TITLE
fix(shell): tighten Windows PowerShell guidance

### DIFF
--- a/src/kimi_cli/tools/shell/powershell.md
+++ b/src/kimi_cli/tools/shell/powershell.md
@@ -2,6 +2,12 @@ Execute a ${SHELL} command. Use this tool to explore the filesystem, inspect or 
 
 Note that you are running on Windows, so make sure to use Windows commands, paths, and conventions.
 
+Assume Windows PowerShell 5.1 compatibility unless you have already checked that the selected shell is PowerShell 7+ (`pwsh`). In particular:
+- Do not use Unix-only commands such as `head`, `tail`, `grep`, `sed`, or `awk`; prefer `Select-Object -First`, `Select-Object -Last`, `Select-String`, `findstr`, or small Python snippets.
+- Do not use PowerShell 7-only pipeline chain operators (`&&`, `||`); use `; if ($?) { ... }` or `; if (-not $?) { ... }`.
+- Do not use `Out-File -Encoding utf8NoBOM` in Windows PowerShell 5.1. Use `Out-File -Encoding utf8` when a BOM is acceptable, or `[System.IO.File]::WriteAllText($path, $text, (New-Object System.Text.UTF8Encoding($false)))` when it is not.
+- `Join-Path` accepts two path parts at a time in Windows PowerShell 5.1. For three or more segments, nest calls, for example `Join-Path (Join-Path $PWD ".git") "tmp-file"`.
+
 **Output:**
 The stdout and stderr streams are combined and returned as a single string. Extremely long output may be truncated. When a command fails, the exit code is provided in a system tag.
 

--- a/tests/tools/test_tool_descriptions.py
+++ b/tests/tools/test_tool_descriptions.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 # ruff: noqa
 
 import platform
+from pathlib import Path
+
 import pytest
 from inline_snapshot import snapshot
 
@@ -176,6 +178,18 @@ If `run_in_background=true`, the command will be started as a background task an
 - Other: Other commands available in the shell environment. Check the existence of a command by running `which <command>` before using it.
 """
     )
+
+
+def test_powershell_description_mentions_51_compatibility():
+    description = (
+        Path(__file__).parents[2] / "src/kimi_cli/tools/shell/powershell.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Windows PowerShell 5.1" in description
+    assert "Select-Object -First" in description
+    assert "PowerShell 7-only pipeline chain operators" in description
+    assert "utf8NoBOM" in description
+    assert "Join-Path" in description
 
 
 def test_task_output_description(task_output_tool: TaskOutput):


### PR DESCRIPTION
## Summary

The Windows Shell tool description currently says to use Windows commands, but it does not spell out the two failure modes that keep showing up on default Windows installs:

- Unix pipeline helpers such as `head`, `tail`, `grep`, `sed`, and `awk` are not available in Windows PowerShell 5.1.
- PowerShell 7-only syntax such as `&&`, `||`, `Out-File -Encoding utf8NoBOM`, and multi-part `Join-Path` fails under the default `powershell.exe` shell.

This patch makes the Windows Shell tool description explicitly assume PowerShell 5.1 unless `pwsh` has been verified, and lists the common compatible alternatives.

Closes #2192
Closes #2194

## To verify

- `python -m uv run pytest tests\tools\test_tool_descriptions.py::test_powershell_description_mentions_51_compatibility -q`
- `python -m uv run ruff check tests\tools\test_tool_descriptions.py`
- `python -m py_compile tests\tools\test_tool_descriptions.py`
- `git diff --check`

Note: I first tried passing the Markdown file itself to `ruff check`; ruff treated it as Python and failed with syntax errors, so the supported ruff check above is the relevant one.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->