### PR TITLE
fix(soul): show rotated backup hint after /clear

### DIFF
--- a/src/kimi_cli/soul/context.py
+++ b/src/kimi_cli/soul/context.py
@@ -199,12 +199,15 @@ class Context:
 
         self._pending_token_estimate = estimate_text_tokens(messages_after_last_usage)
 
-    async def clear(self):
+    async def clear(self) -> Path:
         """
         Clear the context history.
         This is almost equivalent to revert_to(0), but without relying on the assumption
         that the first checkpoint exists.
         File backend will be rotated.
+
+        Returns:
+            Path: Rotated backup file path.
 
         Raises:
             RuntimeError: When no available rotation path is found.
@@ -228,6 +231,7 @@ class Context:
         self._pending_token_estimate = 0
         self._next_checkpoint_id = 0
         self._system_prompt = None
+        return rotated_file_path
 
     async def append_message(self, message: Message | Sequence[Message]):
         logger.debug("Appending message(s) to context: {message}", message=message)

--- a/src/kimi_cli/soul/slash.py
+++ b/src/kimi_cli/soul/slash.py
@@ -81,9 +81,16 @@ async def compact(soul: KimiSoul, args: str):
 async def clear(soul: KimiSoul, args: str):
     """Clear the context"""
     logger.info("Running `/clear`")
-    await soul.context.clear()
+    rotated_file_path = await soul.context.clear()
     await soul.context.write_system_prompt(soul.agent.system_prompt)
-    wire_send(TextPart(text="The context has been cleared."))
+    wire_send(
+        TextPart(
+            text=(
+                "The context has been cleared. Previous history was rotated to "
+                f"{rotated_file_path.name}; `/undo` cannot restore turns from before `/clear`."
+            )
+        )
+    )
     snap = soul.status
     wire_send(
         StatusUpdate(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -215,10 +215,12 @@ async def test_clear_resets_system_prompt(tmp_path: Path) -> None:
     await ctx.restore()
     assert ctx.system_prompt == "Will be cleared"
 
-    await ctx.clear()
+    rotated = await ctx.clear()
 
     assert ctx.system_prompt is None
     assert len(ctx.history) == 0
+    assert rotated.name == "context_1.jsonl"
+    assert rotated.exists()
 
 
 # --- revert_to tests ---

--- a/tests/core/test_slash_afk.py
+++ b/tests/core/test_slash_afk.py
@@ -173,7 +173,7 @@ async def test_clear_slash_reports_rotated_backup_and_undo_note(
     await soul.context.write_system_prompt(soul.agent.system_prompt)
     await soul.context.append_message(Message(role="user", content=[MessageTextPart(text="hello")]))
 
-    sent: list[TextPart] = []
+    sent: list[object] = []
     monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
 
     await _run(clear_slash, soul)

--- a/tests/core/test_slash_afk.py
+++ b/tests/core/test_slash_afk.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
+from kosong.message import Message
+from kosong.message import TextPart as MessageTextPart
 from kosong.tooling.empty import EmptyToolset
 
 from kimi_cli.soul.agent import Agent, Runtime
@@ -12,6 +15,7 @@ from kimi_cli.soul.context import Context
 from kimi_cli.soul.dynamic_injection import DynamicInjection, DynamicInjectionProvider
 from kimi_cli.soul.kimisoul import KimiSoul
 from kimi_cli.soul.slash import afk as afk_slash
+from kimi_cli.soul.slash import clear as clear_slash
 from kimi_cli.soul.slash import yolo as yolo_slash
 from kimi_cli.wire.types import TextPart
 
@@ -160,6 +164,24 @@ async def test_yolo_slash_under_afk_only_toggles_yolo_flag(
     # Toast must reflect yolo being turned ON, not the misleading "require approval".
     assert any("auto-approved" in s.text.lower() for s in sent)
     assert not any("require approval" in s.text.lower() for s in sent)
+
+
+async def test_clear_slash_reports_rotated_backup_and_undo_note(
+    runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    soul = _make_soul(runtime, tmp_path)
+    await soul.context.write_system_prompt(soul.agent.system_prompt)
+    await soul.context.append_message(Message(role="user", content=[MessageTextPart(text="hello")]))
+
+    sent: list[TextPart] = []
+    monkeypatch.setattr("kimi_cli.soul.slash.wire_send", lambda msg: sent.append(msg))
+
+    await _run(clear_slash, soul)
+
+    clear_msgs = [m.text for m in sent if isinstance(m, TextPart) and "context has been cleared" in m.text]
+    assert len(clear_msgs) == 1
+    assert re.search(r"rotated to [^\s]+_1\.jsonl", clear_msgs[0]) is not None
+    assert "/undo" in clear_msgs[0]
 
 
 async def test_yolo_slash_off_under_afk_does_not_claim_approval_required(


### PR DESCRIPTION
## Summary
- return rotated backup path from `Context.clear()`
- show `/clear` message with rotated backup filename
- clarify that `/undo` cannot restore turns from before `/clear`
- add regression tests for clear return value and slash clear message

## Why
`/clear` rotates history on disk, but users had no in-CLI hint about where it went or why `/undo` no longer restores pre-clear turns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->