### PR TITLE
fix: continue latest persisted session

### DIFF
--- a/src/kimi_cli/session.py
+++ b/src/kimi_cli/session.py
@@ -297,13 +297,24 @@ class Session:
             return None
         if work_dir_meta.last_session_id is None:
             logger.debug("Work directory never had a session")
-            return None
+            sessions = await Session.list(work_dir)
+            return sessions[0] if sessions else None
 
         logger.debug(
             "Found last session for work directory: {session_id}",
             session_id=work_dir_meta.last_session_id,
         )
-        return await Session.find(work_dir, work_dir_meta.last_session_id)
+        session = await Session.find(work_dir, work_dir_meta.last_session_id)
+        if session is not None:
+            return session
+
+        logger.debug(
+            "Last session not found, falling back to newest session for work directory: "
+            "{session_id}",
+            session_id=work_dir_meta.last_session_id,
+        )
+        sessions = await Session.list(work_dir)
+        return sessions[0] if sessions else None
 
 
 def _migrate_session_context_file(work_dir_meta: WorkDirMeta, session_id: str) -> None:

--- a/tests/core/test_session.py
+++ b/tests/core/test_session.py
@@ -115,6 +115,48 @@ async def test_continue_without_last_returns_none(isolated_share_dir: Path, work
     assert result is None
 
 
+async def test_continue_falls_back_to_latest_session_when_last_missing(
+    isolated_share_dir: Path, work_dir: KaosPath
+):
+    first = await Session.create(work_dir)
+    second = await Session.create(work_dir)
+
+    _write_context_message(first.context_file, "old context message")
+    _write_context_message(second.context_file, "new context message")
+    _write_wire_turn(first.dir, "old session")
+    _write_wire_turn(second.dir, "new session")
+
+    now = time.time()
+    os.utime(first.context_file, (now - 10, now - 10))
+    os.utime(second.context_file, (now, now))
+
+    result = await Session.continue_(work_dir)
+
+    assert result is not None
+    assert result.id == second.id
+
+
+async def test_continue_falls_back_to_latest_session_when_last_is_stale(
+    isolated_share_dir: Path, work_dir: KaosPath
+):
+    from kimi_cli.metadata import load_metadata, save_metadata
+
+    session = await Session.create(work_dir)
+    _write_context_message(session.context_file, "persisted user message")
+    _write_wire_turn(session.dir, "persisted session")
+
+    metadata = load_metadata()
+    work_dir_meta = metadata.get_work_dir_meta(work_dir)
+    assert work_dir_meta is not None
+    work_dir_meta.last_session_id = "missing-session"
+    save_metadata(metadata)
+
+    result = await Session.continue_(work_dir)
+
+    assert result is not None
+    assert result.id == session.id
+
+
 async def test_list_ignores_empty_sessions(isolated_share_dir: Path, work_dir: KaosPath):
     empty = await Session.create(work_dir)
     populated = await Session.create(work_dir)


### PR DESCRIPTION
## Summary
- Fixes #2222.
- Make --continue fall back to the newest non-empty session for the working directory when metadata has no last_session_id or points at a stale session.
- Keep the existing no-session error when there are no persisted sessions.

## Validated locally
- python -m pytest tests/core/test_session.py -q -o cache_dir=.tmp/pytest-cache
- python -m ruff check src/kimi_cli/session.py tests/core/test_session.py
- python -m ruff format --check src/kimi_cli/session.py tests/core/test_session.py
- python -m py_compile src/kimi_cli/session.py tests/core/test_session.py

Note: I set TMP/TEMP to a repo-local .tmp directory while running pytest because the default Windows pytest temp root was not writable in my environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->