### PR TITLE
chore(skills): upgrade release and gen-changelog skills

### DIFF
--- a/.agents/skills/gen-changelog/SKILL.md
+++ b/.agents/skills/gen-changelog/SKILL.md
@@ -3,18 +3,53 @@ name: gen-changelog
 description: Generate changelog entries for code changes.
 ---
 
-根据当前分支相对于 main 分支的修改，生成更新日志条目并同步到文档站点。
+Generate changelog entries for changes on the current branch relative to `main`, then sync to the docs site.
 
-## 步骤
+## Steps
 
-1. **分析变更**：查看 `git log main..HEAD --oneline` 和 `git diff main..HEAD --stat`，理解所有变更。
-2. **更新源 CHANGELOG**：在根目录 `CHANGELOG.md` 的 `## Unreleased` 下添加条目；如果变更属于 `packages/` 或 `sdks/` 下的子包，同时更新对应目录的 `CHANGELOG.md`。
-3. **同步英文文档 changelog**：运行 `node docs/scripts/sync-changelog.mjs` 将根 `CHANGELOG.md` 同步到 `docs/en/release-notes/changelog.md`。
-4. **更新中文文档 changelog**：在 `docs/zh/release-notes/changelog.md` 的 `## 未发布` 下添加对应的中文翻译条目，遵循现有格式和用词规范（参考 `docs/AGENTS.md` 中的术语表和排版规范）。
-5. **Breaking changes**（如有）：如果变更包含破坏性变更（如移除/重命名选项、更改默认行为、迁移配置格式等），还需在 `docs/en/release-notes/breaking-changes.md` 和 `docs/zh/release-notes/breaking-changes.md` 的 `## Unreleased` / `## 未发布` 下添加对应条目，遵循现有的格式（版本标题 + 小节 + 受影响/迁移说明）。
+1. **Inspect**: `git log main..HEAD --oneline` + `git diff main..HEAD --stat`.
+2. **Edit root CHANGELOG**: add bullets under `## Unreleased` in `CHANGELOG.md` using the prefix table below. For changes scoped to a subpackage under `packages/` or `sdks/`, **also** update that subpackage's `CHANGELOG.md` — subpackage CHANGELOGs follow their own prefix conventions (e.g. `packages/kosong/CHANGELOG.md` uses provider prefixes like `Kimi:` / `Anthropic:`); only the root CHANGELOG follows the table below.
+3. **Sync English docs**: `node docs/scripts/sync-changelog.mjs`.
+4. **Translate to Chinese**: hand-write equivalents under `## 未发布` in `docs/zh/release-notes/changelog.md`. Use the full-width colon `：`. Follow `docs/AGENTS.md` terminology.
+5. **Breaking changes**: if any, add a section under `## Unreleased` in `docs/en/release-notes/breaking-changes.md` with **Affected** + **Migration** subsections, and under `## 未发布` in `docs/zh/release-notes/breaking-changes.md` with **受影响** + **迁移** subsections.
 
-## 注意事项
+## Entry format
 
-- 条目风格遵循现有 CHANGELOG 的格式：`- 分类: 描述`（如 `- Core: ...`、`- Web: ...`）。
-- 只写对用户有意义的变更，不写纯内部重构。
-- 中文翻译应遵循 `docs/AGENTS.md` 中的术语映射和排版规范。
+```
+- <Prefix>: <verb-led sentence, readable standalone> — <optional rationale / before-after / migration>
+```
+
+- **First sentence stands alone** — readers should know after one sentence whether the bullet matters to them.
+- **One change per bullet.** No `; also`, `; and`, or nested em-dashes. Two changes = two bullets.
+- **Verb-led**: `Fix …` / `Add …` / `Switch …` / `Bump …`.
+- **User-meaningful only.** No internal refactors, test churn, or CI tweaks — except `Lib:` for SDK-facing changes.
+
+## Prefixes — pick from this list, do not invent new ones
+
+| Prefix | Scope |
+|---|---|
+| `Shell` | Interactive TUI: keys, status bar, slash commands, terminal rendering |
+| `Web` | `kimi web` |
+| `Vis` | `kimi vis` tracing visualizer |
+| `CLI` | Top-level flags, subcommands, `--print` / `--yolo` / `--afk` |
+| `ACP` | Zed / JetBrains and other ACP integrations |
+| `Core` | Agent runtime, step loop, approval, quota, turns, background tasks |
+| `Tool` | Any built-in tool; name the specific tool in the body (ReadFile, Grep, Todo, Plan, …) |
+| `Skill` | Skill discovery/loading, Flow, Loop (always singular — not `Skills:`) |
+| `MCP` | MCP server integration |
+| `Plugin` | Plugin system, `kimi plugin` subcommands |
+| `LLM` | Provider-agnostic or cross-provider; name the provider in the body (Kimi / Anthropic / OpenAI / DeepSeek …). **Do not** create per-provider prefixes |
+| `Kosong` | Changes to the `kosong` LLM abstraction layer surfaced in the root CHANGELOG (the subpackage's own CHANGELOG uses provider prefixes) |
+| `Wire` | Wire protocol events, version |
+| `Auth` | OAuth, token refresh, `/login` |
+| `Config` | Config schema, env vars |
+| `Lib` | SDK-facing API changes |
+| `Build` | Nix / Rust / Python / packaging |
+
+When unsure, match an existing entry of the same kind. Prefer this list; if you genuinely need a new prefix, raise it with maintainers and update this table in the same PR so the convention stays single-sourced.
+
+**Ordering**: within each version, group bullets by prefix in the order of the table above. Order within a prefix is free — keep the development order.
+
+## Highlights
+
+Starting from the next release, add `**Highlights**: …` under each version header (1–3 items most users will notice); mirror it as `**亮点**：…` in Chinese. Skip on releases that are only internal or `Lib:`. Highlights summarize — every highlighted item still needs its full bullet below. **Do not backfill historical versions.**

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -39,9 +39,14 @@ The Rust implementation (`kagent`) lives in a separate repository and is **not**
 
 8. **Update docs.** Follow the `gen-docs` skill to make sure docs reflect the release.
 
-9. **Open the PR.** Commit all changes, push, and open a PR with `gh` describing the version bumps.
+9. **Confirm with the user before opening the PR.** Summarize the staged changes and ask the user to explicitly confirm:
+   - **Version numbers** — every updated `pyproject.toml` (changed package + `packages/kimi-code` if the root moved) reflects the version agreed in step 3.
+   - **Dependency pins** — the root `pyproject.toml` pins (`kosong[contrib]==<version>`, `pykaos==<version>`) and `packages/kimi-code`'s `kimi-cli==<version>` match the bumped versions.
+   - **Documentation** — CHANGELOG entries are added below `## Unreleased` (Unreleased still present and empty), `breaking-changes.md` is updated in both languages if applicable, and `gen-docs` left no inconsistencies.
 
-10. **Monitor the PR** until it is merged.
+   Wait for explicit user approval before proceeding. If the user flags anything, fix it and re-confirm — do not push.
+
+10. **Open the PR.** Commit all changes, push, and open a PR with `gh` describing the version bumps.
 
 11. **Hand off the tag step.** After merge, switch to `main`, pull latest, and tell the user the exact `git tag` command for the final release tag (pick the right tag pattern from the table above — e.g. `git tag 1.43.0` for a root release, `git tag kosong-0.54.0` for a kosong release). The user will run the tag and push tags themselves.
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,64 +1,56 @@
 ---
 name: release
 description: Execute the release workflow for Kimi Code CLI packages.
-type: flow
 ---
 
-```d2
-understand: |md
-  Understand the release automation by reading AGENTS.md and
-  .github/workflows/release*.yml.
-|
-check_changes: |md
-  Check each package under packages/, sdks/, and repo root for changes since the
-  last release (by tag). Note packages/kimi-code is a thin wrapper and must stay
-  version-synced with kimi-cli.
-|
-has_changes: "Any packages changed?"
-confirm_versions: |md
-  For each changed package, confirm the new version with the user. Follow the
-  project versioning policy: patch is always 0, bump minor for any change,
-  major only changes by explicit manual decision.
-|
-update_files: |md
-  Update the relevant pyproject.toml (and rust/Cargo.toml if root version changes),
-  CHANGELOG.md (keep the Unreleased header), and breaking-changes.md in both languages.
-|
-root_change: "Is the root package version changing?"
-sync_kimi_code: |md
-  Sync packages/kimi-code/pyproject.toml version and dependency
-  `kimi-cli==<version>`.
-|
-sync_kagent: |md
-  Sync rust/Cargo.toml workspace version to match the root package version.
-|
-uv_sync: "Run uv sync."
-gen_docs: |md
-  Follow the gen-docs skill instructions to ensure docs are up to date.
-|
+Release process for Kimi Code CLI packages. Tags are pushed without a `v` prefix and follow one of these patterns (matched by `.github/workflows/release-*.yml`):
 
-new_branch: |md
-  Create a new branch `bump-<package>-<new-version>` (multiple packages can share
-  one branch; name it appropriately).
-|
-open_pr: |md
-  Commit all changes, push to remote, and open a PR with gh describing the
-  updates.
-|
-monitor_pr: "Monitor the PR until it is merged."
-post_merge: |md
-  After merge, switch to main, pull latest changes, and tell the user the git
-  tag command needed for the final release tag (they will tag + push tags). Note:
-  a single numeric tag releases kimi-cli, kimi-code, and kagent together.
-|
+| Tag pattern | Releases |
+|---|---|
+| `1.42.0` (numeric) | `kimi-cli` (root) + `kimi-code` wrapper, released together — versions must stay aligned |
+| `kosong-0.53.0` | `packages/kosong` |
+| `pykaos-0.9.0` | `packages/kaos` (PyPI name `pykaos`) |
+| `kimi-sdk-0.3.0` | `sdks/kimi-sdk` |
 
-BEGIN -> understand -> check_changes -> has_changes
-has_changes -> END: no
-has_changes -> confirm_versions: yes
-confirm_versions -> update_files -> root_change
-root_change -> sync_kimi_code: yes
-root_change -> uv_sync: no
-sync_kimi_code -> sync_kagent
-sync_kagent -> uv_sync
-uv_sync -> gen_docs -> new_branch -> open_pr -> monitor_pr -> post_merge -> END
-```
+The Rust implementation (`kagent`) lives in a separate repository and is **not** released from here.
+
+## Steps
+
+1. **Understand the automation.** Read `AGENTS.md` and `.github/workflows/release*.yml` so you know what each release workflow expects before changing any versions.
+
+2. **Detect changed packages.** Check each release unit under `packages/`, `sdks/`, and the repo root for changes since its last release tag. Use path-scoped diffs for subpackages so unrelated repo changes do not trigger a package release, e.g. `git diff kosong-0.53.0..HEAD -- packages/kosong`, `git diff pykaos-0.9.0..HEAD -- packages/kaos`, and `git diff kimi-sdk-0.2.1..HEAD -- sdks/kimi-sdk`. If nothing changed anywhere, stop and report that there is nothing to release. Note: `packages/kimi-code` is a thin wrapper and must stay version-synced with `kimi-cli`, so treat it as changed whenever the root package changes.
+
+3. **Confirm new versions with the user.** For each changed package, propose a new version and confirm before editing. Versioning policy:
+   - Patch is always `0`.
+   - Bump the minor version for any change.
+   - Major only changes by explicit manual decision from the user.
+
+4. **Create the release branch.** Name it `bump-<package>-<new-version>`. If multiple packages are being bumped together, use a single branch with a descriptive name.
+
+5. **Update version metadata and changelogs.** For each changed package:
+   - Update its `pyproject.toml`.
+   - Update `CHANGELOG.md`, keeping the `## Unreleased` header empty in place (do **not** rename it — add a new dated `## <version> (YYYY-MM-DD)` section below it).
+   - Update `breaking-changes.md` in both languages if there are breaking changes.
+   - If bumping `packages/kosong` or `packages/kaos`, also update the root `pyproject.toml` pinned dependency (`kosong[contrib]==<version>` or `pykaos==<version>`) so root validation keeps passing.
+
+6. **Sync the `kimi-code` wrapper when the root version changes.** Bump `packages/kimi-code/pyproject.toml` `version` and its `kimi-cli==<version>` dependency to match the new root version.
+
+7. **Run `uv sync`** to refresh the lockfile.
+
+8. **Update docs.** Follow the `gen-docs` skill to make sure docs reflect the release.
+
+9. **Open the PR.** Commit all changes, push, and open a PR with `gh` describing the version bumps.
+
+10. **Monitor the PR** until it is merged.
+
+11. **Hand off the tag step.** After merge, switch to `main`, pull latest, and tell the user the exact `git tag` command for the final release tag (pick the right tag pattern from the table above — e.g. `git tag 1.43.0` for a root release, `git tag kosong-0.54.0` for a kosong release). The user will run the tag and push tags themselves.
+
+## Stop conditions
+
+Fail fast — never paper over an error to keep the release moving. Stop and report back to the user when any of these happen:
+
+- Nothing changed since the last tag → there is nothing to release.
+- `uv sync` fails or produces unexpected `uv.lock` churn beyond the version bump.
+- `gen-docs` reports a doc inconsistency you cannot resolve.
+- PR checks go red after push — investigate, do **not** `--no-verify` or force-merge.
+- The release workflow fails after tag push — read the workflow logs and surface the failure, do not retag silently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ For the full procedure, follow the `release` skill (`.agents/skills/release/SKIL
 
 1. Ensure `main` is up to date (pull latest).
 2. Create a release branch, e.g. `bump-0.68` or `bump-pykaos-0.5.3`.
-3. Update `CHANGELOG.md`: rename `[Unreleased]` to `[0.68] - YYYY-MM-DD`.
+3. Update `CHANGELOG.md`: add a new `## 0.68 (YYYY-MM-DD)` section below `## Unreleased` (do not rename `## Unreleased`).
 4. Update `pyproject.toml` version.
 5. Run `uv sync` to align `uv.lock`.
 6. Commit the branch and open a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,14 +132,16 @@ and skill workflows.
 
 ## Release workflow
 
+For the full procedure, follow the `release` skill (`.agents/skills/release/SKILL.md`). The summary:
+
 1. Ensure `main` is up to date (pull latest).
-2. Create a release branch, e.g. `bump-0.68` or `bump-pykaos-0.5.3`.
-3. Update `CHANGELOG.md`: rename `[Unreleased]` to `[0.68] - YYYY-MM-DD`.
-4. Update `pyproject.toml` version.
+2. Create a release branch, e.g. `bump-1.43.0` or `bump-pykaos-0.10.0`.
+3. Update `CHANGELOG.md`: insert a new `## <version> (YYYY-MM-DD)` section below the `## Unreleased` header (do **not** rename Unreleased).
+4. Update the relevant `pyproject.toml` version.
 5. Run `uv sync` to align `uv.lock`.
 6. Commit the branch and open a PR.
 7. Merge the PR, then switch back to `main` and pull latest.
-8. Tag and push:
-   - `git tag 0.68` or `git tag pykaos-0.5.3`
+8. Tag and push (no `v` prefix; see the skill for the tag pattern per package):
+   - `git tag 1.43.0`
    - `git push --tags`
 9. GitHub Actions handles the release after tags are pushed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,13 +135,13 @@ and skill workflows.
 For the full procedure, follow the `release` skill (`.agents/skills/release/SKILL.md`). The summary:
 
 1. Ensure `main` is up to date (pull latest).
-2. Create a release branch, e.g. `bump-1.43.0` or `bump-pykaos-0.10.0`.
-3. Update `CHANGELOG.md`: insert a new `## <version> (YYYY-MM-DD)` section below the `## Unreleased` header (do **not** rename Unreleased).
-4. Update the relevant `pyproject.toml` version.
+2. Create a release branch, e.g. `bump-0.68` or `bump-pykaos-0.5.3`.
+3. Update `CHANGELOG.md`: rename `[Unreleased]` to `[0.68] - YYYY-MM-DD`.
+4. Update `pyproject.toml` version.
 5. Run `uv sync` to align `uv.lock`.
 6. Commit the branch and open a PR.
 7. Merge the PR, then switch back to `main` and pull latest.
-8. Tag and push (no `v` prefix; see the skill for the tag pattern per package):
-   - `git tag 1.43.0`
+8. Tag and push:
+   - `git tag 0.68` or `git tag pykaos-0.5.3`
    - `git push --tags`
 9. GitHub Actions handles the release after tags are pushed.

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -216,8 +216,8 @@ Execute a specific flow skill. Flow skills embed an Agent Flow diagram in `SKILL
 
 For example:
 
-- `/flow:code-review`: Execute code review workflow
-- `/flow:release`: Execute release workflow
+- `/flow:pull-request`: Execute the pull-request creation workflow
+- `/flow:code-review`: Execute a code review workflow
 
 ::: tip
 Flow skills can also be invoked via `/skill:<name>`, which loads the content as a standard skill without automatically executing the flow.

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -216,8 +216,8 @@ Flow Skill 也可以通过 `/skill:<name>` 调用，此时作为普通 Skill 加
 
 例如：
 
+- `/flow:pull-request`：执行创建 Pull Request 的工作流
 - `/flow:code-review`：执行代码审查工作流
-- `/flow:release`：执行发布工作流
 
 ::: tip 提示
 Flow Skill 也可以通过 `/skill:<name>` 调用，此时作为普通 Skill 加载内容，不会自动执行流程。


### PR DESCRIPTION
## Summary

Documentation/skill-only update. No runtime code changes.

- Rewrite the `release` skill from a D2 Flow diagram into prose: adds a tag-pattern table (`1.42.0`, `kosong-…`, `pykaos-…`, `kimi-sdk-…`), path-scoped change detection per package, and explicit fail-fast stop conditions.
- Rewrite the `gen-changelog` skill in English with a closed prefix table (do not invent new prefixes), a single-sentence entry format, and a Highlights convention starting from the next release.
- Update `AGENTS.md` release summary and slash-command docs (en/zh) to match the new release flow.

## Contributor checklist (per CONTRIBUTING.md)

- [x] Prek hooks pass locally (`make format-kimi-cli`, `make check-kimi-cli`).
- [x] Scope is doc/skill-only — no functional code paths touched. The >100-line guideline for prior discussion applies to code changes; this PR only refines internal workflow docs.
- [x] Conventions match existing CHANGELOG entries (verified prefix table against recent root `CHANGELOG.md`).

## Test plan

- [x] Skim `.agents/skills/release/SKILL.md` and `.agents/skills/gen-changelog/SKILL.md` rendered on GitHub for formatting issues.
- [x] Confirm the prefix table in `gen-changelog` covers all prefixes used in recent `CHANGELOG.md` entries.
- [x] Verify the tag patterns in the release skill match `.github/workflows/release*.yml`.