### PR TITLE
refactor(telemetry): track btw side question as tool_call event

### DIFF
--- a/src/kimi_cli/soul/btw.py
+++ b/src/kimi_cli/soul/btw.py
@@ -117,10 +117,19 @@ async def execute_side_question(
     Returns:
         (response_text, None) on success, (None, error_message) on failure.
     """
-    if soul._runtime.llm is None:  # pyright: ignore[reportPrivateUsage]
-        return None, "LLM is not set."
+    import time
+
+    from kimi_cli.telemetry import track
+
+    t0 = time.monotonic()
+    _outcome = "error"
+    _error_type: str | None = None
 
     try:
+        if soul._runtime.llm is None:  # pyright: ignore[reportPrivateUsage]
+            _error_type = "LLMNotSet"
+            return None, "LLM is not set."
+
         chat_provider = soul._runtime.llm.chat_provider  # pyright: ignore[reportPrivateUsage]
         system_prompt, history, toolset = _build_btw_context(soul, question)
 
@@ -146,6 +155,8 @@ async def execute_side_question(
             # didn't also call tools (mixed text+tool = incomplete preamble).
             response_text = "".join(text_chunks).strip()
             if response_text and not result.tool_calls:
+                _outcome = "success"
+                _error_type = None
                 return response_text, None
 
             # No text — did the LLM try to call a tool?
@@ -166,16 +177,30 @@ async def execute_side_question(
                 continue
 
             # Last turn and still no text — report the tool call attempt
+            _error_type = "ToolCallDenied"
             tool_names = [tc.function.name for tc in result.tool_calls]
             return None, (
                 f"Side question tried to call tools ({', '.join(tool_names)}) "
                 "instead of answering directly. Try rephrasing or ask in the main conversation."
             )
 
+        _error_type = "NoResponse"
         return None, "No response received."
     except Exception as e:
+        _error_type = type(e).__name__
         logger.warning("Side question failed: {error}", error=e)
         return None, str(e)
+    finally:
+        elapsed = time.monotonic() - t0
+        kwargs: dict[str, bool | int | float | str | None] = {
+            "tool_name": "btw",
+            "outcome": _outcome,
+            "duration_ms": int(elapsed * 1000),
+            "dup_type": "normal",
+        }
+        if _error_type is not None:
+            kwargs["error_type"] = _error_type
+        track("tool_call", **kwargs)
 
 
 def _tool_result_to_message(tool_result: ToolResult) -> Message:

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -622,9 +622,6 @@ class Shell:
                     )
                     action = classify_input(input_text, is_streaming=False)
                     if action.kind == InputAction.BTW and isinstance(self.soul, KimiSoul):
-                        from kimi_cli.telemetry import track
-
-                        track("input_btw")
                         await self._run_btw_modal(action.args, prompt_session)
                         resume_prompt.set()
                         continue

--- a/tests/ui_and_conv/test_btw.py
+++ b/tests/ui_and_conv/test_btw.py
@@ -445,6 +445,138 @@ class TestExecuteSideQuestion:
 
 
 # ---------------------------------------------------------------------------
+# Telemetry tracking for execute_side_question
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSideQuestionTelemetry:
+    @staticmethod
+    def _make_soul():
+        soul = MagicMock()
+        soul._runtime.llm.chat_provider = MagicMock()
+        soul._agent.system_prompt = "sys"
+        soul._agent.toolset.tools = []
+        soul.context.history = []
+        return soul
+
+    def test_tracks_success(self):
+        """Success → track tool_call with outcome=success."""
+        soul = self._make_soul()
+
+        async def fake_step(*args, **kw):
+            if kw.get("on_message_part"):
+                kw["on_message_part"](TextPart(text="Hello!"))
+            return _text_result("Hello!")
+
+        with (
+            patch("kimi_cli.soul.btw.kosong.step", side_effect=fake_step),
+            patch("kimi_cli.telemetry.track") as mock_track,
+        ):
+            response, error = asyncio.run(execute_side_question(soul, "hi"))
+
+        assert response == "Hello!"
+        assert error is None
+        mock_track.assert_called_once()
+        call_args = mock_track.call_args
+        assert call_args[0][0] == "tool_call"
+        assert call_args.kwargs["tool_name"] == "btw"
+        assert call_args.kwargs["outcome"] == "success"
+        assert call_args.kwargs["dup_type"] == "normal"
+        assert "duration_ms" in call_args.kwargs
+        assert call_args.kwargs["duration_ms"] >= 0
+        assert "error_type" not in call_args.kwargs
+
+    def test_tracks_llm_not_set(self):
+        """LLM not set → track tool_call with outcome=error, error_type=LLMNotSet."""
+        soul = MagicMock()
+        soul._runtime.llm = None
+
+        with patch("kimi_cli.telemetry.track") as mock_track:
+            response, error = asyncio.run(execute_side_question(soul, "hi"))
+
+        assert response is None
+        assert "LLM is not set" in (error or "")
+        mock_track.assert_called_once()
+        call_args = mock_track.call_args
+        assert call_args[0][0] == "tool_call"
+        assert call_args.kwargs["tool_name"] == "btw"
+        assert call_args.kwargs["outcome"] == "error"
+        assert call_args.kwargs["error_type"] == "LLMNotSet"
+        assert call_args.kwargs["dup_type"] == "normal"
+        assert call_args.kwargs["duration_ms"] >= 0
+
+    def test_tracks_tool_call_denied(self):
+        """LLM calls tools on both turns → track tool_call with outcome=error, error_type=ToolCallDenied."""
+        soul = self._make_soul()
+
+        async def fake_step(*args, **kw):
+            return _tool_call_result("Bash")
+
+        with (
+            patch("kimi_cli.soul.btw.kosong.step", side_effect=fake_step),
+            patch("kimi_cli.telemetry.track") as mock_track,
+        ):
+            response, error = asyncio.run(execute_side_question(soul, "hi"))
+
+        assert response is None
+        assert error is not None
+        mock_track.assert_called_once()
+        call_args = mock_track.call_args
+        assert call_args[0][0] == "tool_call"
+        assert call_args.kwargs["tool_name"] == "btw"
+        assert call_args.kwargs["outcome"] == "error"
+        assert call_args.kwargs["error_type"] == "ToolCallDenied"
+        assert call_args.kwargs["dup_type"] == "normal"
+        assert "duration_ms" in call_args.kwargs
+
+    def test_tracks_no_response(self):
+        """LLM returns nothing → track tool_call with outcome=error, error_type=NoResponse."""
+        soul = self._make_soul()
+
+        async def fake_step(*args, **kw):
+            return _text_result("")  # Empty response
+
+        with (
+            patch("kimi_cli.soul.btw.kosong.step", side_effect=fake_step),
+            patch("kimi_cli.telemetry.track") as mock_track,
+        ):
+            response, error = asyncio.run(execute_side_question(soul, "hi"))
+
+        assert response is None
+        assert error is not None
+        mock_track.assert_called_once()
+        call_args = mock_track.call_args
+        assert call_args[0][0] == "tool_call"
+        assert call_args.kwargs["tool_name"] == "btw"
+        assert call_args.kwargs["outcome"] == "error"
+        assert call_args.kwargs["error_type"] == "NoResponse"
+        assert call_args.kwargs["dup_type"] == "normal"
+
+    def test_tracks_exception(self):
+        """LLM call raises exception → track tool_call with outcome=error, error_type=exception name."""
+        soul = self._make_soul()
+
+        async def fake_step(*args, **kw):
+            raise RuntimeError("API timeout")
+
+        with (
+            patch("kimi_cli.soul.btw.kosong.step", side_effect=fake_step),
+            patch("kimi_cli.telemetry.track") as mock_track,
+        ):
+            response, error = asyncio.run(execute_side_question(soul, "hi"))
+
+        assert response is None
+        assert "API timeout" in (error or "")
+        mock_track.assert_called_once()
+        call_args = mock_track.call_args
+        assert call_args[0][0] == "tool_call"
+        assert call_args.kwargs["tool_name"] == "btw"
+        assert call_args.kwargs["outcome"] == "error"
+        assert call_args.kwargs["error_type"] == "RuntimeError"
+        assert call_args.kwargs["dup_type"] == "normal"
+
+
+# ---------------------------------------------------------------------------
 # _BtwModalDelegate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Related Issue

N/A

## Description

Replace the lightweight `input_btw` telemetry event with a structured `tool_call` event so the `/btw` side-question flow shows up alongside the rest of the tool-call observability (outcome, duration, error breakdown) instead of just a fire-and-forget input counter.

---

### 1. Structured telemetry for btw side questions

**Problem:** `/btw` previously emitted a single `input_btw` event at the Shell layer, which only told us that the user typed `/btw …` — not whether the side question actually returned an answer, how long it took, or why it failed. That made it impossible to spot regressions like LLM-not-set, model attempting tool calls instead of replying, empty responses, or transport exceptions.

**What was done:**
- Remove the `track("input_btw")` call from `Shell._main_loop` (it was only counting input, not outcomes).
- Wrap `execute_side_question` in a try/finally that emits `tool_call` with `tool_name=btw`, `outcome`, `duration_ms`, `dup_type=normal`, and `error_type` on failure.
- Cover all error paths with distinct `error_type` values: `LLMNotSet`, `ToolCallDenied` (LLM tried to call tools instead of answering on both turns), `NoResponse`, and the exception class name for uncaught failures.

### 2. Tests

**Problem:** Telemetry regressions are silent — without explicit tests, future refactors to `execute_side_question` could easily drop the `track` call or mis-label an outcome and no test would catch it.

**What was done:**
- Add `TestExecuteSideQuestionTelemetry` in `tests/ui_and_conv/test_btw.py` with one test per outcome branch: success, `LLMNotSet`, `ToolCallDenied`, `NoResponse`, and an exception path.
- Each test asserts the event name, `tool_name`, `outcome`, `error_type` presence/absence, and that `duration_ms` is recorded.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->