### PR TITLE
fix(tests): unbreak main CI after #2177

### DIFF
--- a/tests/ui_and_conv/test_modal_lifecycle.py
+++ b/tests/ui_and_conv/test_modal_lifecycle.py
@@ -858,6 +858,7 @@ async def test_render_agent_status_excludes_panels_in_interactive() -> None:
     view._compacting_spinner = None
     view._current_content_block = None
     view._tool_call_blocks = {}
+    view._current_step_retry = None
     view._live_notification_blocks = cast(
         Any, type("deque", (), {"__iter__": lambda self: iter([])})()
     )

--- a/tests_e2e/test_wire_protocol.py
+++ b/tests_e2e/test_wire_protocol.py
@@ -36,12 +36,12 @@ def test_initialize_handshake(tmp_path) -> None:
     try:
         resp = send_initialize(wire)
         result = _as_dict(resp.get("result"))
-        assert result.get("protocol_version") == "1.9"
+        assert result.get("protocol_version") == "1.10"
         assert "slash_commands" in result
         assert normalize_response(resp) == snapshot(
             {
                 "result": {
-                    "protocol_version": "1.9",
+                    "protocol_version": "1.10",
                     "server": {"name": "Kimi Code CLI", "version": "<VERSION>"},
                     "slash_commands": [
                         {
@@ -151,7 +151,7 @@ def test_initialize_external_tool_conflict(tmp_path) -> None:
         assert normalize_response(resp) == snapshot(
             {
                 "result": {
-                    "protocol_version": "1.9",
+                    "protocol_version": "1.10",
                     "server": {"name": "Kimi Code CLI", "version": "<VERSION>"},
                     "slash_commands": [
                         {


### PR DESCRIPTION
## Summary
- Initialize `view._current_step_retry = None` in the manual `object.__new__(_PromptLiveView)` fixture used by `test_render_agent_status_excludes_panels_in_interactive`.
- Bump the three `protocol_version` literals in `tests_e2e/test_wire_protocol.py` from `"1.9"` to `"1.10"` to match the wire-protocol bump.

## Motivation
PR #2177 (`fix(soul): clear partial UI output when LLM step is retried`) introduced two test/code mismatches that only surfaced once the merge landed on `main`:

1. `_LiveView.__init__` gained a new `_current_step_retry` attribute, read from `compose_agent_output()`. The modal-lifecycle test bypasses `__init__` (`object.__new__(_PromptLiveView)` then sets attributes by hand), so the new attribute was missing — `render_agent_status()` raised `AttributeError: '_PromptLiveView' object has no attribute '_current_step_retry'`.
2. `WIRE_PROTOCOL_VERSION` was bumped from `1.9` to `1.10` in `src/kimi_cli/wire/protocol.py`, but the e2e snapshot in `tests_e2e/test_wire_protocol.py` still asserted `"1.9"`, so `test_initialize_handshake` and `test_initialize_external_tool_conflict` started returning `"1.10"` against a `"1.9"` expectation.

Together these were the only pytest failures in [CI run #2459](https://github.com/MoonshotAI/kimi-cli/actions/runs/25599080265) (push to `main`) and the same two failures reproduced in this PR's first CI run.

## Changes
- `tests/ui_and_conv/test_modal_lifecycle.py`: add `view._current_step_retry = None` to the manual fixture, alongside the other `compose_agent_output` dependencies.
- `tests_e2e/test_wire_protocol.py`: update the three `"1.9"` literals to `"1.10"`.

## Testing
- `prek run --all-files` ✅
- `uv run pytest tests/ui_and_conv/test_modal_lifecycle.py` — 42 passed (was 1 failure before commit 1).
- `uv run pytest tests_e2e/test_wire_protocol.py` — 4 passed (was 2 failures before commit 2).
- `make test-kimi-cli` locally surfaces 7 unrelated failures in `tests/ui/test_usage.py::{test_format_row_handles_no_remaining_quota,test_format_row_renders_remaining_quota}`; verified those exact parametrizations pass on CI #2459 (Linux + Python 3.12), so they are macOS + Python 3.14 environment quirks unrelated to this branch or to #2177.