### PR TITLE
fix: suppress AuthlibDeprecationWarning on fastmcp import

### DIFF
--- a/src/kimi_cli/cli/mcp.py
+++ b/src/kimi_cli/cli/mcp.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
@@ -16,7 +17,8 @@ def get_global_mcp_config_file() -> Path:
 
 def _load_mcp_config() -> dict[str, Any]:
     """Load MCP config from global mcp config file."""
-    from fastmcp.mcp_config import MCPConfig
+    with warnings.catch_warnings(record=True):
+        from fastmcp.mcp_config import MCPConfig
     from pydantic import ValidationError
 
     mcp_file = get_global_mcp_config_file()
@@ -270,7 +272,8 @@ def mcp_auth(
         raise typer.Exit(code=1)
 
     async def _auth() -> None:
-        import fastmcp
+        with warnings.catch_warnings(record=True):
+            import fastmcp
 
         typer.echo(f"Authorizing with '{name}'...")
         typer.echo("A browser window will open for authorization.")
@@ -325,7 +328,8 @@ def mcp_test(
     server = _get_mcp_server(name)
 
     async def _test() -> None:
-        import fastmcp
+        with warnings.catch_warnings(record=True):
+            import fastmcp
 
         typer.echo(f"Testing connection to '{name}'...")
         client = fastmcp.Client({"mcpServers": {name: server}})

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -415,8 +415,11 @@ class KimiToolset:
             MCPRuntimeError(KimiCLIException, RuntimeError): When any MCP server cannot be
                 connected.
         """
-        import fastmcp
-        from fastmcp.mcp_config import MCPConfig, RemoteMCPServer
+        import warnings
+
+        with warnings.catch_warnings(record=True):
+            import fastmcp
+            from fastmcp.mcp_config import MCPConfig, RemoteMCPServer
 
         from kimi_cli.ui.shell.prompt import toast
 


### PR DESCRIPTION
## Summary

Suppress the `AuthlibDeprecationWarning` that prints to stderr on every startup when MCP servers are configured.

## Problem

When `fastmcp` is imported, it transitively imports `authlib.jose`, which triggers an `AuthlibDeprecationWarning`. This warning is printed to stderr on every `kimi` invocation if any MCP server is configured, polluting the terminal output.

The warning cannot be suppressed with standard `PYTHONWARNINGS` or `-W` flags because `authlib` internally calls `warnings.simplefilter("always", AuthlibDeprecationWarning)`, which overrides user-level filters.

## Solution

Wrap `import fastmcp` statements with `warnings.catch_warnings(record=True)` to capture and discard the warning during import. This approach works regardless of authlib's internal filter manipulation because `catch_warnings(record=True)` replaces `showwarning` entirely within the context.

Changes are applied at all three runtime import points:
- `src/kimi_cli/soul/toolset.py` — main startup path (MCP tool loading)
- `src/kimi_cli/cli/mcp.py` — `mcp auth` and `mcp test` commands

## Testing

- All 1417 unit tests pass (1 unrelated failure due to ripgrep binary download)
- Verified `catch_warnings(record=True)` correctly captures warnings without printing

Closes #2203
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->