### PR TITLE
add extra generation kwargs config & fix vLLM empty tools error

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -67,6 +67,7 @@ class OpenAILegacy:
         frequency_penalty: float | None
         stop: str | list[str] | None
         prompt_cache_key: str | None
+        extra_body: dict[str, Any] | None
 
     def __init__(
         self,
@@ -142,7 +143,10 @@ class OpenAILegacy:
             response = await self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
-                tools=(tool_to_openai(tool) for tool in tools),
+                tools=(
+                    omit if not tools
+                    else (tool_to_openai(tool) for tool in tools)
+                ),
                 stream=self.stream,
                 stream_options={"include_usage": True} if self.stream else omit,
                 reasoning_effort=reasoning_effort,

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 import tomlkit
 from pydantic import (
@@ -51,6 +51,11 @@ class LLMProvider(BaseModel):
     when unset. Use an empty string to disable reasoning round-tripping."""
     oauth: OAuthRef | None = None
     """OAuth credential reference (do not store tokens here)."""
+    extra_generation_kwargs: dict[str, Any] | None = None
+    """Extra generation kwargs to forward to the chat provider's generate() call.
+    For ``openai_legacy`` type, supports max_tokens, temperature, top_p,
+    presence_penalty, frequency_penalty, stop, and vLLM-specific
+    parameter extra_body (a dict)."""
 
     @field_serializer("api_key", when_used="json")
     def dump_secret(self, v: SecretStr):

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -167,6 +167,10 @@ def create_llm(
                 reasoning_key=reasoning_key,
                 default_headers=dict(provider.custom_headers) if provider.custom_headers else None,
             )
+            if provider.extra_generation_kwargs:
+                chat_provider = chat_provider.with_generation_kwargs(
+                    **provider.extra_generation_kwargs
+                )
         case "openai_responses":
             from kosong.contrib.chat_provider.openai_responses import OpenAIResponses
 


### PR DESCRIPTION
## Related Issue1

Resolve #(2233)

## Description

omit tools field when empty to prevent vLLM validation errors(openai_legacy)

  - Pass `omit` instead of empty generator for tools parameter when no tools are provided, avoiding vLLM's "tools must not be an empty array" error during context compression.

## Related Issue2

Feat #(2234)

## Description

add extra_generation_kwargs support for openai_legacy providers

  - Add `extra_generation_kwargs` field to LLMProvider model, allowing users to configure generation parameters (max_tokens, temperature, top_p, etc.) and vLLM-specific params (extra_body) directly in config.toml.
  - Apply extra_generation_kwargs via with_generation_kwargs() when creating OpenAILegacy provider instances.

add extra_body to GenerationKwargs TypedDict

  - Declare extra_body key in GenerationKwargs for type-checker support of vLLM specific parameters like top_k and chat_template_kwargs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->