### PR TITLE
fix: omit empty tools in OpenAI legacy requests

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -138,11 +138,13 @@ class OpenAILegacy:
             if has_think_part:
                 reasoning_effort = "medium"
 
+        openai_tools = [tool_to_openai(tool) for tool in tools] if tools else omit
+
         try:
             response = await self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
-                tools=(tool_to_openai(tool) for tool in tools),
+                tools=openai_tools,
                 stream=self.stream,
                 stream_options={"include_usage": True} if self.stream else omit,
                 reasoning_effort=reasoning_effort,

--- a/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
@@ -27,16 +27,14 @@ async def test_openai_legacy_message_conversion():
                     "messages": [
                         {"role": "system", "content": "You are helpful."},
                         {"role": "user", "content": "Hello!"},
-                    ],
-                    "tools": [],
+                    ]
                 },
                 "multi_turn_conversation": {
                     "messages": [
                         {"role": "user", "content": "What is 2+2?"},
                         {"role": "assistant", "content": "2+2 equals 4."},
                         {"role": "user", "content": "And 3+3?"},
-                    ],
-                    "tools": [],
+                    ]
                 },
                 "multi_turn_with_system": {
                     "messages": [
@@ -44,8 +42,7 @@ async def test_openai_legacy_message_conversion():
                         {"role": "user", "content": "What is 2+2?"},
                         {"role": "assistant", "content": "2+2 equals 4."},
                         {"role": "user", "content": "And 3+3?"},
-                    ],
-                    "tools": [],
+                    ]
                 },
                 "image_url": {
                     "messages": [
@@ -62,8 +59,7 @@ async def test_openai_legacy_message_conversion():
                                 },
                             ],
                         }
-                    ],
-                    "tools": [],
+                    ]
                 },
                 "tool_definition": {
                     "messages": [{"role": "user", "content": "Add 2 and 3"}],
@@ -134,8 +130,7 @@ async def test_openai_legacy_message_conversion():
                             ],
                             "tool_call_id": "call_abc123",
                         },
-                    ],
-                    "tools": [],
+                    ]
                 },
                 "tool_call": {
                     "messages": [
@@ -152,8 +147,7 @@ async def test_openai_legacy_message_conversion():
                             ],
                         },
                         {"role": "tool", "content": "5", "tool_call_id": "call_abc123"},
-                    ],
-                    "tools": [],
+                    ]
                 },
                 "parallel_tool_calls": {
                     "messages": [
@@ -240,6 +234,20 @@ async def test_openai_legacy_message_conversion():
                 },
             }
         )
+
+
+async def test_openai_legacy_omits_empty_tools():
+    with respx.mock(base_url="https://api.openai.com") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response("gpt-4.1"))
+        )
+        provider = OpenAILegacy(model="gpt-4.1", api_key="test-key", stream=False)
+        stream = await provider.generate("", [], [Message(role="user", content="Compact this")])
+        async for _ in stream:
+            pass
+
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert "tools" not in body
 
 
 async def test_openai_legacy_reasoning_content():


### PR DESCRIPTION
﻿## Summary

Fixes #2233.

OpenAI-compatible chat APIs such as vLLM reject `tools: []`. `OpenAILegacy.generate()` always passed a tools iterable, so empty tool lists could still serialize as an empty `tools` array during `/compact` and other no-tool calls.

This changes the OpenAI legacy provider to omit `tools` when no tools are available, while preserving the existing tool schema when tools are present.

## To verify

- `uv run pytest packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py -q`
- `uv run ruff check packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py`
- `uv run ruff format --check packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py`
- `uv run python -m py_compile packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->