### PR TITLE
feat(toolset): add tool call deduplication for same-step and cross-step repeats

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -187,8 +187,10 @@ class KimiSoul:
             self._checkpoint_with_user_message = False
 
         self._steer_queue: asyncio.Queue[str | list[ContentPart]] = asyncio.Queue()
+        self._last_tool_calls: list[tuple[str, str]] = []
         self._plan_mode: bool = self._runtime.session.state.plan_mode
         self._plan_session_id: str | None = self._runtime.session.state.plan_session_id
+        self._current_turn_id: str = ""
         # Pre-warm slug cache so the persisted slug survives process restarts
         if self._plan_session_id is not None and self._runtime.session.state.plan_slug is not None:
             from kimi_cli.tools.plan.heroes import seed_slug_cache
@@ -719,6 +721,8 @@ class KimiSoul:
         if missing_caps := check_message(user_message, self._runtime.llm.capabilities):
             raise LLMNotSupported(self._runtime.llm, list(missing_caps))
 
+        self._current_turn_id = uuid.uuid4().hex
+        self._last_tool_calls = []
         await self._checkpoint()  # this creates the checkpoint 0 on first run
         await self._context.append_message(user_message)
         logger.debug("Appended user message to context")
@@ -808,13 +812,31 @@ class KimiSoul:
         return _run_skill
 
     async def _agent_loop(self) -> TurnOutcome:
-        """The main agent loop for one run."""
+        """The main agent loop for one run.
+
+        Lifecycle:
+            1. Turn Initialization   - clean up stale steers, load MCP tools.
+            2. Step Loop             - iterate until the turn stops or fails.
+               a. Step Guard         - enforce max-steps-per-turn limit.
+               b. Step Begin         - emit StepBegin wire event.
+               c. Context Compaction - auto-compact if context exceeds trigger ratio.
+               d. Checkpoint         - persist current state before calling LLM.
+               e. Step Execution     - run _step() (LLM call + tool execution).
+               f. Error Handling     - BackToTheFuture (revert) or fatal exception.
+               g. Outcome Resolution - steers / stop / continue.
+            3. Turn Resolution       - return TurnOutcome to the caller.
+        """
         assert self._runtime.llm is not None
+
+        # ═══════════════════════════════════════════════════════════════════════
+        # 1. TURN INITIALIZATION
+        # ═══════════════════════════════════════════════════════════════════════
 
         # Discard any stale steers from a previous turn.
         while not self._steer_queue.empty():
             self._steer_queue.get_nowait()
 
+        # ── 1a. MCP deferred loading ──────────────────────────────────────────
         if isinstance(self._agent.toolset, KimiToolset):
             await self.start_background_mcp_loading()
             loading = bool((snapshot := self._mcp_status_snapshot()) and snapshot.loading)
@@ -847,19 +869,27 @@ class KimiSoul:
                     wire_send(StatusUpdate(mcp_status=self._mcp_status_snapshot()))
                     wire_send(MCPLoadingEnd())
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2. STEP LOOP
+        # ═══════════════════════════════════════════════════════════════════════
         step_no = 0
         self._current_step_no = 0
         while True:
             step_no += 1
+
+            # ── 2a. Step Guard ──────────────────────────────────────────────────
             if step_no > self._loop_control.max_steps_per_turn:
                 raise MaxStepsReached(self._loop_control.max_steps_per_turn)
 
             self._current_step_no = step_no
+
+            # ── 2b. Step Begin ──────────────────────────────────────────────────
             wire_send(StepBegin(n=step_no))
             back_to_the_future: BackToTheFuture | None = None
             step_outcome: StepOutcome | None = None
+
             try:
-                # compact the context if needed
+                # ── 2c. Context Compaction ──────────────────────────────────────
                 if should_auto_compact(
                     self._context.token_count_with_pending,
                     self._runtime.llm.max_context_size,
@@ -878,14 +908,20 @@ class KimiSoul:
                         )
                         raise
 
+                # ── 2d. Checkpoint ──────────────────────────────────────────────
                 logger.debug("Beginning step {step_no}", step_no=step_no)
                 await self._checkpoint()
                 self._denwa_renji.set_n_checkpoints(self._context.n_checkpoints)
+
+                # ── 2e. Step Execution ──────────────────────────────────────────
                 step_outcome = await self._step()
+
             except BackToTheFuture as e:
+                # ── 2f-i. D-Mail revert signal ────────────────────────────────
                 back_to_the_future = e
+
             except Exception as e:
-                # any other exception should interrupt the step
+                # ── 2f-ii. Fatal step error ───────────────────────────────────
                 req_id = getattr(e, "request_id", None)
                 logger.error(
                     "Agent step {step_no} failed: {error_type}: {error}"
@@ -896,6 +932,7 @@ class KimiSoul:
                     request_id=req_id,
                 )
                 wire_send(StepInterrupted())
+
                 # Track API/step errors
                 from kimi_cli.telemetry import track
 
@@ -910,6 +947,7 @@ class KimiSoul:
                         if key in _kimi_ctx:
                             track_kwargs[key] = _kimi_ctx[key]
                 track("api_error", **track_kwargs)
+
                 # --- StopFailure hook ---
                 from kimi_cli.hooks import events as _hook_events
 
@@ -929,11 +967,16 @@ class KimiSoul:
                 # break the agent loop
                 raise
 
+            # ── 2g. Outcome Resolution ──────────────────────────────────────────
             if step_outcome is not None:
+                # Step returned a stop reason -- check for steers before finishing.
                 has_steers = await self._consume_pending_steers()
                 if has_steers:
                     continue  # steers injected, force another LLM step
 
+                # ═══════════════════════════════════════════════════════════════
+                # 3. TURN RESOLUTION
+                # ═══════════════════════════════════════════════════════════════
                 final_message = (
                     step_outcome.assistant_message
                     if step_outcome.stop_reason == "no_tool_calls"
@@ -946,19 +989,39 @@ class KimiSoul:
                 )
 
             if back_to_the_future is not None:
+                # Revert context to the checkpoint and inject D-Mail message.
                 await self._context.revert_to(back_to_the_future.checkpoint_id)
+                self._last_tool_calls = []
                 await self._checkpoint()
                 await self._context.append_message(back_to_the_future.messages)
 
-            # Consume any pending steers between steps
+            # Consume any pending steers between steps before next iteration.
             await self._consume_pending_steers()
 
     async def _step(self) -> StepOutcome | None:
-        """Run a single step and return a stop outcome, or None to continue."""
+        """Run a single step and return a stop outcome, or None to continue.
+
+        This is the implementation of ``2e. Step Execution`` in ``_agent_loop``.
+
+        Sub-lifecycle (2e.x):
+            2e.1. Notification delivery  - push pending notifications (root only).
+            2e.2. Dynamic injection      - collect and append provider injections.
+            2e.3. History normalization  - merge adjacent user messages.
+            2e.4. LLM call with retry    - kosong.step + tenacity retry + recovery.
+               2e.4.1. Toolset begin_step- reset per-step dedup state.
+               2e.4.2. kosong.step       - actual LLM call (may be interrupted).
+            2e.5. Usage & status update  - track tokens, emit StatusUpdate.
+            2e.6. Tool execution         - wait for all tool results.
+            2e.7. Context growth         - append assistant + tool messages.
+            2e.8. Outcome resolution     - rejection / D-Mail / stop / continue.
+        """
         # already checked in `run`
         assert self._runtime.llm is not None
         chat_provider = self._runtime.llm.chat_provider
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.1. NOTIFICATION DELIVERY (root role only)
+        # ═══════════════════════════════════════════════════════════════════════
         if self.is_root:
 
             async def _append_notification(view: NotificationView) -> None:
@@ -990,7 +1053,9 @@ class KimiSoul:
                 on_notification=_append_notification,
             )
 
-        # Dynamic injection
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.2. DYNAMIC INJECTION
+        # ═══════════════════════════════════════════════════════════════════════
         injections = await self._collect_injections()
         if injections:
             combined_reminders = "\n".join(system_reminder(inj.content).text for inj in injections)
@@ -1001,10 +1066,24 @@ class KimiSoul:
                 )
             )
 
-        # Normalize: merge adjacent user messages for clean API input
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.3. HISTORY NORMALIZATION
+        # ═══════════════════════════════════════════════════════════════════════
         effective_history = normalize_history(self._context.history)
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.4. LLM CALL WITH RETRY
+        # ═══════════════════════════════════════════════════════════════════════
         async def _run_step_once() -> StepResult:
+            """Single LLM invocation (wrapped by retry + connection recovery)."""
+            # ── 2e.4.1. Toolset begin_step ────────────────────────────────────
+            if isinstance(self._agent.toolset, KimiToolset):
+                self._agent.toolset.begin_step(
+                    self._last_tool_calls,
+                    step_no=self._current_step_no,
+                    turn_id=self._current_turn_id,
+                )
+            # ── 2e.4.2. kosong.step ───────────────────────────────────────────
             # run an LLM step (may be interrupted)
             return await kosong.step(
                 chat_provider,
@@ -1048,6 +1127,10 @@ class KimiSoul:
                 _ctx["input_tokens"] = self._context.token_count
             _step_exc._kimi_api_error_context = _ctx  # type: ignore[attr-defined]
             raise
+
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.5. USAGE & STATUS UPDATE
+        # ═══════════════════════════════════════════════════════════════════════
         llm_elapsed = time.monotonic() - t0
         usage = result.usage
         logger.info(
@@ -1068,19 +1151,32 @@ class KimiSoul:
             status_update.max_context_tokens = snap.max_context_tokens
         wire_send(status_update)
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.6. TOOL EXECUTION
+        # ═══════════════════════════════════════════════════════════════════════
         # wait for all tool results (may be interrupted)
         plan_mode_before_tools = self._plan_mode
         results = await result.tool_results()
         logger.debug("Got tool results: {results}", results=results)
+
+        # Update dedup tracking for the next step
+        if isinstance(self._agent.toolset, KimiToolset):
+            self._last_tool_calls = self._agent.toolset.end_step()
 
         # If a tool (EnterPlanMode/ExitPlanMode) changed plan mode during execution,
         # send a corrected StatusUpdate so the client sees the up-to-date state.
         if self._plan_mode != plan_mode_before_tools:
             wire_send(StatusUpdate(plan_mode=self._plan_mode))
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.7. CONTEXT GROWTH
+        # ═══════════════════════════════════════════════════════════════════════
         # shield the context manipulation from interruption
         await asyncio.shield(self._grow_context(result, results))
 
+        # ═══════════════════════════════════════════════════════════════════════
+        # 2e.8. OUTCOME RESOLUTION
+        # ═══════════════════════════════════════════════════════════════════════
         rejected_errors = [
             result.return_value
             for result in results

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import importlib
 import inspect
 import json
@@ -90,6 +91,37 @@ if TYPE_CHECKING:
         _: Toolset = kimi_toolset
 
 
+_REMINDER_TEXT = (
+    "\n\n<system-reminder>\n"
+    "You are repeating the exact same tool call with identical parameters."
+    " Please carefully analyze the previous result. If the task is not yet complete,"
+    " try a different method or parameters instead of repeating the same call."
+    "\n</system-reminder>"
+)
+
+
+def _append_reminder_to_return_value(return_value: Any) -> Any:
+    """Append dedup reminder text to a ToolReturnValue output."""
+    from kosong.tooling import ToolReturnValue
+
+    if not isinstance(return_value, ToolReturnValue):
+        return return_value
+
+    output = return_value.output
+    reminder = _REMINDER_TEXT
+
+    if isinstance(output, str):
+        new_output = output + reminder
+    else:
+        new_output = list(output)
+        if new_output and isinstance(new_output[-1], TextPart):
+            new_output[-1] = TextPart(text=new_output[-1].text + reminder)
+        else:
+            new_output.append(TextPart(text=reminder))
+
+    return return_value.model_copy(update={"output": new_output})
+
+
 class KimiToolset:
     def __init__(self) -> None:
         self._tool_dict: dict[str, ToolType] = {}
@@ -98,6 +130,14 @@ class KimiToolset:
         self._mcp_loading_task: asyncio.Task[None] | None = None
         self._deferred_mcp_load: tuple[list[MCPConfig], Runtime] | None = None
         self._hook_engine: HookEngine = HookEngine()
+
+        # Deduplication state
+        self._previous_step_calls: list[tuple[str, str]] = []
+        self._current_step_calls: list[tuple[str, str]] = []
+        self._current_step_tasks: dict[tuple[str, str], asyncio.Task[ToolResult]] = {}
+        self._dedup_triggered: bool = False
+        self._step_no: int = 0
+        self._turn_id: str = ""
 
     def set_hook_engine(self, engine: HookEngine) -> None:
         self._hook_engine = engine
@@ -135,9 +175,74 @@ class KimiToolset:
             tool.base for tool in self._tool_dict.values() if tool.name not in self._hidden_tools
         ]
 
+    def begin_step(
+        self,
+        previous_calls: list[tuple[str, str]],
+        *,
+        step_no: int = 0,
+        turn_id: str = "",
+    ) -> None:
+        """Called before each step to set up deduplication state."""
+        self._previous_step_calls = previous_calls
+        self._current_step_calls = []
+        self._current_step_tasks = {}
+        self._dedup_triggered = False
+        self._step_no = step_no
+        self._turn_id = turn_id
+
+    def end_step(self) -> list[tuple[str, str]]:
+        """Called after each step to capture the calls made in this step."""
+        return list(self._current_step_calls)
+
+    @property
+    def dedup_triggered(self) -> bool:
+        """Whether a cross-step duplicate was blocked in the current step."""
+        return self._dedup_triggered
+
     def handle(self, tool_call: ToolCall) -> HandleResult:
         token = current_tool_call.set(tool_call)
         try:
+            call_key = (tool_call.function.name, tool_call.function.arguments or "{}")
+
+            # Same-step dedup: wait for the original task and copy its result
+            if call_key in self._current_step_tasks:
+                from kimi_cli.telemetry import track
+
+                track(
+                    "tool_call_dedup_detected",
+                    session_id=_get_session_id(),
+                    turn_id=self._turn_id,
+                    step_no=self._step_no,
+                    tool_name=tool_call.function.name,
+                    dup_type="same_step",
+                    args_hash=hashlib.sha256(call_key[1].encode()).hexdigest()[:8],
+                )
+                original_task = self._current_step_tasks[call_key]
+
+                async def _await_dup() -> ToolResult:
+                    original_result = await original_task
+                    return ToolResult(
+                        tool_call_id=tool_call.id,
+                        return_value=original_result.return_value,
+                    )
+
+                return asyncio.create_task(_await_dup())
+
+            is_cross_step_dup = call_key in self._previous_step_calls
+            if is_cross_step_dup:
+                from kimi_cli.telemetry import track
+
+                track(
+                    "tool_call_dedup_detected",
+                    session_id=_get_session_id(),
+                    turn_id=self._turn_id,
+                    step_no=self._step_no,
+                    tool_name=tool_call.function.name,
+                    dup_type="cross_step",
+                    args_hash=hashlib.sha256(call_key[1].encode()).hexdigest()[:8],
+                )
+                self._dedup_triggered = True
+
             if tool_call.function.name not in self._tool_dict:
                 return ToolResult(
                     tool_call_id=tool_call.id,
@@ -244,6 +349,7 @@ class KimiToolset:
                         outcome="error",
                         duration_ms=int(tool_elapsed * 1000),
                         error_type=type(ret).__name__,
+                        dup_type="cross_step" if is_cross_step_dup else "normal",
                     )
                 else:
                     _track_tool_call(
@@ -251,6 +357,7 @@ class KimiToolset:
                         tool_name=tool_call.function.name,
                         outcome="success",
                         duration_ms=int(tool_elapsed * 1000),
+                        dup_type="cross_step" if is_cross_step_dup else "normal",
                     )
 
                 # --- PostToolUse (fire-and-forget) ---
@@ -272,7 +379,23 @@ class KimiToolset:
 
                 return ToolResult(tool_call_id=tool_call.id, return_value=ret)
 
-            return asyncio.create_task(_call())
+            task = asyncio.create_task(_call())
+            if is_cross_step_dup:
+
+                async def _wrap_with_reminder(
+                    inner_task: asyncio.Task[ToolResult],
+                ) -> ToolResult:
+                    tr = await inner_task
+                    return ToolResult(
+                        tool_call_id=tr.tool_call_id,
+                        return_value=_append_reminder_to_return_value(tr.return_value),
+                    )
+
+                task = asyncio.create_task(_wrap_with_reminder(task))
+
+            self._current_step_tasks[call_key] = task
+            self._current_step_calls.append(call_key)
+            return task
         finally:
             current_tool_call.reset(token)
 

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -1,4 +1,4 @@
-"""Tests for KimiToolset hide/unhide functionality."""
+"""Tests for KimiToolset hide/unhide and deduplication functionality."""
 
 from __future__ import annotations
 
@@ -186,3 +186,187 @@ def test_hide_unhide_cycle():
 
     ts.unhide("ToolA")
     assert "ToolA" in _tool_names(ts)
+
+
+# --- deduplication ---
+
+
+async def test_same_step_dedup():
+    """Duplicate tool calls within the same step should share the original result."""
+    ts = _make_toolset()
+    ts.begin_step([])
+
+    args = json.dumps({"value": "x"})
+    tool_call_1 = ToolCall(
+        id="tc-dedup-1",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+    tool_call_2 = ToolCall(
+        id="tc-dedup-2",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+
+    result_1 = ts.handle(tool_call_1)
+    assert isinstance(result_1, asyncio.Task)
+
+    result_2 = ts.handle(tool_call_2)
+    assert isinstance(result_2, asyncio.Task)
+
+    # Both should eventually return the same output but with different tool_call_id
+    tr_1 = await result_1
+    tr_2 = await result_2
+
+    assert tr_1.return_value.output == "a"
+    assert tr_2.return_value.output == "a"
+    assert tr_1.tool_call_id == "tc-dedup-1"
+    assert tr_2.tool_call_id == "tc-dedup-2"
+
+    assert ts.end_step() == [("ToolA", args)]
+
+
+async def test_cross_step_duplicate_appends_reminder():
+    """A tool call identical to one in the previous step should execute and append reminder in output."""
+    ts = _make_toolset()
+    args = json.dumps({"value": "x"})
+    ts.begin_step([("ToolA", args)])
+
+    tool_call = ToolCall(
+        id="tc-dedup-reminder",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+
+    result = ts.handle(tool_call)
+    assert isinstance(result, asyncio.Task)
+    tr = await result
+    output = tr.return_value.output
+    assert isinstance(output, str)
+    assert output.startswith("a")
+    assert "You are repeating the exact same tool call" in output
+    assert ts.dedup_triggered is True
+    assert ts.end_step() == [("ToolA", args)]
+
+
+async def test_non_duplicate_allowed():
+    """A tool call with different arguments should be allowed even if the tool name matches."""
+    ts = _make_toolset()
+    ts.begin_step([("ToolA", json.dumps({"value": "x"}))])
+
+    args = json.dumps({"value": "y"})
+    tool_call = ToolCall(
+        id="tc-ok-1",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+
+    result = ts.handle(tool_call)
+    assert isinstance(result, asyncio.Task)
+    tr = await result
+    assert tr.return_value.output == "a"
+    assert ts.dedup_triggered is False
+    assert ts.end_step() == [("ToolA", args)]
+
+
+def test_begin_end_step():
+    """begin_step and end_step should correctly manage deduplication state."""
+    ts = _make_toolset()
+
+    ts.begin_step([("ToolA", "{}")])
+    assert ts._previous_step_calls == [("ToolA", "{}")]
+    assert ts._current_step_calls == []
+    assert ts._current_step_tasks == {}
+    assert ts.dedup_triggered is False
+
+    ts._current_step_calls.append(("ToolB", "{}"))
+    assert ts.end_step() == [("ToolB", "{}")]
+
+    # After end_step, internal lists are not cleared by end_step itself;
+    # the caller (KimiSoul) is expected to call begin_step again for the next step.
+    # But dedup_triggered should still reflect the last step's state.
+    assert ts.dedup_triggered is False
+
+
+async def test_begin_step_resets_cancelled_tasks():
+    """begin_step() must clear _current_step_tasks so a retry does not await a cancelled task."""
+    ts = _make_toolset()
+
+    ts.begin_step([], step_no=1, turn_id="t1")
+    args = json.dumps({"value": "x"})
+    tc1 = ToolCall(
+        id="c1",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+    result1 = ts.handle(tc1)
+    assert isinstance(result1, asyncio.Task)
+    result1.cancel()
+
+    # Simulate retry: begin_step again for the same step
+    ts.begin_step([], step_no=1, turn_id="t1")
+    tc2 = ToolCall(
+        id="c2",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+    result2 = ts.handle(tc2)
+    assert isinstance(result2, asyncio.Task)
+    assert result2 is not result1
+
+    # The new task should complete successfully (not raise CancelledError)
+    tr = await result2
+    assert tr.return_value.output == "a"
+
+
+async def test_cross_step_dedup_not_triggered_after_back_to_the_future():
+    """When _last_tool_calls is emptied (back_to_the_future), the same call must not be treated as a cross-step duplicate."""
+    ts = _make_toolset()
+
+    # Step 1: execute a tool
+    args = json.dumps({"value": "x"})
+    ts.begin_step([], step_no=1, turn_id="t1")
+    tc1 = ToolCall(
+        id="c1",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+    result1 = ts.handle(tc1)
+    assert isinstance(result1, asyncio.Task)
+    await result1
+    last_calls = ts.end_step()
+    assert last_calls == [("ToolA", args)]
+
+    # Simulate back_to_the_future: caller clears last_calls
+    last_calls = []
+
+    # Step 2: same call with empty last_calls should execute normally
+    ts.begin_step(last_calls, step_no=2, turn_id="t1")
+    tc2 = ToolCall(
+        id="c2",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments=args,
+        ),
+    )
+    result2 = ts.handle(tc2)
+    assert isinstance(result2, asyncio.Task)
+    tr = await result2
+
+    # Should NOT have the cross-step reminder appended
+    assert tr.return_value.output == "a"
+    assert ts.dedup_triggered is False


### PR DESCRIPTION
## Summary

This PR introduces tool call deduplication in the toolset layer to avoid redundant executions when the model issues identical tool calls either within the same step or across consecutive steps.

---

### 1. Tool call deduplication

**Problem:** The agent can issue duplicate tool calls in a single step or repeat the same call in a subsequent step, wasting tokens and latency.

**What was done:**
- Detect duplicate tool calls within the same step and return shared results without re-executing.
- Detect cross-step duplicates and append a system reminder to the output so the model is aware of the redundancy.

### 2. Telemetry and step hooks

**Problem:** Dedup events were invisible and the step loop lacked lifecycle hooks.

**What was done:**
- Track deduplication events via telemetry.
- Wire `begin_step` / `end_step` hooks into the `KimiSoul` step loop.

### 3. Tests

**What was done:**
- Add unit tests covering same-step, cross-step, and non-duplicate scenarios.

---

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description

<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->