### PR TITLE
feat(skill,agent): add .piebox/skills and align AGENTS.local.md loading

### DIFF
--- a/src/kimi_cli/agents/default/system.md
+++ b/src/kimi_cli/agents/default/system.md
@@ -112,9 +112,7 @@ Markdown files named `AGENTS.md` usually contain the background, structure, codi
 
 The `AGENTS.md` instructions (merged from all applicable directories):
 
-`````````
 ${KIMI_AGENTS_MD}
-`````````
 
 `AGENTS.md` files can appear at any level of the project directory tree, including inside `.kimi/` directories. Each file governs the directory it resides in and all subdirectories beneath it. When multiple `AGENTS.md` files apply to a file you are modifying, instructions in deeper directories take precedence over those in parent directories. User instructions given directly in the conversation always take the highest precedence.
 
@@ -144,6 +142,8 @@ ${KIMI_SKILLS}
 ## How to use skills
 
 Identify the skills that are likely to be useful for the tasks you are currently working on, read the `SKILL.md` file for detailed instructions, guidelines, scripts and more.
+
+When a skill is triggered — by the user invoking `/skill:xxx` or `/flow:xxx`, or when the task clearly matches a skill's description — you must use that skill for the current turn. Follow its instructions directly; if the skill does not explicitly ask you to confirm with the user, proceed without asking.
 
 Only read skill details when needed to conserve the context window.
 

--- a/src/kimi_cli/skill/__init__.py
+++ b/src/kimi_cli/skill/__init__.py
@@ -27,7 +27,7 @@ SkillScope = Literal["builtin", "user", "project", "extra"]
 - ``builtin``: bundled with kimi-cli
 - ``user``: from the user's home (``~/.kimi/skills``, ``~/.agents/skills``, ...)
 - ``project``: from the current project's working directory
-  (``<work_dir>/.kimi/skills``, ``<work_dir>/.agents/skills``, ...)
+  (``<work_dir>/.piebox/skills``, ``<work_dir>/.kimi/skills``, ``<work_dir>/.agents/skills``, ...)
 - ``extra``: from ``extra_skill_dirs`` config or ``--skills-dir`` override
 """
 
@@ -90,9 +90,10 @@ def _get_project_brand_skills_dir_candidates(work_dir: KaosPath) -> tuple[KaosPa
     """
     Get project-level brand skills directory candidates in priority order.
 
-    Brand group: ``.kimi/skills`` > ``.claude/skills`` > ``.codex/skills``
+    Brand group: ``.piebox/skills`` > ``.kimi/skills`` > ``.claude/skills`` > ``.codex/skills``
     """
     return (
+        work_dir / ".piebox" / "skills",
         work_dir / ".kimi" / "skills",
         work_dir / ".claude" / "skills",
         work_dir / ".codex" / "skills",

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -89,13 +89,14 @@ async def load_agents_md(work_dir: KaosPath) -> str | None:
 
     For each directory on the path, the following candidates are checked in order:
 
-    1. ``.kimi/AGENTS.md``  — project-local kimi config (highest priority)
-    2. ``AGENTS.md``        — standard location
-    3. ``agents.md``        — lowercase variant (mutually exclusive with 2)
+    1. ``.kimi/AGENTS.md``       — project-local kimi config
+    2. ``AGENTS.md``             — standard location
+    3. ``agents.md``             — lowercase variant (mutually exclusive with 2)
+    4. ``.kimi/AGENTS.local.md`` — project-local local override
+    5. ``AGENTS.local.md``       — local override (highest priority, loaded last)
 
-    Within a single directory, ``.kimi/AGENTS.md`` and ``AGENTS.md``/``agents.md``
-    are **both** loaded (with ``.kimi/`` first), but ``AGENTS.md`` and ``agents.md``
-    are mutually exclusive (uppercase wins).
+    Within a single directory, all of the above are **all** loaded (in that order),
+    but ``AGENTS.md`` and ``agents.md`` are mutually exclusive (uppercase wins).
 
     All discovered files are concatenated root→leaf, separated by ``\\n\\n``, with
     source annotations.  Total size is capped at :data:`_AGENTS_MD_MAX_BYTES`.
@@ -112,6 +113,9 @@ async def load_agents_md(work_dir: KaosPath) -> str | None:
         kimi_path = d / ".kimi" / "AGENTS.md"
         # AGENTS.md and agents.md are mutually exclusive (uppercase wins)
         root_candidates = [d / "AGENTS.md", d / "agents.md"]
+        # .kimi/AGENTS.local.md is always checked independently
+        kimi_local_path = d / ".kimi" / "AGENTS.local.md"
+        local_path = d / "AGENTS.local.md"
 
         candidates: list[KaosPath] = []
         if await kimi_path.is_file():
@@ -120,6 +124,10 @@ async def load_agents_md(work_dir: KaosPath) -> str | None:
             if await rc.is_file():
                 candidates.append(rc)
                 break
+        if await kimi_local_path.is_file():
+            candidates.append(kimi_local_path)
+        if await local_path.is_file():
+            candidates.append(local_path)
 
         for path in candidates:
             content = (await path.read_text()).strip()

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -786,8 +786,11 @@ class KimiSoul:
                 )
                 return
             extra = args.strip()
+            header = f"The user has triggered the skill '{_skill.name}'. Follow the instructions below and execute accordingly. If the skill does not explicitly require user confirmation, proceed directly."
             if extra:
-                skill_text = f"{skill_text}\n\nUser request:\n{extra}"
+                skill_text = f"{header}\n\n{skill_text}\n\nUser request:\n{extra}"
+            else:
+                skill_text = f"{header}\n\n{skill_text}"
             await soul._turn(Message(role="user", content=skill_text))
 
         _run_skill.__doc__ = skill.description

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import subprocess
 import time
+import types
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass
@@ -1522,6 +1523,7 @@ class CustomPromptSession:
         )
         self._install_slash_completion_menu()
         self._install_prompt_buffer_visibility()
+        self._install_display_line_navigation()
         self._apply_mode()
 
         # Allow completion to be triggered when the text is changed,
@@ -1592,6 +1594,119 @@ class CustomPromptSession:
             self._should_render_input_buffer
         )
         self._prompt_buffer_container = buffer_container
+
+    def _install_display_line_navigation(self) -> None:
+        """Patch buffer cursor methods to move by wrapped display lines."""
+        buf = self._session.default_buffer
+
+        def _get_render_info():
+            container = self._prompt_buffer_container
+            if container is None:
+                return None
+            window = container.content
+            if not isinstance(window, Window):
+                return None
+            return window.render_info
+
+        def _is_first_display_line(buffer: Buffer) -> bool:
+            ri = _get_render_info()
+            if ri is None or not ri.wrap_lines:
+                return buffer.document.cursor_position_row == 0
+            return ri.cursor_position.y <= 0
+
+        def _is_last_display_line(buffer: Buffer) -> bool:
+            ri = _get_render_info()
+            if ri is None or not ri.wrap_lines:
+                return buffer.document.cursor_position_row >= buffer.document.line_count - 1
+            if not ri.visible_line_to_row_col:
+                return True
+            max_y = max(ri.visible_line_to_row_col.keys())
+            return ri.cursor_position.y >= max_y
+
+        def _move_cursor_by_display_line(
+            buffer: Buffer, direction: int, count: int
+        ) -> bool:
+            """Move cursor up/down by display line. Return True if moved."""
+            ri = _get_render_info()
+            if ri is None or not ri.wrap_lines:
+                return False
+
+            current_yx = ri.cursor_position
+            target_y = current_yx.y + direction * count
+
+            if not ri.visible_line_to_row_col:
+                return False
+            max_visible_y = max(ri.visible_line_to_row_col.keys())
+            if target_y < 0 or target_y > max_visible_y:
+                return False
+
+            target_rowcol = ri.visible_line_to_row_col.get(target_y)
+            if target_rowcol is None:
+                return False
+
+            target_row = target_rowcol[0]
+            target_abs_y = target_y + getattr(ri, "_y_offset", 0)
+            target_abs_x = current_yx.x + getattr(ri, "_x_offset", 0)
+
+            best_col: int | None = None
+            best_diff = float("inf")
+            for (_row, col), (y, x) in getattr(ri, "_rowcol_to_yx", {}).items():
+                if y == target_abs_y:
+                    diff = abs(x - target_abs_x)
+                    if diff < best_diff:
+                        best_diff = diff
+                        best_col = col
+
+            if best_col is None:
+                return False
+
+            line_text = buffer.document.lines[target_row]
+            best_col = min(best_col, len(line_text))
+
+            new_pos = buffer.document.translate_row_col_to_index(target_row, best_col)
+            buffer.cursor_position = new_pos
+            buffer.preferred_column = best_col
+            return True
+
+        original_cursor_up = Buffer.cursor_up
+        original_cursor_down = Buffer.cursor_down
+
+        def _display_cursor_up(self: Buffer, count: int = 1) -> None:
+            if not _move_cursor_by_display_line(self, -1, count):
+                original_cursor_up(self, count)
+
+        def _display_cursor_down(self: Buffer, count: int = 1) -> None:
+            if not _move_cursor_by_display_line(self, 1, count):
+                original_cursor_down(self, count)
+
+        def _display_auto_up(
+            self: Buffer, count: int = 1, go_to_start_of_line_if_history_changes: bool = False
+        ) -> None:
+            if self.complete_state:
+                self.complete_previous(count=count)
+            elif not _is_first_display_line(self):
+                _display_cursor_up(self, count)
+            elif not self.selection_state:
+                self.history_backward(count=count)
+                if go_to_start_of_line_if_history_changes:
+                    self.cursor_position += self.document.get_start_of_line_position()
+
+        def _display_auto_down(
+            self: Buffer, count: int = 1, go_to_start_of_line_if_history_changes: bool = False
+        ) -> None:
+            if self.complete_state:
+                self.complete_next(count=count)
+            elif not _is_last_display_line(self):
+                _display_cursor_down(self, count)
+            elif not self.selection_state:
+                self.history_forward(count=count)
+                if go_to_start_of_line_if_history_changes:
+                    self.cursor_position += self.document.get_start_of_line_position()
+
+        buf.cursor_up = types.MethodType(_display_cursor_up, buf)
+        buf.cursor_down = types.MethodType(_display_cursor_down, buf)
+        buf.auto_up = types.MethodType(_display_auto_up, buf)
+        buf.auto_down = types.MethodType(_display_auto_down, buf)
 
     def _should_show_slash_completion_menu(self) -> bool:
         document = self._session.default_buffer.document

--- a/tests/core/test_load_agents_md.py
+++ b/tests/core/test_load_agents_md.py
@@ -72,6 +72,74 @@ async def test_kimi_dir_and_root_both_loaded(temp_work_dir: KaosPath):
     assert content.count("<!-- From:") == 2
 
 
+async def test_local_md_loaded(temp_work_dir: KaosPath):
+    """AGENTS.local.md is loaded alongside AGENTS.md; .local is last (highest override)."""
+    await (temp_work_dir / "AGENTS.md").write_text("root agents")
+    await (temp_work_dir / "AGENTS.local.md").write_text("local agents")
+
+    content = await load_agents_md(temp_work_dir)
+
+    assert content is not None
+    assert content.index("root agents") < content.index("local agents")
+    assert content.count("<!-- From:") == 2
+
+
+async def test_local_md_overrides_kimi_and_root(temp_work_dir: KaosPath):
+    """AGENTS.local.md is loaded after .kimi/AGENTS.md and AGENTS.md."""
+    kimi_dir = temp_work_dir / ".kimi"
+    await kimi_dir.mkdir()
+    await (kimi_dir / "AGENTS.md").write_text("kimi agents")
+    await (temp_work_dir / "AGENTS.md").write_text("root agents")
+    await (temp_work_dir / "AGENTS.local.md").write_text("local agents")
+
+    content = await load_agents_md(temp_work_dir)
+
+    assert content is not None
+    assert content.index("kimi agents") < content.index("root agents") < content.index("local agents")
+    assert content.count("<!-- From:") == 3
+
+
+async def test_local_md_alone(temp_work_dir: KaosPath):
+    """Only AGENTS.local.md exists."""
+    await (temp_work_dir / "AGENTS.local.md").write_text("local only")
+
+    content = await load_agents_md(temp_work_dir)
+
+    assert content is not None
+    assert "local only" in content
+    assert content.count("<!-- From:") == 1
+
+
+async def test_kimi_local_md_loaded(temp_work_dir: KaosPath):
+    """.kimi/AGENTS.local.md is loaded alongside .kimi/AGENTS.md; .local is last."""
+    kimi_dir = temp_work_dir / ".kimi"
+    await kimi_dir.mkdir()
+    await (kimi_dir / "AGENTS.md").write_text("kimi agents")
+    await (kimi_dir / "AGENTS.local.md").write_text("kimi local agents")
+
+    content = await load_agents_md(temp_work_dir)
+
+    assert content is not None
+    assert content.index("kimi agents") < content.index("kimi local agents")
+    assert content.count("<!-- From:") == 2
+
+
+async def test_kimi_local_md_and_root_local_md(temp_work_dir: KaosPath):
+    """.kimi/AGENTS.local.md loads before root AGENTS.local.md."""
+    kimi_dir = temp_work_dir / ".kimi"
+    await kimi_dir.mkdir()
+    await (kimi_dir / "AGENTS.local.md").write_text("kimi local agents")
+    await (temp_work_dir / "AGENTS.local.md").write_text("root local agents")
+
+    content = await load_agents_md(temp_work_dir)
+
+    assert content is not None
+    assert (
+        content.index("kimi local agents") < content.index("root local agents")
+    )
+    assert content.count("<!-- From:") == 2
+
+
 async def test_kimi_dir_in_parent(temp_work_dir: KaosPath):
     """.kimi/AGENTS.md in a parent directory is discovered via hierarchy."""
     await (temp_work_dir / ".git").mkdir()

--- a/tests/core/test_skill.py
+++ b/tests/core/test_skill.py
@@ -460,6 +460,63 @@ async def test_find_project_skills_dirs_brand_prefers_kimi(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_find_project_skills_dirs_piebox_highest_priority(tmp_path):
+    """.piebox/skills takes priority over all other project brand dirs."""
+    work_dir = tmp_path / "project"
+    piebox_dir = work_dir / ".piebox" / "skills"
+    piebox_dir.mkdir(parents=True)
+    kimi_dir = work_dir / ".kimi" / "skills"
+    kimi_dir.mkdir(parents=True)
+
+    dirs = await find_project_skills_dirs(KaosPath.unsafe_from_local_path(work_dir))
+    assert len(dirs) == 1
+    assert dirs[0] == KaosPath.unsafe_from_local_path(piebox_dir)
+
+
+@pytest.mark.asyncio
+async def test_find_project_skills_dirs_piebox_alone(tmp_path):
+    """Only .piebox/skills exists → returned alone."""
+    work_dir = tmp_path / "project"
+    piebox_dir = work_dir / ".piebox" / "skills"
+    piebox_dir.mkdir(parents=True)
+
+    dirs = await find_project_skills_dirs(KaosPath.unsafe_from_local_path(work_dir))
+    assert dirs == [KaosPath.unsafe_from_local_path(piebox_dir)]
+
+
+@pytest.mark.asyncio
+async def test_resolve_skills_roots_piebox_wins_over_brand(monkeypatch, tmp_path):
+    """.piebox/skills skills win over .kimi/skills skills via discover."""
+    work_dir = tmp_path / "project"
+    piebox_dir = work_dir / ".piebox" / "skills"
+    piebox_dir.mkdir(parents=True)
+    _write_skill(
+        piebox_dir / "deploy",
+        "---\nname: deploy\ndescription: piebox deploy\n---\n",
+    )
+
+    kimi_dir = work_dir / ".kimi" / "skills"
+    kimi_dir.mkdir(parents=True)
+    _write_skill(
+        kimi_dir / "deploy",
+        "---\nname: deploy\ndescription: kimi deploy\n---\n",
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "empty_home")
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path / "share"))
+
+    roots = _roots_of(await resolve_skills_roots(KaosPath.unsafe_from_local_path(work_dir)))
+    assert roots[0] == KaosPath.unsafe_from_local_path(piebox_dir)
+
+    skills = await discover_skills_from_roots(
+        [ScopedSkillsRoot(root=KaosPath.unsafe_from_local_path(r), scope="project") for r in roots]
+    )
+    deploy_skills = [s for s in skills if s.name == "deploy"]
+    assert len(deploy_skills) == 1
+    assert deploy_skills[0].description == "piebox deploy"
+
+
+@pytest.mark.asyncio
 async def test_resolve_skills_roots_merges_user_and_project(monkeypatch, tmp_path):
     """Exact ordering (Fix 7): proj_brand → proj_generic → user_brand → user_generic → builtin.
 


### PR DESCRIPTION
- Add `.piebox/skills` skill scanning path
- Support `AGENTS.local.md` loading
- Remove 9-backtick code block wrapping for AGENTS.md in system prompt
- Add display-line navigation in shell prompt (visual wrap line cursor movement)
- Enforce skill usage when triggered via /skill:xxx or /flow:xxx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->