### PR TITLE
feat(shell): add --prompt-interactive option

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -684,7 +684,11 @@ class KimiCLI:
                         await external_cancel_task
 
     async def run_shell(
-        self, command: str | None = None, *, prefill_text: str | None = None
+        self,
+        command: str | None = None,
+        *,
+        prefill_text: str | None = None,
+        initial_command: str | None = None,
     ) -> bool:
         """Run the Kimi Code CLI instance with shell UI."""
         from kimi_cli.ui.shell import Shell, WelcomeInfoItem
@@ -767,7 +771,7 @@ class KimiCLI:
         )
         async with self._env():
             shell = Shell(self._soul, welcome_info=welcome_info, prefill_text=prefill_text)
-            return await shell.run(command)
+            return await shell.run(command, initial_command=initial_command)
 
     async def run_print(
         self,

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -606,7 +606,7 @@ def kimi(
                 session = await Session.create(work_dir)
                 logger.info("Created new session: {session_id}", session_id=session.id)
 
-            nonlocal _latest_created_session
+            nonlocal _latest_created_session, prompt_interactive
             _latest_created_session = session
 
             # Add CLI-provided additional directories to session state
@@ -682,6 +682,8 @@ def kimi(
                 match ui:
                     case "shell":
                         initial_cmd = prompt_interactive if prompt_interactive is not None else None
+                        # Consume prompt_interactive immediately so Reload does not replay it
+                        prompt_interactive = None
                         shell_ok = await instance.run_shell(
                             prompt,
                             prefill_text=prefill_text,

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -224,6 +224,17 @@ def kimi(
             help="User prompt to the agent. Default: prompt interactively.",
         ),
     ] = None,
+    prompt_interactive: Annotated[
+        str | None,
+        typer.Option(
+            "--prompt-interactive",
+            "-P",
+            help=(
+                "User prompt to the agent, then keep the interactive session open. "
+                "Default: prompt interactively."
+            ),
+        ),
+    ] = None,
     print_mode: Annotated[
         bool,
         typer.Option(
@@ -447,6 +458,10 @@ def kimi(
             "--session": session_id is not None or _picker_mode,
         },
         {
+            "--prompt": prompt is not None,
+            "--prompt-interactive": prompt_interactive is not None,
+        },
+        {
             "--config": config_string is not None,
             "--config-file": config_file is not None,
         },
@@ -478,6 +493,15 @@ def kimi(
         prompt = prompt.strip()
         if not prompt:
             raise typer.BadParameter("Prompt cannot be empty", param_hint="--prompt")
+    if prompt_interactive is not None:
+        prompt_interactive = prompt_interactive.strip()
+        if not prompt_interactive:
+            raise typer.BadParameter("Prompt cannot be empty", param_hint="--prompt-interactive")
+        if ui != "shell":
+            raise typer.BadParameter(
+                "--prompt-interactive is only supported for shell UI",
+                param_hint="--prompt-interactive",
+            )
 
     if input_format is not None and ui != "print":
         raise typer.BadParameter(
@@ -657,7 +681,12 @@ def kimi(
             try:
                 match ui:
                     case "shell":
-                        shell_ok = await instance.run_shell(prompt, prefill_text=prefill_text)
+                        initial_cmd = prompt_interactive if prompt_interactive is not None else None
+                        shell_ok = await instance.run_shell(
+                            prompt,
+                            prefill_text=prefill_text,
+                            initial_command=initial_cmd,
+                        )
                         exit_code = ExitCode.SUCCESS if shell_ok else ExitCode.FAILURE
                     case "print":
                         exit_code = await instance.run_print(

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -657,7 +657,7 @@ def kimi(
                 max_retries_per_step=max_retries_per_step,
                 max_ralph_iterations=max_ralph_iterations,
                 startup_progress=startup_progress.update if ui == "shell" else None,
-                defer_mcp_loading=ui == "shell" and prompt is None,
+                defer_mcp_loading=ui == "shell" and prompt is None and prompt_interactive is None,
                 ui_mode=ui,
             )
             startup_progress.stop()

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -378,7 +378,7 @@ class Shell:
             resume_prompt.clear()
             await idle_events.put(_PromptEvent(kind="input", user_input=user_input))
 
-    async def run(self, command: str | None = None) -> bool:
+    async def run(self, command: str | None = None, *, initial_command: str | None = None) -> bool:
         _run_start_time = time.monotonic()
 
         # Initialize theme from config
@@ -535,6 +535,16 @@ class Shell:
             bg_auto_failures = 0
             deferred_bg_trigger = False
             try:
+                if initial_command is not None:
+                    resume_prompt.clear()
+                    background_autotrigger_armed = True
+                    try:
+                        await self.run_soul_command(initial_command)
+                        console.print()
+                        if self._exit_after_run:
+                            return shell_ok
+                    finally:
+                        resume_prompt.set()
                 while True:
                     if deferred_bg_trigger and not self._should_defer_background_auto_trigger(
                         prompt_session

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import shlex
+import sys
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Coroutine
@@ -322,6 +323,7 @@ class Shell:
         prompt_session: CustomPromptSession,
         idle_events: asyncio.Queue[_PromptEvent],
         resume_prompt: asyncio.Event,
+        on_prompt_waiting: Callable[[], None] | None = None,
     ) -> None:
         while True:
             # Keep exactly one active prompt read. Idle submissions pause the
@@ -331,6 +333,9 @@ class Shell:
             ensure_tty_sane()
             try:
                 ensure_new_line()
+                if on_prompt_waiting is not None:
+                    on_prompt_waiting()
+                    on_prompt_waiting = None
                 user_input = await prompt_session.prompt_next()
             except KeyboardInterrupt:
                 logger.debug("Prompt router got KeyboardInterrupt")
@@ -351,7 +356,10 @@ class Shell:
                     and prompt_session.running_prompt_accepts_submission()
                 ):
                     self._exit_after_run = True
-                    if self._running_interrupt_handler is not None:
+                    # In a real TTY, Ctrl+D (EOF) during a run means "cancel and
+                    # exit". In non-TTY mode (piped/redirected stdin), EOF simply
+                    # means there is no more input; let the current run finish.
+                    if sys.stdin.isatty() and self._running_interrupt_handler is not None:
                         self._running_interrupt_handler()
                     return
                 resume_prompt.clear()
@@ -512,6 +520,7 @@ class Shell:
                     self._start_background_task(_invalidate_after_mcp_loading())
             self._exit_after_run = False
             idle_events: asyncio.Queue[_PromptEvent] = asyncio.Queue()
+            prompt_waiting = asyncio.Event()
             # resume_prompt controls whether the prompt router reads input.
             # Set BEFORE an await = prompt stays live during the operation
             # (agent runs that accept steer input); set AFTER = prompt is
@@ -519,9 +528,21 @@ class Shell:
             resume_prompt = asyncio.Event()
             resume_prompt.set()
             prompt_task = asyncio.create_task(
-                self._route_prompt_events(prompt_session, idle_events, resume_prompt)
+                self._route_prompt_events(
+                    prompt_session,
+                    idle_events,
+                    resume_prompt,
+                    on_prompt_waiting=prompt_waiting.set,
+                )
             )
             background_autotrigger_armed = False
+
+            # Let the prompt router enter prompt_async() before consuming
+            # initial_command so running-prompt rendering can show spinners
+            # exactly like a normal Enter-submitted turn.
+            _EXIT_COMMANDS = {"exit", "quit", "/exit", "/quit"}
+            if initial_command is not None and initial_command.strip() not in _EXIT_COMMANDS:
+                await prompt_waiting.wait()
 
             def _can_auto_trigger_pending() -> bool:
                 return background_autotrigger_armed
@@ -539,6 +560,8 @@ class Shell:
                     resume_prompt.clear()
                     background_autotrigger_armed = True
                     try:
+                        console.print(render_user_echo_text(initial_command))
+                        console.print()
                         await self.run_soul_command(initial_command)
                         console.print()
                         if self._exit_after_run:

--- a/tests/core/test_defer_mcp_loading.py
+++ b/tests/core/test_defer_mcp_loading.py
@@ -1,0 +1,129 @@
+"""Test defer_mcp_loading logic in CLI entry point.
+
+PR #2246 added --prompt-interactive (-P). The defer_mcp_loading condition at
+src/kimi_cli/cli/__init__.py:660 must consider prompt_interactive so that MCP
+tools are available immediately when an initial command is provided.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kaos.path import KaosPath
+from typer.testing import CliRunner
+
+from kimi_cli.cli import cli
+
+
+@pytest.fixture
+def isolated_share_dir(monkeypatch, tmp_path):
+    share_dir = tmp_path / "share"
+    share_dir.mkdir()
+
+    def _get_share_dir():
+        share_dir.mkdir(parents=True, exist_ok=True)
+        return share_dir
+
+    monkeypatch.setattr("kimi_cli.share.get_share_dir", _get_share_dir)
+    monkeypatch.setattr("kimi_cli.metadata.get_share_dir", _get_share_dir)
+    return share_dir
+
+
+@pytest.fixture
+def work_dir(tmp_path):
+    path = tmp_path / "work"
+    path.mkdir()
+    return KaosPath.unsafe_from_local_path(path)
+
+
+class TestDeferMcpLoading:
+    """Verify defer_mcp_loading is passed correctly to KimiCLI.create()."""
+
+    def _setup_mocks(self, work_dir):
+        mock_session = MagicMock()
+        mock_session.id = "test-session-id"
+        mock_session.work_dir = work_dir
+        mock_session.is_empty.return_value = False
+        mock_session.wire_file.is_empty.return_value = False
+        mock_session.state.additional_dirs = []
+
+        mock_instance = MagicMock()
+        mock_instance.soul.hook_engine.trigger = AsyncMock()
+        mock_instance.shutdown_background_tasks = AsyncMock()
+        mock_instance.await_bg_tasks_shutdown = AsyncMock()
+        mock_instance.run_shell = AsyncMock(return_value=True)
+
+        return mock_session, mock_instance
+
+    def test_shell_no_prompt_defer_mcp_loading(self, isolated_share_dir, work_dir):
+        """Plain shell mode (no --prompt, no --prompt-interactive) should defer MCP."""
+        mock_session, mock_instance = self._setup_mocks(work_dir)
+
+        with (
+            patch(
+                "kimi_cli.session.Session.create", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.session.Session.find", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.app.KimiCLI.create", new_callable=AsyncMock, return_value=mock_instance
+            ) as mock_create,
+        ):
+            result = CliRunner().invoke(
+                cli,
+                ["--work-dir", str(work_dir)],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs.get("defer_mcp_loading") is True
+
+    def test_shell_with_prompt_no_defer(self, isolated_share_dir, work_dir):
+        """--prompt should not defer MCP loading."""
+        mock_session, mock_instance = self._setup_mocks(work_dir)
+
+        with (
+            patch(
+                "kimi_cli.session.Session.create", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.session.Session.find", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.app.KimiCLI.create", new_callable=AsyncMock, return_value=mock_instance
+            ) as mock_create,
+        ):
+            result = CliRunner().invoke(
+                cli,
+                ["--prompt", "hello", "--work-dir", str(work_dir)],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs.get("defer_mcp_loading") is False
+
+    def test_shell_with_prompt_interactive_no_defer(self, isolated_share_dir, work_dir):
+        """--prompt-interactive should not defer MCP loading."""
+        mock_session, mock_instance = self._setup_mocks(work_dir)
+
+        with (
+            patch(
+                "kimi_cli.session.Session.create", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.session.Session.find", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.app.KimiCLI.create", new_callable=AsyncMock, return_value=mock_instance
+            ) as mock_create,
+        ):
+            result = CliRunner().invoke(
+                cli,
+                ["--prompt-interactive", "hello", "--work-dir", str(work_dir)],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs.get("defer_mcp_loading") is False

--- a/tests/core/test_prompt_interactive_reload.py
+++ b/tests/core/test_prompt_interactive_reload.py
@@ -1,0 +1,100 @@
+"""Test that --prompt-interactive does not replay initial_command after Reload.
+
+When --prompt-interactive is used, the prompt_interactive value is passed as
+initial_command on the first shell run. After a Reload (e.g. /theme or /model),
+_run() is re-entered. The bug is that prompt_interactive was not set to None
+after first use, so the same initial_command was passed again on reload.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kaos.path import KaosPath
+from typer.testing import CliRunner
+
+from kimi_cli.cli import Reload, cli
+
+
+@pytest.fixture
+def isolated_share_dir(monkeypatch, tmp_path):
+    share_dir = tmp_path / "share"
+    share_dir.mkdir()
+
+    def _get_share_dir():
+        share_dir.mkdir(parents=True, exist_ok=True)
+        return share_dir
+
+    monkeypatch.setattr("kimi_cli.share.get_share_dir", _get_share_dir)
+    monkeypatch.setattr("kimi_cli.metadata.get_share_dir", _get_share_dir)
+    return share_dir
+
+
+@pytest.fixture
+def work_dir(tmp_path):
+    path = tmp_path / "work"
+    path.mkdir()
+    return KaosPath.unsafe_from_local_path(path)
+
+
+class TestPromptInteractiveReload:
+    def test_initial_command_not_replayed_after_reload(
+        self, isolated_share_dir, work_dir, monkeypatch
+    ):
+        """Bug: after Reload, initial_command should be None, not the original prompt."""
+
+        mock_session = MagicMock()
+        mock_session.id = "test-session-id"
+        mock_session.work_dir = work_dir
+        mock_session.is_empty.return_value = False
+        mock_session.wire_file.is_empty.return_value = False
+        mock_session.state.additional_dirs = []
+
+        mock_instance = MagicMock()
+        mock_instance.soul.hook_engine.trigger = AsyncMock()
+        mock_instance.shutdown_background_tasks = AsyncMock()
+        mock_instance.await_bg_tasks_shutdown = AsyncMock()
+
+        run_shell_calls = []
+
+        async def run_shell_side_effect(*args, **kwargs):
+            run_shell_calls.append(kwargs.copy())
+            if len(run_shell_calls) == 1:
+                # First call: simulate a slash command that triggers Reload
+                raise Reload(session_id="test-session-id")
+            # Second call: normal exit
+            return True
+
+        mock_instance.run_shell = AsyncMock(side_effect=run_shell_side_effect)
+
+        with (
+            patch(
+                "kimi_cli.session.Session.create", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.session.Session.find", new_callable=AsyncMock, return_value=mock_session
+            ),
+            patch(
+                "kimi_cli.app.KimiCLI.create", new_callable=AsyncMock, return_value=mock_instance
+            ),
+        ):
+            result = CliRunner().invoke(
+                cli,
+                ["--prompt-interactive", "hello", "--work-dir", str(work_dir)],
+            )
+
+        # Should succeed after reload (exit code 0)
+        assert result.exit_code == 0, result.output
+
+        # run_shell should have been called twice
+        assert mock_instance.run_shell.call_count == 2
+
+        # First call: initial_command should be the prompt
+        first_call = mock_instance.run_shell.call_args_list[0]
+        assert first_call.kwargs.get("initial_command") == "hello"
+
+        # Second call (after Reload): initial_command MUST be None
+        # Bug: it is still "hello" because prompt_interactive was not cleared
+        second_call = mock_instance.run_shell.call_args_list[1]
+        assert second_call.kwargs.get("initial_command") is None

--- a/tests/e2e/test_cli_error_output.py
+++ b/tests/e2e/test_cli_error_output.py
@@ -157,6 +157,60 @@ Invalid value for --continue: Cannot combine --continue, --session.
     )
 
 
+def test_prompt_and_prompt_interactive_conflict_is_reported(tmp_path: Path) -> None:
+    share_dir = tmp_path / "share"
+    result = _run_kimi(
+        ["--prompt", "hello", "--prompt-interactive", "world"],
+        share_dir=share_dir,
+    )
+    assert result.returncode == snapshot(2)
+    assert result.stdout == snapshot("")
+    assert _normalize_cli_error_output(result.stderr) == snapshot(
+        """\
+Usage: python -m kimi_cli.cli [OPTIONS] COMMAND [ARGS]...
+Try 'python -m kimi_cli.cli -h' for help.
+Error:
+Invalid value for --prompt: Cannot combine --prompt, --prompt-interactive.
+"""
+    )
+
+
+def test_prompt_interactive_with_print_mode_is_reported(tmp_path: Path) -> None:
+    share_dir = tmp_path / "share"
+    result = _run_kimi(
+        ["--print", "--prompt-interactive", "hello"],
+        share_dir=share_dir,
+    )
+    assert result.returncode == snapshot(2)
+    assert result.stdout == snapshot("")
+    assert _normalize_cli_error_output(result.stderr) == snapshot(
+        """\
+Usage: python -m kimi_cli.cli [OPTIONS] COMMAND [ARGS]...
+Try 'python -m kimi_cli.cli -h' for help.
+Error:
+Invalid value for --prompt-interactive: --prompt-interactive is only supported for shell UI
+"""
+    )
+
+
+def test_prompt_interactive_empty_is_reported(tmp_path: Path) -> None:
+    share_dir = tmp_path / "share"
+    result = _run_kimi(
+        ["--prompt-interactive", ""],
+        share_dir=share_dir,
+    )
+    assert result.returncode == snapshot(2)
+    assert result.stdout == snapshot("")
+    assert _normalize_cli_error_output(result.stderr) == snapshot(
+        """\
+Usage: python -m kimi_cli.cli [OPTIONS] COMMAND [ARGS]...
+Try 'python -m kimi_cli.cli -h' for help.
+Error:
+Invalid value for --prompt-interactive: Prompt cannot be empty
+"""
+    )
+
+
 def test_continue_without_previous_session_is_reported(tmp_path: Path) -> None:
     share_dir = tmp_path / "share"
     work_dir = tmp_path / "work"

--- a/tests/ui_and_conv/test_prompt_interactive.py
+++ b/tests/ui_and_conv/test_prompt_interactive.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+import kimi_cli.ui.shell as shell_module
+from kimi_cli.soul import Soul
+from kimi_cli.ui.shell.prompt import PromptMode, UserInput
+from kimi_cli.wire.types import TextPart
+
+
+class _FakePromptSession:
+    instances: list[_FakePromptSession] = []
+    responses: deque[UserInput | BaseException] = deque()
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.prompt_calls = 0
+        self.last_submission_was_running = False
+        _FakePromptSession.instances.append(self)
+
+    def __enter__(self) -> _FakePromptSession:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def prompt_next(self) -> UserInput:
+        self.prompt_calls += 1
+        response = _FakePromptSession.responses.popleft()
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    def attach_running_prompt(self, delegate) -> None:
+        return None
+
+    def detach_running_prompt(self, delegate) -> None:
+        return None
+
+    def invalidate(self) -> None:
+        pass
+
+
+def _make_user_input(command: str) -> UserInput:
+    return UserInput(
+        mode=PromptMode.AGENT,
+        command=command,
+        resolved_command=command,
+        content=[TextPart(text=command)],
+    )
+
+
+def _make_fake_soul():
+    return SimpleNamespace(
+        name="Test Soul",
+        available_slash_commands=[],
+        model_capabilities=set(),
+        model_name=None,
+        thinking=False,
+        status=SimpleNamespace(
+            context_usage=0.0,
+            context_tokens=0,
+            max_context_tokens=0,
+            mcp_status=None,
+        ),
+    )
+
+
+@pytest.fixture
+def _patched_shell_run(monkeypatch):
+    _FakePromptSession.instances = []
+    _FakePromptSession.responses = deque()
+    monkeypatch.setattr(shell_module, "CustomPromptSession", _FakePromptSession)
+    monkeypatch.setattr(shell_module, "_print_welcome_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(shell_module, "get_env_bool", lambda name: True)
+    monkeypatch.setattr(shell_module, "ensure_tty_sane", lambda: None)
+    monkeypatch.setattr(shell_module, "ensure_new_line", lambda: None)
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        shell_module.console,
+        "print",
+        lambda text="": printed.append(getattr(text, "plain", str(text))),
+    )
+    return printed
+
+
+@pytest.mark.asyncio
+async def test_initial_command_executes_then_enters_interactive_loop(
+    monkeypatch, _patched_shell_run
+) -> None:
+    """--prompt-interactive runs the initial command then keeps the shell open."""
+    _FakePromptSession.responses = deque([EOFError()])
+
+    shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
+    shell.run_soul_command = AsyncMock(return_value=True)
+
+    result = await shell.run(initial_command="hello world")
+
+    assert result is True
+    # initial_command should trigger one run_soul_command call
+    shell.run_soul_command.assert_awaited_once_with("hello world")
+    # After the initial command the loop should wait for user input (EOF)
+    assert _FakePromptSession.instances[0].prompt_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_initial_command_failure_still_enters_interactive_loop(
+    monkeypatch, _patched_shell_run
+) -> None:
+    """Even if the initial command fails, the interactive loop continues."""
+    _FakePromptSession.responses = deque([EOFError()])
+
+    shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
+    shell.run_soul_command = AsyncMock(return_value=False)
+
+    result = await shell.run(initial_command="fail me")
+
+    assert result is True  # initial command failure should not affect interactive session exit code
+    shell.run_soul_command.assert_awaited_once_with("fail me")
+    assert _FakePromptSession.instances[0].prompt_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_initial_command_with_exit_stops_immediately(monkeypatch, _patched_shell_run) -> None:
+    """If the initial command triggers /exit, the shell exits without prompting."""
+    shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
+
+    async def _mock_run(cmd):
+        shell._exit_after_run = True
+        return True
+
+    shell.run_soul_command = AsyncMock(side_effect=_mock_run)
+
+    result = await shell.run(initial_command="/exit")
+
+    assert result is True
+    shell.run_soul_command.assert_awaited_once_with("/exit")
+    # No prompt calls because we exited immediately
+    assert _FakePromptSession.instances[0].prompt_calls == 0

--- a/tests/ui_and_conv/test_prompt_interactive.py
+++ b/tests/ui_and_conv/test_prompt_interactive.py
@@ -109,6 +109,20 @@ async def test_initial_command_executes_then_enters_interactive_loop(
 
 
 @pytest.mark.asyncio
+async def test_initial_command_is_rendered_in_transcript(monkeypatch, _patched_shell_run) -> None:
+    """Initial prompt-interactive command is echoed to the shell transcript."""
+    _FakePromptSession.responses = deque([EOFError()])
+
+    shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
+    shell.run_soul_command = AsyncMock(return_value=True)
+
+    result = await shell.run(initial_command="hello")
+
+    assert result is True
+    assert "✨ hello" in _patched_shell_run
+
+
+@pytest.mark.asyncio
 async def test_initial_command_failure_still_enters_interactive_loop(
     monkeypatch, _patched_shell_run
 ) -> None:

--- a/tests/ui_and_conv/test_shell_prompt_router.py
+++ b/tests/ui_and_conv/test_shell_prompt_router.py
@@ -118,8 +118,11 @@ async def test_route_prompt_events_converts_running_keyboard_interrupt_to_cancel
 
 @pytest.mark.asyncio
 async def test_route_prompt_events_marks_eof_during_run_and_stops_router(
-    _patched_prompt_router,
+    _patched_prompt_router, monkeypatch
 ) -> None:
+    """EOF in a TTY during an active run cancels the run and sets exit flag."""
+    monkeypatch.setattr("sys.stdin", type("obj", (object,), {"isatty": lambda self: True})())
+
     shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
     prompt_session = _FakePromptSession([(False, EOFError())])
     idle_events: asyncio.Queue[shell_module._PromptEvent] = asyncio.Queue()
@@ -132,6 +135,29 @@ async def test_route_prompt_events_marks_eof_during_run_and_stops_router(
     await shell._route_prompt_events(cast(Any, prompt_session), idle_events, resume_prompt)
 
     assert cancelled == [True]
+    assert shell._exit_after_run is True
+    assert idle_events.empty()
+
+
+@pytest.mark.asyncio
+async def test_route_prompt_events_eof_in_non_tty_does_not_cancel_run(
+    _patched_prompt_router, monkeypatch
+) -> None:
+    """EOF in a non-TTY during an active run sets exit flag but does not cancel."""
+    monkeypatch.setattr("sys.stdin", type("obj", (object,), {"isatty": lambda self: False})())
+
+    shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
+    prompt_session = _FakePromptSession([(False, EOFError())])
+    idle_events: asyncio.Queue[shell_module._PromptEvent] = asyncio.Queue()
+    resume_prompt = asyncio.Event()
+    resume_prompt.set()
+
+    cancelled: list[bool] = []
+    shell._bind_running_input(lambda _user_input: None, lambda: cancelled.append(True))
+
+    await shell._route_prompt_events(cast(Any, prompt_session), idle_events, resume_prompt)
+
+    assert cancelled == []
     assert shell._exit_after_run is True
     assert idle_events.empty()
 


### PR DESCRIPTION
## Related Issue

Resolve #2240

## Description

This PR adds a new CLI option `--prompt-interactive` (short: `-P`) that allows users to pass an initial prompt when starting the shell UI, and then keeps the interactive session open for follow-up questions.

### Current behavior

The existing `--prompt` (or `-p`) option is designed for single-shot execution: the CLI processes the prompt and exits immediately.

### New behavior

With `--prompt-interactive`, the CLI:
1. Processes the initial prompt
2. Then enters the normal interactive shell loop

### Changes

- **CLI (`src/kimi_cli/cli/__init__.py`)**: Added `--prompt-interactive`/`-P` parameter, mutually exclusive with `--prompt`, only available in shell UI mode.
- **App (`src/kimi_cli/app.py`)**: Passes `initial_command` through to `Shell.run()`.
- **Shell (`src/kimi_cli/ui/shell/__init__.py`)**: Executes `initial_command` before entering the `while True` interactive loop, with proper `resume_prompt` management to pause user input during initial command execution.
- **Tests**: Added unit tests for `initial_command` behavior and E2E tests for CLI validation (mutual exclusion, UI restriction, empty prompt).

### Usage example

```bash
kimi --prompt-interactive "Analyze the dependency graph of src/main.js"
```

After the AI responds to the initial prompt, the user can continue typing follow-up questions in the same session.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
