### PR TITLE
feat(webui): editable path bar with autocomplete in Workspace files sidebar

### DIFF
--- a/web/src/features/chat/components/session-files-panel.tsx
+++ b/web/src/features/chat/components/session-files-panel.tsx
@@ -80,6 +80,21 @@ export function SessionFilesPanel({
   const [error, setError] = useState<string | null>(null);
   const requestIdRef = useRef(0);
 
+  // Inject CSS override for Radix UI ScrollArea (build-safe: inlined to avoid
+  // Vite/Tailwind CSS tree-shaking dropping the global rule).
+  useEffect(() => {
+    const id = "session-files-scrollarea-fix";
+    if (document.getElementById(id)) return;
+    const style = document.createElement("style");
+    style.id = id;
+    style.textContent =
+      '[data-radix-scroll-area-viewport] > div[style*="display:table"] { display: block !important; }';
+    document.head.appendChild(style);
+    return () => {
+      document.getElementById(id)?.remove();
+    };
+  }, []);
+
   const loadDirectory = useCallback(
     async (path: string, refresh = false) => {
       if (!onListSessionDirectory) {
@@ -268,6 +283,7 @@ export function SessionFilesPanel({
                   <div
                     key={`${entry.type}:${itemPath}`}
                     className="flex items-center gap-2 rounded-xl border bg-card/60 px-2.5 py-2 overflow-hidden"
+                    style={{ overflow: "hidden" }}
                   >
                     {isDirectory ? (
                       <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -275,9 +291,13 @@ export function SessionFilesPanel({
                       <FileTextIcon className="size-4 shrink-0 text-muted-foreground" />
                     )}
 
-                    <div className="min-w-0 flex-1 overflow-hidden">
+                    <div
+                      className="min-w-0 flex-1 overflow-hidden"
+                      style={{ overflow: "hidden" }}
+                    >
                       <div
                         className="truncate text-sm font-medium w-full"
+                        style={{ width: "100%" }}
                         title={entry.name}
                       >
                         {entry.name}

--- a/web/src/features/chat/components/session-files-panel.tsx
+++ b/web/src/features/chat/components/session-files-panel.tsx
@@ -112,6 +112,7 @@ export function SessionFilesPanel({
   const [activeSuggestion, setActiveSuggestion] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suggestRequestIdRef = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const isComposingRef = useRef(false);
   // When focused on a complete directory path (e.g. "./projects/foo" without "/"),
@@ -123,6 +124,15 @@ export function SessionFilesPanel({
   useEffect(() => {
     setInputValue(getDisplayPath(currentPath));
   }, [currentPath]);
+
+  // Clear pending suggestion debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (suggestTimerRef.current) {
+        clearTimeout(suggestTimerRef.current);
+      }
+    };
+  }, []);
 
   // Inject CSS override for Radix UI ScrollArea (build-safe: inlined to avoid
   // Vite/Tailwind CSS tree-shaking dropping the global rule).
@@ -190,6 +200,8 @@ export function SessionFilesPanel({
         return;
       }
 
+      const requestId = ++suggestRequestIdRef.current;
+
       // Focus mode: if input looks like a complete directory path
       // (no trailing "/"), try listing it directly first.
       if (isFocus && !input.endsWith("/") && input !== "." && input !== "./") {
@@ -197,21 +209,25 @@ export function SessionFilesPanel({
         if (fullPath) {
           try {
             const entries = await onListSessionDirectory(sessionId, fullPath);
+            if (requestId !== suggestRequestIdRef.current) return;
             // Full path is a directory — show its contents.
             suggestionBasePathRef.current = fullPath;
             setSuggestions(entries.slice(0, 20));
             setActiveSuggestion(-1);
             return;
           } catch {
+            if (requestId !== suggestRequestIdRef.current) return;
             // Not a directory, fall through to normal behavior.
           }
         }
       }
 
+      if (requestId !== suggestRequestIdRef.current) return;
       suggestionBasePathRef.current = null;
       const { parentPath, filter } = parsePathInput(input);
       try {
         const allEntries = await onListSessionDirectory(sessionId, parentPath);
+        if (requestId !== suggestRequestIdRef.current) return;
         const filtered = filter
           ? allEntries.filter((e) =>
               e.name.toLowerCase().startsWith(filter.toLowerCase()),
@@ -220,6 +236,7 @@ export function SessionFilesPanel({
         setSuggestions(filtered.slice(0, 20));
         setActiveSuggestion(-1);
       } catch {
+        if (requestId !== suggestRequestIdRef.current) return;
         setSuggestions([]);
       }
     },
@@ -251,8 +268,8 @@ export function SessionFilesPanel({
       suggestionBasePathRef.current = null;
       return;
     }
-    // Strip leading ./ if present
-    let target = trimmed.replace(/^\.\//, "");
+    // Strip leading ./ and / if present
+    let target = trimmed.replace(/^\.?\//, "");
     if (target === "") {
       target = ".";
     }
@@ -278,18 +295,32 @@ export function SessionFilesPanel({
         display = buildDisplayPath(parentPath, suggestion.name);
       }
 
-      setInputValue(display);
       setShowSuggestions(false);
       setActiveSuggestion(-1);
       suggestionBasePathRef.current = null;
 
       if (suggestion.type === "directory") {
+        setInputValue(display);
         setCurrentPath(fullPath);
       } else {
+        // File selected: trigger download if possible, otherwise reset
+        // the input to the current directory so we don't leave a file
+        // path that would fail on next Enter.
+        if (onGetSessionFileUrl) {
+          const url = onGetSessionFileUrl(sessionId, fullPath);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = suggestion.name;
+          a.style.display = "none";
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+        }
+        setInputValue(getDisplayPath(currentPath));
         inputRef.current?.focus();
       }
     },
-    [inputValue],
+    [inputValue, currentPath, onGetSessionFileUrl, sessionId],
   );
 
   const handleInputKeyDown = useCallback(

--- a/web/src/features/chat/components/session-files-panel.tsx
+++ b/web/src/features/chat/components/session-files-panel.tsx
@@ -30,6 +30,7 @@ type SessionFilesPanelProps = {
 };
 
 const FILE_SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"];
+const SUGGESTION_DEBOUNCE_MS = 150;
 
 function formatFileSize(size?: number): string | null {
   if (size === null || size === undefined) {
@@ -65,6 +66,30 @@ function getDisplayPath(path: string): string {
   return path === "." ? "." : `./${path}`;
 }
 
+function parsePathInput(input: string): { parentPath: string; filter: string } {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed === ".") {
+    return { parentPath: ".", filter: "" };
+  }
+  // Strip leading ./
+  const normalized = trimmed.replace(/^\.\//, "");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash < 0) {
+    return { parentPath: ".", filter: normalized };
+  }
+  return {
+    parentPath: normalized.slice(0, lastSlash),
+    filter: normalized.slice(lastSlash + 1),
+  };
+}
+
+function buildDisplayPath(parentPath: string, name: string): string {
+  if (parentPath === ".") {
+    return `./${name}`;
+  }
+  return `./${parentPath}/${name}`;
+}
+
 export function SessionFilesPanel({
   className,
   sessionId,
@@ -80,6 +105,25 @@ export function SessionFilesPanel({
   const [error, setError] = useState<string | null>(null);
   const requestIdRef = useRef(0);
 
+  // Path input & autocomplete state
+  const [inputValue, setInputValue] = useState(".");
+  const [suggestions, setSuggestions] = useState<SessionFileEntry[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [activeSuggestion, setActiveSuggestion] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isComposingRef = useRef(false);
+  // When focused on a complete directory path (e.g. "./projects/foo" without "/"),
+  // this ref stores the resolved directory path so applySuggestion can build
+  // the correct full path (e.g. "./projects/foo/bar").
+  const suggestionBasePathRef = useRef<string | null>(null);
+
+  // Sync input value when currentPath changes externally (click, Up, Root)
+  useEffect(() => {
+    setInputValue(getDisplayPath(currentPath));
+  }, [currentPath]);
+
   // Inject CSS override for Radix UI ScrollArea (build-safe: inlined to avoid
   // Vite/Tailwind CSS tree-shaking dropping the global rule).
   useEffect(() => {
@@ -88,7 +132,7 @@ export function SessionFilesPanel({
     const style = document.createElement("style");
     style.id = id;
     style.textContent =
-      '[data-radix-scroll-area-viewport] > div[style*="display:table"] { display: block !important; }';
+      '[data-radix-scroll-area-viewport] > div { display: block !important; min-width: 0 !important; }';
     document.head.appendChild(style);
     return () => {
       document.getElementById(id)?.remove();
@@ -138,6 +182,178 @@ export function SessionFilesPanel({
   useEffect(() => {
     loadDirectory(currentPath).catch(() => undefined);
   }, [currentPath, loadDirectory]);
+
+  const fetchSuggestions = useCallback(
+    async (input: string, isFocus = false) => {
+      if (!onListSessionDirectory) {
+        setSuggestions([]);
+        return;
+      }
+
+      // Focus mode: if input looks like a complete directory path
+      // (no trailing "/"), try listing it directly first.
+      if (isFocus && !input.endsWith("/") && input !== "." && input !== "./") {
+        const fullPath = input.replace(/^\.\//, "");
+        if (fullPath) {
+          try {
+            const entries = await onListSessionDirectory(sessionId, fullPath);
+            // Full path is a directory — show its contents.
+            suggestionBasePathRef.current = fullPath;
+            setSuggestions(entries.slice(0, 20));
+            setActiveSuggestion(-1);
+            return;
+          } catch {
+            // Not a directory, fall through to normal behavior.
+          }
+        }
+      }
+
+      suggestionBasePathRef.current = null;
+      const { parentPath, filter } = parsePathInput(input);
+      try {
+        const allEntries = await onListSessionDirectory(sessionId, parentPath);
+        const filtered = filter
+          ? allEntries.filter((e) =>
+              e.name.toLowerCase().startsWith(filter.toLowerCase()),
+            )
+          : allEntries;
+        setSuggestions(filtered.slice(0, 20));
+        setActiveSuggestion(-1);
+      } catch {
+        setSuggestions([]);
+      }
+    },
+    [onListSessionDirectory, sessionId],
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setInputValue(value);
+      setShowSuggestions(true);
+      suggestionBasePathRef.current = null;
+
+      if (suggestTimerRef.current) {
+        clearTimeout(suggestTimerRef.current);
+      }
+      suggestTimerRef.current = setTimeout(() => {
+        fetchSuggestions(value).catch(() => undefined);
+      }, SUGGESTION_DEBOUNCE_MS);
+    },
+    [fetchSuggestions],
+  );
+
+  const navigateToInputPath = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed || trimmed === ".") {
+      setCurrentPath(".");
+      setShowSuggestions(false);
+      suggestionBasePathRef.current = null;
+      return;
+    }
+    // Strip leading ./ if present
+    let target = trimmed.replace(/^\.\//, "");
+    if (target === "") {
+      target = ".";
+    }
+    setCurrentPath(target);
+    setShowSuggestions(false);
+    setActiveSuggestion(-1);
+    suggestionBasePathRef.current = null;
+  }, [inputValue]);
+
+  const applySuggestion = useCallback(
+    (suggestion: SessionFileEntry) => {
+      const basePath = suggestionBasePathRef.current;
+      let fullPath: string;
+      let display: string;
+
+      if (basePath) {
+        // Focus-directory mode: basePath itself is the parent directory.
+        fullPath = joinSessionPath(basePath, suggestion.name);
+        display = buildDisplayPath(basePath, suggestion.name);
+      } else {
+        const { parentPath, filter } = parsePathInput(inputValue);
+        fullPath = joinSessionPath(parentPath, suggestion.name);
+        display = buildDisplayPath(parentPath, suggestion.name);
+      }
+
+      setInputValue(display);
+      setShowSuggestions(false);
+      setActiveSuggestion(-1);
+      suggestionBasePathRef.current = null;
+
+      if (suggestion.type === "directory") {
+        setCurrentPath(fullPath);
+      } else {
+        inputRef.current?.focus();
+      }
+    },
+    [inputValue],
+  );
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (isComposingRef.current) {
+        return;
+      }
+
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (showSuggestions && activeSuggestion >= 0 && suggestions[activeSuggestion]) {
+          applySuggestion(suggestions[activeSuggestion]);
+        } else {
+          navigateToInputPath();
+        }
+        return;
+      }
+
+      if (e.key === "Escape") {
+        setShowSuggestions(false);
+        setActiveSuggestion(-1);
+        return;
+      }
+
+      if (!showSuggestions || suggestions.length === 0) {
+        return;
+      }
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveSuggestion((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : 0,
+        );
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveSuggestion((prev) =>
+          prev > 0 ? prev - 1 : suggestions.length - 1,
+        );
+      }
+    },
+    [
+      showSuggestions,
+      activeSuggestion,
+      suggestions,
+      applySuggestion,
+      navigateToInputPath,
+    ],
+  );
+
+  // Close suggestions on click outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setShowSuggestions(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   const handleRefresh = useCallback(() => {
     loadDirectory(currentPath, true).catch(() => undefined);
@@ -224,11 +440,69 @@ export function SessionFilesPanel({
           ) : null}
         </div>
 
-        <div
-          className="mt-2 truncate rounded-md border bg-muted/40 px-2.5 py-2 text-xs text-muted-foreground"
-          title={getDisplayPath(currentPath)}
-        >
-          {getDisplayPath(currentPath)}
+        {/* Editable path input with autocomplete */}
+        <div ref={containerRef} className="relative mt-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={handleInputChange}
+            onKeyDown={handleInputKeyDown}
+            onFocus={() => {
+              setShowSuggestions(true);
+              fetchSuggestions(inputValue, true).catch(() => undefined);
+            }}
+            onCompositionStart={() => {
+              isComposingRef.current = true;
+            }}
+            onCompositionEnd={(e) => {
+              isComposingRef.current = false;
+              setInputValue(e.currentTarget.value);
+              fetchSuggestions(e.currentTarget.value).catch(() => undefined);
+            }}
+            className={cn(
+              "w-full truncate rounded-md border bg-muted/40 px-2.5 py-2 text-xs text-muted-foreground outline-none transition-[color,box-shadow]",
+              "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[2px]",
+              "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+            )}
+            aria-label="Current path"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+
+          {showSuggestions && suggestions.length > 0 && (
+            <div className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-popover shadow-md">
+              {suggestions.map((entry, index) => {
+                const isDir = entry.type === "directory";
+                return (
+                  <button
+                    key={`${entry.type}:${entry.name}`}
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => applySuggestion(entry)}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs transition-colors",
+                      index === activeSuggestion
+                        ? "bg-accent text-accent-foreground"
+                        : "text-popover-foreground hover:bg-accent/50",
+                    )}
+                  >
+                    {isDir ? (
+                      <FolderIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <FileTextIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="truncate">{entry.name}</span>
+                    {isDir && (
+                      <ChevronRightIcon className="ml-auto size-3 shrink-0 text-muted-foreground" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
       </div>
 
@@ -297,7 +571,12 @@ export function SessionFilesPanel({
                     >
                       <div
                         className="truncate text-sm font-medium w-full"
-                        style={{ width: "100%" }}
+                        style={{
+                          width: "100%",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
                         title={entry.name}
                       >
                         {entry.name}

--- a/web/src/features/chat/components/session-files-panel.tsx
+++ b/web/src/features/chat/components/session-files-panel.tsx
@@ -230,7 +230,7 @@ export function SessionFilesPanel({
             <div className="rounded-xl border border-destructive/20 bg-destructive/5 p-4 text-sm">
               <div className="flex items-start gap-2">
                 <AlertTriangleIcon className="mt-0.5 size-4 text-destructive" />
-                <div className="min-w-0 flex-1">
+                <div className="min-w-0 flex-1 overflow-hidden">
                   <div className="font-medium text-foreground">
                     Failed to load this directory
                   </div>
@@ -267,7 +267,7 @@ export function SessionFilesPanel({
                 return (
                   <div
                     key={`${entry.type}:${itemPath}`}
-                    className="flex items-center gap-2 rounded-xl border bg-card/60 px-2.5 py-2"
+                    className="flex items-center gap-2 rounded-xl border bg-card/60 px-2.5 py-2 overflow-hidden"
                   >
                     {isDirectory ? (
                       <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -275,9 +275,9 @@ export function SessionFilesPanel({
                       <FileTextIcon className="size-4 shrink-0 text-muted-foreground" />
                     )}
 
-                    <div className="min-w-0 flex-1">
+                    <div className="min-w-0 flex-1 overflow-hidden">
                       <div
-                        className="truncate text-sm font-medium"
+                        className="truncate text-sm font-medium w-full"
                         title={entry.name}
                       >
                         {entry.name}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -435,3 +435,12 @@ body {
     opacity: 1 !important;
   }
 }
+
+/* ==========================================================================
+ * Fix: Override Radix UI ScrollArea content container display
+ * Prevents content width from expanding beyond viewport when filenames are long.
+ * See: https://github.com/MoonshotAI/kimi-cli/issues/TODO
+ * ========================================================================== */
+[data-radix-scroll-area-viewport] > div[style*="display:table"] {
+  display: block !important;
+}


### PR DESCRIPTION
## Summary
This PR adds an **editable path bar with smart autocomplete** to the Workspace files sidebar, significantly improving navigation efficiency when working with deep directory structures. Users can now type paths directly, get intelligent suggestions, and jump to any directory without repetitive mouse clicks.

## Problem
The current Workspace files sidebar only supports navigation via mouse clicks:
- Click directory arrow `>` to enter
- Click **Up** / **Root** buttons to go back
- No way to jump directly to a deeply nested path like `./projects/vcp-mate/src/components`

This is tedious when working with complex project structures.

## Solution

### 1. Editable Path Input
- Replaced the static path display `<div>` with an `<input type="text">` field
- Users can type a path and press **Enter** to jump directly to that directory
- Input value syncs automatically when navigating via clicks (Up, Root, directory arrows)

### 2. Smart Autocomplete Dropdown
The autocomplete works in two modes:

#### Mode A: Filter mode (while typing)
- Parses input to identify parent directory and filter prefix
- Examples:
  - `./projects/vcp` → lists `./projects/` entries filtered by `vcp*`
  - `docker` → lists current directory entries filtered by `docker*`
- Debounced at **150ms** to avoid excessive API calls

#### Mode B: Focus-directory mode (on click/focus)
- When the input contains a complete directory path (e.g. `./projects/HY-World-2.0` without trailing `/`)
- On focus, the component automatically detects that the path is a directory
- Suggestions switch to showing the **contents of that directory**
- Example: focus on `./projects/HY-World-2.0` → shows `src/`, `docs/`, `package.json`, etc.

### 3. Keyboard & Mouse Navigation
| Key | Action |
|-----|--------|
| `↑` / `↓` | Navigate suggestion items |
| `Enter` | Select highlighted suggestion, or jump to typed path |
| `Escape` | Close dropdown |
| Mouse click | Select suggestion |

### 4. IME Support
- Correctly handles CJK input method composition state
- `onCompositionStart` / `onCompositionEnd` prevent premature autocomplete during IME composition

### 5. Long Filename Fix (included)
This branch also includes the fix for the long-filename bug where action buttons get pushed out of viewport:
- Inline `overflow: hidden` styles on file list items (Tailwind v4 build-safe)
- Inline `text-overflow: ellipsis` + `white-space: nowrap` on filename divs
- Runtime CSS injection to override Radix UI ScrollArea `display: table` → `display: block`

## Technical Details

### New state & refs
```ts
const [inputValue, setInputValue] = useState(".");
const [suggestions, setSuggestions] = useState<SessionFileEntry[]>([]);
const [showSuggestions, setShowSuggestions] = useState(false);
const [activeSuggestion, setActiveSuggestion] = useState(-1);
const suggestionBasePathRef = useRef<string | null>(null);
```

### Focus-directory detection logic
```ts
// On focus, try treating the full input as a directory path
if (isFocus && !input.endsWith("/") && input !== "." && input !== "./") {
  const fullPath = input.replace(/^\.\//, "");
  const entries = await onListSessionDirectory(sessionId, fullPath);
  // If successful, show this directory's contents
  suggestionBasePathRef.current = fullPath;
}
```

### Path construction on selection
```ts
if (suggestionBasePathRef.current) {
  // Focus-directory mode: basePath itself is the parent
  fullPath = joinSessionPath(basePath, suggestion.name);
} else {
  // Normal filter mode
  const { parentPath } = parsePathInput(inputValue);
  fullPath = joinSessionPath(parentPath, suggestion.name);
}
```

## Files Changed
- `web/src/features/chat/components/session-files-panel.tsx`

## Verification Checklist
- [x] Path input accepts typed paths and jumps on Enter
- [x] Autocomplete dropdown appears while typing (filter mode)
- [x] Focus on a directory path shows its contents (focus-directory mode)
- [x] Keyboard navigation (↑/↓/Enter/Escape) works
- [x] Mouse selection works
- [x] IME composition handled correctly
- [x] Input syncs with click navigation (Up/Root/directory arrows)
- [x] Long filenames truncate with `...` ellipsis
- [x] Action buttons remain visible with long filenames

## Notes for Maintainers
- The ScrollArea CSS override is injected at runtime via `useEffect` rather than `index.css`, because Tailwind CSS v4 + LightningCSS appears to drop certain global CSS rules (like `.overflow-hidden` and `.truncate`) from the production build.
- All critical layout styles are applied as inline `style` props to ensure they survive the build process regardless of Tailwind configuration.
- The `suggestionBasePathRef` pattern is used (instead of state) to avoid stale closures in the `applySuggestion` callback.

Closes #2216
