### PR TITLE
fix: recover background auto-trigger after cooldown

### DIFF
--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -73,6 +73,9 @@ class _PromptEvent:
 _MAX_BG_AUTO_TRIGGER_FAILURES = 3
 """Stop auto-triggering after this many consecutive failures."""
 
+_BG_AUTO_TRIGGER_FAILURE_COOLDOWN_S = 600.0
+"""Temporarily pause background auto-trigger after repeated failures."""
+
 _BG_AUTO_TRIGGER_INPUT_GRACE_S = 0.75
 """Delay background auto-trigger briefly after local prompt activity."""
 
@@ -510,6 +513,7 @@ class Shell:
 
             shell_ok = True
             bg_auto_failures = 0
+            bg_auto_disabled_until: float | None = None
             deferred_bg_trigger = False
             try:
                 while True:
@@ -526,7 +530,19 @@ class Shell:
                     else:
                         bg_watcher.clear()
                         if bg_auto_failures >= _MAX_BG_AUTO_TRIGGER_FAILURES:
-                            result = await idle_events.get()
+                            if bg_auto_disabled_until is None:
+                                bg_auto_disabled_until = (
+                                    time.monotonic() + _BG_AUTO_TRIGGER_FAILURE_COOLDOWN_S
+                                )
+                            cooldown_remaining = bg_auto_disabled_until - time.monotonic()
+                            if cooldown_remaining <= 0:
+                                bg_auto_failures = 0
+                                bg_auto_disabled_until = None
+                                continue
+                            result = await self._wait_for_background_auto_trigger_cooldown(
+                                idle_events,
+                                timeout_s=cooldown_remaining,
+                            )
                         else:
                             result = await bg_watcher.wait_for_next(idle_events)
 
@@ -547,6 +563,10 @@ class Shell:
                         console.print()
                         if not ok:
                             bg_auto_failures += 1
+                            if bg_auto_failures >= _MAX_BG_AUTO_TRIGGER_FAILURES:
+                                bg_auto_disabled_until = (
+                                    time.monotonic() + _BG_AUTO_TRIGGER_FAILURE_COOLDOWN_S
+                                )
                             logger.warning(
                                 "Background auto-trigger failed ({n}/{max})",
                                 n=bg_auto_failures,
@@ -554,6 +574,7 @@ class Shell:
                             )
                         else:
                             bg_auto_failures = 0
+                            bg_auto_disabled_until = None
                         if self._exit_after_run:
                             console.print("Bye!")
                             break
@@ -562,6 +583,11 @@ class Shell:
                     event = result
 
                     if event.kind == "input_activity":
+                        continue
+
+                    if event.kind == "bg_retry":
+                        bg_auto_failures = 0
+                        bg_auto_disabled_until = None
                         continue
 
                     if event.kind == "bg_noop":
@@ -588,6 +614,7 @@ class Shell:
                     user_input = event.user_input
                     assert user_input is not None
                     bg_auto_failures = 0
+                    bg_auto_disabled_until = None
                     deferred_bg_trigger = False
                     if not user_input:
                         logger.debug("Got empty input, skipping")
@@ -1033,6 +1060,17 @@ class Shell:
             within_s=_BG_AUTO_TRIGGER_INPUT_GRACE_S
         )
         return remaining if remaining > 0 else None
+
+    @staticmethod
+    async def _wait_for_background_auto_trigger_cooldown(
+        idle_events: asyncio.Queue[_PromptEvent],
+        *,
+        timeout_s: float,
+    ) -> _PromptEvent:
+        try:
+            return await asyncio.wait_for(idle_events.get(), timeout=timeout_s)
+        except TimeoutError:
+            return _PromptEvent(kind="bg_retry")
 
     async def _wait_for_input_or_activity(
         self,

--- a/tests/ui_and_conv/test_background_completion_watcher.py
+++ b/tests/ui_and_conv/test_background_completion_watcher.py
@@ -265,3 +265,32 @@ async def test_shell_wait_for_input_or_activity_times_out_for_recent_activity_on
 
     assert result.kind == "input_activity"
     assert elapsed >= 0.04
+
+
+@pytest.mark.asyncio
+async def test_shell_background_auto_trigger_cooldown_returns_idle_event() -> None:
+    queue: asyncio.Queue[_PromptEvent] = asyncio.Queue()
+    expected = _PromptEvent(kind="input")
+    await queue.put(expected)
+
+    result = await Shell._wait_for_background_auto_trigger_cooldown(
+        queue,
+        timeout_s=1.0,
+    )
+
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_shell_background_auto_trigger_cooldown_expires_to_retry() -> None:
+    queue: asyncio.Queue[_PromptEvent] = asyncio.Queue()
+
+    started = asyncio.get_running_loop().time()
+    result = await Shell._wait_for_background_auto_trigger_cooldown(
+        queue,
+        timeout_s=0.05,
+    )
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert result.kind == "bg_retry"
+    assert elapsed >= 0.04


### PR DESCRIPTION
﻿Fixes #2193.

## What changed
- pause background auto-trigger for 10 minutes after 3 consecutive failed follow-up runs
- reset the failure counter after the cooldown expires so new background completions can trigger the agent again
- keep user input responsive during the cooldown
- add focused regression coverage for the cooldown wait path

## To verify
- uv run ruff check src\kimi_cli\ui\shell\__init__.py tests\ui_and_conv\test_background_completion_watcher.py
- uv run pytest tests\ui_and_conv\test_background_completion_watcher.py -q
- uv run ruff format --check src\kimi_cli\ui\shell\__init__.py tests\ui_and_conv\test_background_completion_watcher.py
- uv run pyright src\kimi_cli\ui\shell\__init__.py tests\ui_and_conv\test_background_completion_watcher.py
- uv run python -m py_compile src\kimi_cli\ui\shell\__init__.py tests\ui_and_conv\test_background_completion_watcher.py
- git diff --check

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->