### PR TITLE
fix: redirect stdio MCP stderr to logs

### DIFF
--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -96,7 +96,7 @@ def _build_mcp_client(server_name: str, server_config: Any) -> fastmcp.Client[An
     from fastmcp.client.transports import StdioTransport
     from fastmcp.mcp_config import MCPConfig, StdioMCPServer
 
-    if isinstance(server_config, StdioMCPServer):
+    if type(server_config) is StdioMCPServer:
         log_path = _mcp_stdio_log_path(server_name)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         transport = StdioTransport(

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib
 import inspect
 import json
+import re
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -33,6 +34,7 @@ from kosong.utils.typing import JsonType
 from kimi_cli import logger
 from kimi_cli.exception import InvalidToolError, MCPRuntimeError
 from kimi_cli.hooks.engine import HookEngine
+from kimi_cli.share import get_share_dir
 from kimi_cli.tools import SkipThisTool
 from kimi_cli.wire.types import (
     AudioURLPart,
@@ -61,6 +63,8 @@ current_tool_call = ContextVar[ToolCall | None]("current_tool_call", default=Non
 
 _current_session_id: ContextVar[str] = ContextVar("_current_session_id", default="")
 
+_MCP_LOG_FILENAME_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
 
 def set_session_id(sid: str) -> None:
     _current_session_id.set(sid)
@@ -80,6 +84,32 @@ def get_current_tool_call_or_none() -> ToolCall | None:
     Expect to be not None when called from a `__call__` method of a tool.
     """
     return current_tool_call.get()
+
+
+def _mcp_stdio_log_path(server_name: str) -> Path:
+    safe_name = _MCP_LOG_FILENAME_PATTERN.sub("_", server_name).strip("._") or "server"
+    return get_share_dir() / "logs" / "mcp" / f"{safe_name}.log"
+
+
+def _build_mcp_client(server_name: str, server_config: Any) -> fastmcp.Client[Any]:
+    import fastmcp
+    from fastmcp.client.transports import StdioTransport
+    from fastmcp.mcp_config import MCPConfig, StdioMCPServer
+
+    if isinstance(server_config, StdioMCPServer):
+        log_path = _mcp_stdio_log_path(server_name)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        transport = StdioTransport(
+            command=server_config.command,
+            args=server_config.args,
+            env=server_config.env,
+            cwd=server_config.cwd,
+            keep_alive=server_config.keep_alive,
+            log_file=log_path,
+        )
+        return fastmcp.Client(transport)
+
+    return fastmcp.Client(MCPConfig(mcpServers={server_name: server_config}))
 
 
 type ToolType = CallableTool | CallableTool2[Any]
@@ -538,8 +568,7 @@ class KimiToolset:
             MCPRuntimeError(KimiCLIException, RuntimeError): When any MCP server cannot be
                 connected.
         """
-        import fastmcp
-        from fastmcp.mcp_config import MCPConfig, RemoteMCPServer
+        from fastmcp.mcp_config import RemoteMCPServer
 
         from kimi_cli.mcp_oauth import create_mcp_oauth, has_mcp_oauth_tokens
         from kimi_cli.ui.shell.prompt import toast
@@ -644,7 +673,7 @@ class KimiToolset:
                         continue
                     server_config = server_config.model_copy(update={"auth": auth})
 
-                client = fastmcp.Client(MCPConfig(mcpServers={server_name: server_config}))
+                client = _build_mcp_client(server_name, server_config)
                 self._mcp_servers[server_name] = MCPServerInfo(
                     status="pending", client=client, tools=[]
                 )

--- a/tests/core/test_mcp_stdio_logging.py
+++ b/tests/core/test_mcp_stdio_logging.py
@@ -26,3 +26,30 @@ def test_stdio_mcp_stderr_goes_to_kimi_log_file(tmp_path, monkeypatch):
     assert isinstance(client.transport, StdioTransport)
     assert client.transport.log_file == tmp_path / "logs" / "mcp" / "chrome_devtools.log"
     assert (tmp_path / "logs" / "mcp").is_dir()
+
+
+def test_transforming_stdio_mcp_config_keeps_fastmcp_transport(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+
+    from fastmcp.client.transports.config import MCPConfigTransport
+    from fastmcp.mcp_config import MCPConfig
+
+    from kimi_cli.soul.toolset import _build_mcp_client
+
+    mcp_config = MCPConfig.model_validate(
+        {
+            "mcpServers": {
+                "filtered": {
+                    "command": "npx",
+                    "args": ["-y", "some-mcp-server"],
+                    "include_tags": ["safe"],
+                }
+            }
+        }
+    )
+    server_config = mcp_config.mcpServers["filtered"]
+
+    client = _build_mcp_client("filtered", server_config)
+
+    assert isinstance(client.transport, MCPConfigTransport)
+    assert client.transport.config.mcpServers["filtered"].include_tags == {"safe"}

--- a/tests/core/test_mcp_stdio_logging.py
+++ b/tests/core/test_mcp_stdio_logging.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+
+def test_stdio_mcp_stderr_goes_to_kimi_log_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+
+    from fastmcp.client.transports import StdioTransport
+    from fastmcp.mcp_config import MCPConfig
+
+    from kimi_cli.soul.toolset import _build_mcp_client
+
+    mcp_config = MCPConfig.model_validate(
+        {
+            "mcpServers": {
+                "chrome/devtools": {
+                    "command": "npx",
+                    "args": ["-y", "chrome-devtools-mcp@latest"],
+                }
+            }
+        }
+    )
+    server_config = mcp_config.mcpServers["chrome/devtools"]
+
+    client = _build_mcp_client("chrome/devtools", server_config)
+
+    assert isinstance(client.transport, StdioTransport)
+    assert client.transport.log_file == tmp_path / "logs" / "mcp" / "chrome_devtools.log"
+    assert (tmp_path / "logs" / "mcp").is_dir()


### PR DESCRIPTION
﻿## Summary
- route stdio MCP subprocess stderr to `~/.kimi/logs/mcp/<server>.log` instead of the interactive terminal
- keep non-stdio MCP server setup on the existing MCPConfig path
- add a focused regression test for sanitized per-server log paths

## Notes
This addresses the stderr leak described in #2251. It is separate from MCP logging notifications handled in #1637; those are in-protocol log messages, while this patch covers the child process stderr stream that FastMCP 3.2.4 defaults to sys.stderr.

## To verify
- uv run pytest tests\core\test_mcp_stdio_logging.py -q -p no:cacheprovider --basetemp .tmp\pytest
- uv run pytest tests\cli\test_mcp_oauth.py::test_load_mcp_tools_treats_unreadable_oauth_storage_as_unauthorized -q -p no:cacheprovider --basetemp .tmp\pytest-oauth
- uv run ruff check src\kimi_cli\soul\toolset.py tests\core\test_mcp_stdio_logging.py
- uv run ruff format --check src\kimi_cli\soul\toolset.py tests\core\test_mcp_stdio_logging.py
- uv run pyright src\kimi_cli\soul\toolset.py tests\core\test_mcp_stdio_logging.py

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->