### PR TITLE
feat(telemetry): polish event schema with outcome enum, lifecycle tracking and error enrichment

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -33,6 +33,7 @@ The configuration file contains the following top-level configuration items:
 | `theme` | `string` | Terminal color theme, either `"dark"` or `"light"` (defaults to `"dark"`) |
 | `show_thinking_stream` | `boolean` | Whether to stream the raw reasoning text in the live area as a 6-line scrolling preview and commit the full reasoning markdown to history when the block ends (defaults to `true`; set to `false` to show only the compact `Thinking ...` indicator and a one-line trace summary) |
 | `merge_all_available_skills` | `boolean` | Whether to merge skills from all brand directories (defaults to `true`); see [Skills configuration](../customization/skills.md) |
+| `telemetry` | `boolean` | Whether to enable anonymous telemetry to help improve kimi-cli (defaults to `true`; set to `false` to disable) |
 | `providers` | `table` | API provider configuration |
 | `models` | `table` | Model configuration |
 | `loop_control` | `table` | Agent loop control parameters |
@@ -52,6 +53,7 @@ default_editor = ""
 theme = "dark"
 show_thinking_stream = true
 merge_all_available_skills = true
+telemetry = true
 
 [providers.kimi-for-coding]
 type = "kimi"

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -33,6 +33,7 @@ kimi --config '{"default_model": "kimi-for-coding", "providers": {...}, "models"
 | `theme` | `string` | 终端配色主题，可选 `"dark"` 或 `"light"`（默认为 `"dark"`） |
 | `show_thinking_stream` | `boolean` | 是否在 Live 区域以 6 行滚动预览方式实时展示模型的原始思考文本，并在 thinking 块结束时把完整思考内容（Markdown）写入历史记录（默认为 `true`；设为 `false` 则仅显示紧凑的 `Thinking ...` 指示器和一行 trace 总结） |
 | `merge_all_available_skills` | `boolean` | 是否合并所有品牌目录中的 Skills（默认为 `true`）；详见 [Skills 配置](../customization/skills.md) |
+| `telemetry` | `boolean` | 是否启用匿名遥测以帮助改进 kimi-cli（默认为 `true`；设为 `false` 可关闭） |
 | `providers` | `table` | API 供应商配置 |
 | `models` | `table` | 模型配置 |
 | `loop_control` | `table` | Agent 循环控制参数 |
@@ -52,6 +53,7 @@ default_editor = ""
 theme = "dark"
 show_thinking_stream = true
 merge_all_available_skills = true
+telemetry = true
 
 [providers.kimi-for-coding]
 type = "kimi"

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -5,7 +5,6 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -621,6 +620,9 @@ class KimiSoul:
 
             wire_send(TurnBegin(user_input=user_input))
             turn_started = True
+            from kimi_cli.telemetry import track as _track_telemetry
+
+            _track_telemetry("turn_started", mode="plan" if self._plan_mode else "agent")
             user_message = Message(role="user", content=user_input)
             text_input = user_message.extract_text(" ").strip()
 
@@ -690,6 +692,13 @@ class KimiSoul:
         finally:
             if turn_started and not turn_finished:
                 wire_send(TurnEnd())
+                from kimi_cli.telemetry import track as _track_telemetry
+
+                _track_telemetry(
+                    "turn_interrupted",
+                    mode="plan" if self._plan_mode else "agent",
+                    at_step=getattr(self, "_current_step_no", 0),
+                )
             if created_approval_source is not None and self._runtime.approval_runtime is not None:
                 self._runtime.approval_runtime.cancel_by_source(
                     created_approval_source.kind,

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -1165,9 +1165,17 @@ class KimiSoul:
                 self._context.history, self._runtime.llm, custom_instruction=custom_instruction
             )
 
+        start_time = time.monotonic()
+        retry_count = 0
+
+        def _retry_log_compaction(retry_state: RetryCallState) -> None:
+            nonlocal retry_count
+            retry_count = retry_state.attempt_number
+            self._retry_log("compaction", retry_state)
+
         @tenacity.retry(
             retry=retry_if_exception(self._is_retryable_error),
-            before_sleep=partial(self._retry_log, "compaction"),
+            before_sleep=_retry_log_compaction,
             wait=wait_exponential_jitter(initial=0.3, max=5, jitter=0.5),
             stop=stop_after_attempt(self._loop_control.max_retries_per_step),
             reraise=True,
@@ -1202,13 +1210,16 @@ class KimiSoul:
         wire_send(CompactionBegin())
         try:
             compaction_result = await _compact_with_retry()
-        except Exception:
+        except Exception as _compact_exc:
             from kimi_cli.telemetry import track
 
             track(
                 "compaction_failed",
                 trigger_type=trigger_reason,
                 before_tokens=before_tokens,
+                duration_ms=int((time.monotonic() - start_time) * 1000),
+                retry_count=retry_count,
+                error_type=type(_compact_exc).__name__,
             )
             raise
         await self._context.clear()
@@ -1246,12 +1257,18 @@ class KimiSoul:
 
         from kimi_cli.telemetry import track
 
-        track(
-            "compaction_finished",
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        track_kwargs = dict(
             trigger_type=trigger_reason,
             before_tokens=before_tokens,
             after_tokens=estimated_token_count,
+            duration_ms=duration_ms,
+            retry_count=retry_count,
         )
+        if compaction_result.usage is not None:
+            track_kwargs["llm_input_tokens"] = compaction_result.usage.input
+            track_kwargs["llm_output_tokens"] = compaction_result.usage.output
+        track("compaction_finished", **track_kwargs)
 
         _hook_task = asyncio.create_task(
             self._hook_engine.trigger(

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -886,10 +886,16 @@ class KimiSoul:
                 from kimi_cli.telemetry import track
 
                 error_type, status_code = classify_api_error(e)
+                track_kwargs: dict[str, Any] = {"error_type": error_type}
                 if status_code is not None:
-                    track("api_error", error_type=error_type, status_code=status_code)
-                else:
-                    track("api_error", error_type=error_type)
+                    track_kwargs["status_code"] = status_code
+                # Enrich with context attached by _step() (model, duration, input_tokens)
+                _kimi_ctx = getattr(e, "_kimi_api_error_context", None)
+                if _kimi_ctx is not None:
+                    for key in ("model", "duration_ms", "input_tokens"):
+                        if key in _kimi_ctx:
+                            track_kwargs[key] = _kimi_ctx[key]
+                track("api_error", **track_kwargs)
                 # --- StopFailure hook ---
                 from kimi_cli.hooks import events as _hook_events
 
@@ -1016,7 +1022,18 @@ class KimiSoul:
             )
 
         t0 = time.monotonic()
-        result = await _kosong_step_with_retry()
+        try:
+            result = await _kosong_step_with_retry()
+        except Exception as _step_exc:
+            # Attach known context so the outer loop can enrich api_error telemetry
+            _ctx: dict[str, Any] = {
+                "model": self._runtime.llm.model_name,
+                "duration_ms": int((time.monotonic() - t0) * 1000),
+            }
+            if self._context.token_count > 0:
+                _ctx["input_tokens"] = self._context.token_count
+            _step_exc._kimi_api_error_context = _ctx  # type: ignore[attr-defined]
+            raise
         llm_elapsed = time.monotonic() - t0
         usage = result.usage
         logger.info(
@@ -1189,10 +1206,9 @@ class KimiSoul:
             from kimi_cli.telemetry import track
 
             track(
-                "compaction_triggered",
+                "compaction_failed",
                 trigger_type=trigger_reason,
                 before_tokens=before_tokens,
-                success=False,
             )
             raise
         await self._context.clear()
@@ -1231,11 +1247,10 @@ class KimiSoul:
         from kimi_cli.telemetry import track
 
         track(
-            "compaction_triggered",
+            "compaction_finished",
             trigger_type=trigger_reason,
             before_tokens=before_tokens,
             after_tokens=estimated_token_count,
-            success=True,
         )
 
         _hook_task = asyncio.create_task(

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -217,14 +217,9 @@ class KimiToolset:
 
                     _error_type = type(e).__name__
                     track(
-                        "tool_error",
-                        tool_name=tool_call.function.name,
-                        error_type=_error_type,
-                    )
-                    track(
                         "tool_call",
                         tool_name=tool_call.function.name,
-                        success=False,
+                        outcome="error",
                         duration_ms=int(tool_elapsed * 1000),
                         error_type=_error_type,
                     )
@@ -242,12 +237,21 @@ class KimiToolset:
                 )
                 from kimi_cli.telemetry import track as _track_tool_call
 
-                _track_tool_call(
-                    "tool_call",
-                    tool_name=tool_call.function.name,
-                    success=not isinstance(ret, ToolError),
-                    duration_ms=int(tool_elapsed * 1000),
-                )
+                if isinstance(ret, ToolError):
+                    _track_tool_call(
+                        "tool_call",
+                        tool_name=tool_call.function.name,
+                        outcome="error",
+                        duration_ms=int(tool_elapsed * 1000),
+                        error_type=type(ret).__name__,
+                    )
+                else:
+                    _track_tool_call(
+                        "tool_call",
+                        tool_name=tool_call.function.name,
+                        outcome="success",
+                        duration_ms=int(tool_elapsed * 1000),
+                    )
 
                 # --- PostToolUse (fire-and-forget) ---
                 _hook_task = asyncio.create_task(

--- a/src/kimi_cli/tools/plan/__init__.py
+++ b/src/kimi_cli/tools/plan/__init__.py
@@ -133,6 +133,9 @@ class ExitPlanMode(CallableTool2[Params]):
 
         # Auto-approve plan approval only when no user is present (afk).
         if self._should_auto_approve_exit and self._should_auto_approve_exit():
+            from kimi_cli.telemetry import track
+
+            track("plan_resolved", outcome="auto_approved")
             await self._toggle_callback()
             return ToolReturnValue(
                 is_error=False,
@@ -193,6 +196,10 @@ class ExitPlanMode(CallableTool2[Params]):
         # Display plan content inline in the chat
         wire_send(PlanDisplay(content=plan_content, file_path=str(plan_path)))
 
+        from kimi_cli.telemetry import track as _track_telemetry
+
+        _track_telemetry("plan_submitted", has_options=has_options)
+
         request = QuestionRequest(
             id=str(uuid4()),
             tool_call_id=tool_call.id,
@@ -225,6 +232,7 @@ class ExitPlanMode(CallableTool2[Params]):
             )
 
         if not answers:
+            _track_telemetry("plan_resolved", outcome="dismissed")
             return ToolReturnValue(
                 is_error=False,
                 output="User dismissed without choosing. Plan mode remains active. "
@@ -237,6 +245,7 @@ class ExitPlanMode(CallableTool2[Params]):
         chose_reject_and_exit = any(v == "Reject and Exit" for v in answers.values())
 
         if chose_reject_and_exit:
+            _track_telemetry("plan_resolved", outcome="rejected_and_exited")
             await self._toggle_callback()
             return ToolRejectedError(
                 message=(
@@ -250,6 +259,7 @@ class ExitPlanMode(CallableTool2[Params]):
         chose_reject = any(v == "Reject" for v in answers.values())
 
         if chose_reject:
+            _track_telemetry("plan_resolved", outcome="rejected")
             return ToolRejectedError(
                 message=(
                     "Plan rejected by user. Stay in plan mode. "
@@ -270,6 +280,7 @@ class ExitPlanMode(CallableTool2[Params]):
                     break
 
             if chosen_option:
+                _track_telemetry("plan_resolved", outcome="approved", chosen_option=chosen_option)
                 await self._toggle_callback()
                 return ToolReturnValue(
                     is_error=False,
@@ -288,6 +299,7 @@ class ExitPlanMode(CallableTool2[Params]):
         # Approve — single-approach only (has_options uses option labels, not "Approve")
         chose_approve = not has_options and any(v == "Approve" for v in answers.values())
         if chose_approve:
+            _track_telemetry("plan_resolved", outcome="approved")
             await self._toggle_callback()
             return ToolReturnValue(
                 is_error=False,
@@ -306,6 +318,8 @@ class ExitPlanMode(CallableTool2[Params]):
         for v in answers.values():
             if v not in ("Approve", "Reject", "Reject and Exit"):
                 feedback = v
+        has_feedback = bool(feedback)
+        _track_telemetry("plan_resolved", outcome="revise", has_feedback=has_feedback)
         if feedback:
             msg = (
                 "User wants to revise the plan. Stay in plan mode. "

--- a/src/kimi_cli/tools/plan/enter.py
+++ b/src/kimi_cli/tools/plan/enter.py
@@ -71,6 +71,9 @@ class EnterPlanMode(CallableTool2[Params]):
 
         # Auto-approve entering plan mode when approvals are bypassed.
         if self._is_auto_approve and self._is_auto_approve():
+            from kimi_cli.telemetry import track
+
+            track("plan_enter_resolved", outcome="auto_approved")
             await self._toggle_callback()
             plan_path = self._plan_file_path_getter()
             return ToolReturnValue(
@@ -143,6 +146,9 @@ class EnterPlanMode(CallableTool2[Params]):
             )
 
         if not answers:
+            from kimi_cli.telemetry import track
+
+            track("plan_enter_resolved", outcome="dismissed")
             return ToolReturnValue(
                 is_error=False,
                 output="User dismissed without choosing. Proceed with implementation directly.",
@@ -153,6 +159,9 @@ class EnterPlanMode(CallableTool2[Params]):
         # Parse user choice — exact match on option label
         chose_yes = any(v == "Yes" for v in answers.values())
         if chose_yes:
+            from kimi_cli.telemetry import track
+
+            track("plan_enter_resolved", outcome="accepted")
             await self._toggle_callback()
             plan_path = self._plan_file_path_getter()
             return ToolReturnValue(
@@ -174,6 +183,9 @@ class EnterPlanMode(CallableTool2[Params]):
                 display=[BriefDisplayBlock(text="Plan mode on")],
             )
         else:
+            from kimi_cli.telemetry import track
+
+            track("plan_enter_resolved", outcome="declined")
             return ToolReturnValue(
                 is_error=False,
                 output=(

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -982,12 +982,6 @@ class Shell:
             )
         except RunCancelled:
             logger.info("Cancelled by user")
-            from kimi_cli.telemetry import track
-
-            _at_step = (
-                getattr(self.soul, "_current_step_no", 0) if isinstance(self.soul, KimiSoul) else 0
-            )
-            track("turn_interrupted", at_step=_at_step)
             console.print("[red]Interrupted by user[/red]")
         except Exception as e:
             logger.exception("Unexpected error:")

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -871,7 +871,7 @@ class TestSessionStarted:
 
 
 class TestCompactionTracking:
-    """compaction_triggered must fire on both success and failure paths."""
+    """compaction_finished / compaction_failed must fire on success / failure paths."""
 
     def _make_soul(self, *, before_tokens: int, estimated_after: int) -> Any:
         """Construct a minimal KimiSoul stub bypassing __init__."""
@@ -922,7 +922,7 @@ class TestCompactionTracking:
 
     @pytest.mark.asyncio
     async def test_auto_compaction_success_emits_event(self):
-        """Auto-triggered success: track has trigger_type=auto + after_tokens + success=True."""
+        """Auto-triggered success: track has trigger_type=auto + after_tokens."""
         soul = self._make_soul(before_tokens=12000, estimated_after=3000)
 
         with (
@@ -933,14 +933,13 @@ class TestCompactionTracking:
 
         # Filter to the compaction event — other events (hook triggers etc.)
         # shouldn't go through telemetry.track.
-        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_triggered"]
+        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
         args, kwargs = calls[0]
-        assert args[0] == "compaction_triggered"
+        assert args[0] == "compaction_finished"
         assert kwargs["trigger_type"] == "auto"
         assert kwargs["before_tokens"] == 12000
         assert kwargs["after_tokens"] == 3000
-        assert kwargs["success"] is True
 
     @pytest.mark.asyncio
     async def test_manual_compaction_without_prompt_emits_event(self):
@@ -953,10 +952,9 @@ class TestCompactionTracking:
         ):
             await soul.compact_context(manual=True)
 
-        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_triggered"]
+        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
         assert calls[0][1]["trigger_type"] == "manual"
-        assert calls[0][1]["success"] is True
 
     @pytest.mark.asyncio
     async def test_manual_compaction_with_prompt_emits_event(self):
@@ -969,14 +967,13 @@ class TestCompactionTracking:
         ):
             await soul.compact_context(manual=True, custom_instruction="focus on auth")
 
-        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_triggered"]
+        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
         assert calls[0][1]["trigger_type"] == "manual-with-prompt"
-        assert calls[0][1]["success"] is True
 
     @pytest.mark.asyncio
     async def test_compaction_failure_emits_event_then_reraises(self):
-        """On compaction failure: track success=False (no after_tokens), then re-raise."""
+        """On compaction failure: track compaction_failed (no after_tokens), then re-raise."""
         soul = self._make_soul(before_tokens=50000, estimated_after=0)
         # Force the compaction to fail with a non-retryable error
         soul._run_with_connection_recovery = AsyncMock(side_effect=RuntimeError("compaction boom"))
@@ -988,10 +985,9 @@ class TestCompactionTracking:
         ):
             await soul.compact_context()
 
-        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_triggered"]
+        calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_failed"]
         assert len(calls) == 1
         kwargs = calls[0][1]
         assert kwargs["trigger_type"] == "auto"
         assert kwargs["before_tokens"] == 50000
-        assert kwargs["success"] is False
         assert "after_tokens" not in kwargs

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -484,21 +484,13 @@ class TestEventPropertyCorrectness:
             event = _collect_events()[-1]
             assert event["properties"]["method"] == method
 
-    def test_tool_error_has_tool_name_and_error_type(self):
-        """tool_error includes tool_name and error_type (Python exception class name)."""
-        track("tool_error", tool_name="Bash", error_type="RuntimeError")
-        event = _collect_events()[-1]
-        assert event["event"] == "tool_error"
-        assert event["properties"]["tool_name"] == "Bash"
-        assert event["properties"]["error_type"] == "RuntimeError"
-
     def test_tool_call_success_has_no_error_type(self):
-        """tool_call success path: tool_name + success=True + duration_ms, no error_type."""
-        track("tool_call", tool_name="ReadFile", success=True, duration_ms=123)
+        """tool_call success path: tool_name + outcome=success + duration_ms, no error_type."""
+        track("tool_call", tool_name="ReadFile", outcome="success", duration_ms=123)
         event = _collect_events()[-1]
         assert event["event"] == "tool_call"
         assert event["properties"]["tool_name"] == "ReadFile"
-        assert event["properties"]["success"] is True
+        assert event["properties"]["outcome"] == "success"
         assert event["properties"]["duration_ms"] == 123
         assert isinstance(event["properties"]["duration_ms"], int)
         assert "error_type" not in event["properties"]
@@ -508,13 +500,20 @@ class TestEventPropertyCorrectness:
         track(
             "tool_call",
             tool_name="Bash",
-            success=False,
+            outcome="error",
             duration_ms=42,
             error_type="TimeoutError",
         )
         event = _collect_events()[-1]
-        assert event["properties"]["success"] is False
+        assert event["properties"]["outcome"] == "error"
         assert event["properties"]["error_type"] == "TimeoutError"
+
+    def test_tool_call_cancelled_has_no_error_type(self):
+        """tool_call cancelled path: outcome=cancelled + duration_ms, no error_type."""
+        track("tool_call", tool_name="Bash", outcome="cancelled", duration_ms=10)
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "cancelled"
+        assert "error_type" not in event["properties"]
 
     def test_oauth_refresh_success_has_no_reason(self):
         """oauth_refresh success: only success=True, no reason field."""

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -915,6 +915,7 @@ class TestCompactionTracking:
         fake_result = MagicMock()
         fake_result.messages = []
         fake_result.estimated_token_count = estimated_after
+        fake_result.usage = None
         soul._run_with_connection_recovery = AsyncMock(return_value=fake_result)
 
         soul._injection_providers = []
@@ -940,6 +941,10 @@ class TestCompactionTracking:
         assert kwargs["trigger_type"] == "auto"
         assert kwargs["before_tokens"] == 12000
         assert kwargs["after_tokens"] == 3000
+        assert kwargs["duration_ms"] >= 0
+        assert kwargs["retry_count"] == 0
+        assert "llm_input_tokens" not in kwargs
+        assert "llm_output_tokens" not in kwargs
 
     @pytest.mark.asyncio
     async def test_manual_compaction_without_prompt_emits_event(self):
@@ -955,6 +960,8 @@ class TestCompactionTracking:
         calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
         assert calls[0][1]["trigger_type"] == "manual"
+        assert calls[0][1]["duration_ms"] >= 0
+        assert calls[0][1]["retry_count"] == 0
 
     @pytest.mark.asyncio
     async def test_manual_compaction_with_prompt_emits_event(self):
@@ -970,6 +977,8 @@ class TestCompactionTracking:
         calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
         assert calls[0][1]["trigger_type"] == "manual-with-prompt"
+        assert calls[0][1]["duration_ms"] >= 0
+        assert calls[0][1]["retry_count"] == 0
 
     @pytest.mark.asyncio
     async def test_compaction_failure_emits_event_then_reraises(self):
@@ -991,3 +1000,6 @@ class TestCompactionTracking:
         assert kwargs["trigger_type"] == "auto"
         assert kwargs["before_tokens"] == 50000
         assert "after_tokens" not in kwargs
+        assert kwargs["duration_ms"] >= 0
+        assert kwargs["retry_count"] == 0
+        assert kwargs["error_type"] == "RuntimeError"

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -351,6 +351,19 @@ class TestCancelInterrupt:
         event = _collect_events()[-1]
         assert isinstance(event["properties"]["at_step"], int)
 
+    def test_turn_interrupted_includes_mode(self):
+        """turn_interrupted must include mode property (agent or plan)."""
+        track("turn_interrupted", at_step=1, mode="agent")
+        event = _collect_events()[-1]
+        assert event["properties"]["mode"] == "agent"
+
+    def test_turn_started_includes_mode(self):
+        """turn_started must include mode property."""
+        track("turn_started", mode="plan")
+        event = _collect_events()[-1]
+        assert event["event"] == "turn_started"
+        assert event["properties"]["mode"] == "plan"
+
     def test_cancel_and_dismissed_are_distinct(self):
         """cancel and question_dismissed are different events."""
         track("cancel")
@@ -1003,3 +1016,98 @@ class TestCompactionTracking:
         assert kwargs["duration_ms"] >= 0
         assert kwargs["retry_count"] == 0
         assert kwargs["error_type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# 8. Plan lifecycle events
+# ---------------------------------------------------------------------------
+
+
+class TestPlanLifecycleEvents:
+    """Verify plan mode telemetry events and their properties."""
+
+    def test_plan_submitted_with_has_options(self):
+        """ExitPlanMode emits plan_submitted with has_options flag."""
+        track("plan_submitted", has_options=True)
+        event = _collect_events()[-1]
+        assert event["event"] == "plan_submitted"
+        assert event["properties"]["has_options"] is True
+
+    def test_plan_submitted_without_options(self):
+        """plan_submitted can have has_options=False."""
+        track("plan_submitted", has_options=False)
+        event = _collect_events()[-1]
+        assert event["properties"]["has_options"] is False
+
+    def test_plan_resolved_approved(self):
+        """Plan approval emits plan_resolved with outcome=approved."""
+        track("plan_resolved", outcome="approved")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "approved"
+
+    def test_plan_resolved_approved_with_chosen_option(self):
+        """Multi-approach plan approval includes chosen_option."""
+        track("plan_resolved", outcome="approved", chosen_option="Refactor (Recommended)")
+        event = _collect_events()[-1]
+        assert event["properties"]["chosen_option"] == "Refactor (Recommended)"
+
+    def test_plan_resolved_rejected(self):
+        """Plan rejection emits plan_resolved with outcome=rejected."""
+        track("plan_resolved", outcome="rejected")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "rejected"
+
+    def test_plan_resolved_rejected_and_exited(self):
+        """Plan reject-and-exit emits plan_resolved with outcome=rejected_and_exited."""
+        track("plan_resolved", outcome="rejected_and_exited")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "rejected_and_exited"
+
+    def test_plan_resolved_auto_approved(self):
+        """AFK auto-approval emits plan_resolved with outcome=auto_approved."""
+        track("plan_resolved", outcome="auto_approved")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "auto_approved"
+
+    def test_plan_resolved_dismissed(self):
+        """Plan dismissal emits plan_resolved with outcome=dismissed."""
+        track("plan_resolved", outcome="dismissed")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "dismissed"
+
+    def test_plan_resolved_revise_with_feedback(self):
+        """Plan revision emits plan_resolved with outcome=revise and has_feedback."""
+        track("plan_resolved", outcome="revise", has_feedback=True)
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "revise"
+        assert event["properties"]["has_feedback"] is True
+
+    def test_plan_resolved_revise_without_feedback(self):
+        """Plan revision without text emits plan_resolved with has_feedback=False."""
+        track("plan_resolved", outcome="revise", has_feedback=False)
+        event = _collect_events()[-1]
+        assert event["properties"]["has_feedback"] is False
+
+    def test_plan_enter_resolved_accepted(self):
+        """User accepting plan mode emits plan_enter_resolved with outcome=accepted."""
+        track("plan_enter_resolved", outcome="accepted")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "accepted"
+
+    def test_plan_enter_resolved_declined(self):
+        """User declining plan mode emits plan_enter_resolved with outcome=declined."""
+        track("plan_enter_resolved", outcome="declined")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "declined"
+
+    def test_plan_enter_resolved_dismissed(self):
+        """User dismissing plan mode dialog emits plan_enter_resolved with outcome=dismissed."""
+        track("plan_enter_resolved", outcome="dismissed")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "dismissed"
+
+    def test_plan_enter_resolved_auto_approved(self):
+        """AFK auto-approving plan mode entry emits plan_enter_resolved with outcome=auto_approved."""
+        track("plan_enter_resolved", outcome="auto_approved")
+        event = _collect_events()[-1]
+        assert event["properties"]["outcome"] == "auto_approved"

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -337,7 +337,7 @@ class TestAsyncTransport:
 
         events_in = [
             {"event": "started", "timestamp": 1.0, "properties": {}},
-            {"event": "tool_call", "timestamp": 2.0, "properties": {"success": True}},
+            {"event": "tool_call", "timestamp": 2.0, "properties": {"outcome": "success"}},
         ]
         with patch.object(transport, "_send_http", new=capture):
             await transport.send(events_in)
@@ -349,9 +349,9 @@ class TestAsyncTransport:
         assert [e["event"] for e in outbound] == ["kfc_started", "kfc_tool_call"]
         # Original events list untouched (save_to_disk would keep bare + nested shape)
         assert [e["event"] for e in events_in] == ["started", "tool_call"]
-        assert events_in[1]["properties"] == {"success": True}
+        assert events_in[1]["properties"] == {"outcome": "success"}
         # Properties flattened; timestamp preserved
-        assert outbound[1]["property_success"] is True
+        assert outbound[1]["property_outcome"] == "success"
         assert outbound[1]["timestamp"] == 2.0
         # Outbound events should not carry the nested sub-dicts anymore
         assert "properties" not in outbound[1]


### PR DESCRIPTION
## Summary

This PR polishes the telemetry event schema and adds richer observability across tool calls, API errors, compaction and turn lifecycle.

---

### 1. Unify tool_call/tool_error into single event with outcome enum

**Problem:** Previously, tool success and failure were tracked by two separate events (tool_call and tool_error), making aggregation harder.

**What was done:**
- Removed duplicate tool_error event; error path now emits only tool_call
- Replaced success: bool with outcome: success|error|cancelled
- Included error_type on both exception and ToolError return paths
- Updated tests accordingly

### 2. Enrich api_error with model, duration and input tokens

**Problem:** api_error events lacked contextual metadata needed for debugging.

**What was done:**
- Attached _kimi_api_error_context in _step() with model, duration_ms and input_tokens when available
- Enriched api_error track call via explicit key whitelist

### 3. Add duration, retry and token tracking to compaction events

**Problem:** Compaction events did not capture execution duration or token impact.

**What was done:**
- Split compaction_triggered into compaction_finished (success) and compaction_failed (failure)
- Added duration_ms, retry_count and token deltas to compaction telemetry
- Updated instrumentation tests

### 4. Add turn lifecycle and plan mode tracking events

**Problem:** There was no telemetry coverage for turn boundaries or plan-mode state transitions.

**What was done:**
- Added turn_started with mode (agent/plan) for denominator tracking
- Moved turn_interrupted into KimiSoul.run() finally for unified reporting
- Merged Plan approval outcomes into plan_resolved with outcome enum
- Merged Plan entry outcomes into plan_enter_resolved with outcome enum
- Added plan_submitted with has_options flag
- Updated instrumentation tests

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
