### PR TITLE
feat(shell): add slash command alias resolution and display

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -46,7 +46,29 @@ The Rust implementation (`kagent`) lives in a separate repository and is **not**
 
    Wait for explicit user approval before proceeding. If the user flags anything, fix it and re-confirm — do not push.
 
-10. **Open the PR.** Commit all changes, push, and open a PR with `gh` describing the version bumps.
+10. **Open the PR.** Commit all changes, push, and open a PR with `gh`. The PR description must follow this structure (see https://github.com/MoonshotAI/kimi-cli/pull/2225 for reference):
+
+    ```markdown
+    ## Summary
+    - Bump <package> to <version>
+    - Move the current release notes under <version>
+    - (If applicable) Move breaking-change entries under <version>
+    - (If applicable) Any additional noteworthy changes (dependency pin updates, etc.)
+
+    ## Validation
+    - uv run python scripts/check_version_tag.py --pyproject <pyproject> --expected-version <version>
+    - (For root releases) uv run python scripts/check_version_tag.py --pyproject packages/kimi-code/pyproject.toml --expected-version <version>
+    - uv run python scripts/check_kimi_dependency_versions.py --root-pyproject pyproject.toml --kosong-pyproject packages/kosong/pyproject.toml --pykaos-pyproject packages/kaos/pyproject.toml
+    - make check
+
+    ## Post-merge
+    After this PR lands, create and push the release tag:
+
+    ```sh
+    git tag <tag>
+    git push origin <tag>
+    ```
+    ```
 
 11. **Hand off the tag step.** After merge, switch to `main`, pull latest, and tell the user the exact `git tag` command for the final release tag (pick the right tag pattern from the table above — e.g. `git tag 1.43.0` for a root release, `git tag kosong-0.54.0` for a kosong release). The user will run the tag and push tags themselves.
 

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -200,16 +200,38 @@ class Shell:
         self._current_prompt_approval_request: ApprovalRequest | None = None
         self._approval_modal: ApprovalPromptDelegate | None = None
         self._exit_after_run = False
+        soul_slash_commands = list(soul.available_slash_commands)
+        shell_slash_commands = shell_slash_registry.list_commands()
         self._available_slash_commands: dict[str, SlashCommand[Any]] = {
-            **{cmd.name: cmd for cmd in soul.available_slash_commands},
-            **{cmd.name: cmd for cmd in shell_slash_registry.list_commands()},
+            **{cmd.name: cmd for cmd in soul_slash_commands},
+            **{cmd.name: cmd for cmd in shell_slash_commands},
         }
-        """Shell-level slash commands + soul-level slash commands. Name to command mapping."""
+        """Shell-level slash commands + soul-level slash commands. Primary name mapping."""
+        self._available_slash_command_index = self._index_slash_commands(
+            [*soul_slash_commands, *shell_slash_commands]
+        )
+        """Shell-level slash commands + soul-level slash commands.
+        Primary name and alias mapping.
+        """
 
     @property
     def available_slash_commands(self) -> dict[str, SlashCommand[Any]]:
         """Get all available slash commands, including shell-level and soul-level commands."""
         return self._available_slash_commands
+
+    @staticmethod
+    def _index_slash_commands(commands: list[SlashCommand[Any]]) -> dict[str, SlashCommand[Any]]:
+        indexed: dict[str, SlashCommand[Any]] = {}
+        for command in commands:
+            indexed[command.name] = command
+            for alias in command.aliases:
+                indexed[alias] = command
+        return indexed
+
+    def _find_available_slash_command(self, name: str) -> SlashCommand[Any] | None:
+        return self._available_slash_command_index.get(name) or self._available_slash_commands.get(
+            name
+        )
 
     def _print_cwd_lost_crash(self) -> None:
         """Print a crash report when the working directory is no longer accessible."""
@@ -634,14 +656,16 @@ class Shell:
                         continue
 
                     if slash_cmd_call := self._agent_slash_command_call(user_input):
+                        available_command = self._find_available_slash_command(slash_cmd_call.name)
                         is_soul_slash = (
-                            slash_cmd_call.name in self._available_slash_commands
+                            available_command is not None
                             and shell_slash_registry.find_command(slash_cmd_call.name) is None
                         )
                         if is_soul_slash:
                             from kimi_cli.telemetry import track
 
-                            track("input_command", command=slash_cmd_call.name)
+                            assert available_command is not None
+                            track("input_command", command=available_command.name)
                             background_autotrigger_armed = True
                             resume_prompt.set()
                             await self.run_soul_command(slash_cmd_call.raw_input)
@@ -755,7 +779,8 @@ class Shell:
         from kimi_cli.cli import Reload, SwitchToVis, SwitchToWeb
         from kimi_cli.telemetry import track
 
-        if command_call.name not in self._available_slash_commands:
+        available_command = self._find_available_slash_command(command_call.name)
+        if available_command is None:
             logger.info("Unknown slash command /{command}", command=command_call.name)
             track("input_command_invalid")
             console.print(
@@ -764,7 +789,7 @@ class Shell:
             )
             return
 
-        track("input_command", command=command_call.name)
+        track("input_command", command=available_command.name)
 
         command = shell_slash_registry.find_command(command_call.name)
         if command is None:

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -89,7 +89,7 @@ class CwdLostError(OSError):
 class SlashCommandCompleter(Completer):
     """
     A completer that:
-    - Shows one line per slash command using the canonical "/name"
+    - Shows canonical matches as "/name" and alias matches as "/name (alias)"
     - Fuzzy-matches by primary name or any alias while inserting the canonical "/name"
     - Only activates when the current token starts with '/'
     """
@@ -142,25 +142,32 @@ class SlashCommandCompleter(Completer):
         token = text[last_space + 1 :]
 
         typed = token[1:]
-        if typed and typed in self._command_lookup:
-            return
         mention_doc = Document(text=typed, cursor_position=len(typed))
         candidates = list(self._fuzzy.get_completions(mention_doc, complete_event))
 
         seen: set[str] = set()
-
+        candidate_triggers: list[str] = []
+        if typed and typed in self._command_lookup:
+            candidate_triggers.append(typed)
         for candidate in candidates:
-            commands = self._command_lookup.get(candidate.text)
+            if candidate.text not in candidate_triggers:
+                candidate_triggers.append(candidate.text)
+
+        for trigger in candidate_triggers:
+            commands = self._command_lookup.get(trigger)
             if not commands:
                 continue
             for cmd in commands:
                 if cmd.name in seen:
                     continue
                 seen.add(cmd.name)
+                completion_text = f"/{cmd.name}"
+                if trigger == cmd.name and typed == cmd.name:
+                    completion_text += " "
                 yield Completion(
-                    text=f"/{cmd.name}",
+                    text=completion_text,
                     start_position=-len(token),
-                    display=f"/{cmd.name}",
+                    display=cmd.display_name(trigger),
                     display_meta=cmd.description,
                 )
 

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, cast
 
 from prompt_toolkit.shortcuts.choice_input import ChoiceInput
@@ -63,6 +63,30 @@ _KEYBOARD_SHORTCUTS = [
 ]
 
 
+def _unique_commands(commands: Iterable[SlashCommand[Any]]) -> list[SlashCommand[Any]]:
+    unique: list[SlashCommand[Any]] = []
+    seen: set[str] = set()
+    for cmd in commands:
+        if cmd.name in seen:
+            continue
+        unique.append(cmd)
+        seen.add(cmd.name)
+    return unique
+
+
+def _expanded_command_items(commands: Iterable[SlashCommand[Any]]) -> list[tuple[str, str]]:
+    items: list[tuple[str, str]] = []
+    for cmd in sorted(_unique_commands(commands), key=lambda c: c.name):
+        seen = {cmd.name}
+        items.append((cmd.display_name(cmd.name), cmd.description))
+        for alias in cmd.aliases:
+            if alias in seen:
+                continue
+            items.append((cmd.display_name(alias), cmd.description))
+            seen.add(alias)
+    return items
+
+
 @registry.command(aliases=["h", "?"])
 @shell_mode_registry.command(aliases=["h", "?"])
 def help(app: Shell, args: str):
@@ -115,7 +139,7 @@ def help(app: Shell, args: str):
     renderables.append(
         section(
             "Slash commands",
-            [(c.slash_name(), c.description) for c in sorted(commands, key=lambda c: c.name)],
+            _expanded_command_items(commands),
             "blue",
         )
     )
@@ -123,7 +147,7 @@ def help(app: Shell, args: str):
         renderables.append(
             section(
                 "Skills",
-                [(c.slash_name(), c.description) for c in sorted(skills, key=lambda c: c.name)],
+                _expanded_command_items(skills),
                 "cyan",
             )
         )

--- a/src/kimi_cli/ui/shell/usage.py
+++ b/src/kimi_cli/ui/shell/usage.py
@@ -34,7 +34,7 @@ class UsageRow:
     reset_hint: str | None = None
 
 
-@registry.command(aliases=["/status"])
+@registry.command(aliases=["status"])
 async def usage(app: Shell, args: str):
     """Display API usage and quota information"""
     assert isinstance(app.soul, KimiSoul)

--- a/src/kimi_cli/utils/slashcmd.py
+++ b/src/kimi_cli/utils/slashcmd.py
@@ -11,6 +11,12 @@ class SlashCommand[F: Callable[..., None | Awaitable[None]]]:
     func: F
     aliases: list[str]
 
+    def display_name(self, trigger: str | None = None) -> str:
+        """/name for canonical triggers, /name (alias) for alias triggers."""
+        if trigger is not None and trigger != self.name and trigger in self.aliases:
+            return f"/{self.name} ({trigger})"
+        return f"/{self.name}"
+
     def slash_name(self):
         """/name (aliases)"""
         if self.aliases:
@@ -91,6 +97,21 @@ class SlashCommandRegistry[F: Callable[..., None | Awaitable[None]]]:
     def list_commands(self) -> list[SlashCommand[F]]:
         """Get all unique primary slash commands (without duplicating aliases)."""
         return list(self._commands.values())
+
+    def iter_command_entries(self) -> list[tuple[str, SlashCommand[F]]]:
+        """Get canonical and alias entries as (trigger, command) pairs."""
+        entries: list[tuple[str, SlashCommand[F]]] = []
+        for cmd in self._commands.values():
+            entries.append((cmd.name, cmd))
+            seen = {cmd.name}
+            for alias in cmd.aliases:
+                if alias in seen:
+                    continue
+                if self._command_aliases.get(alias) is not cmd:
+                    continue
+                entries.append((alias, cmd))
+                seen.add(alias)
+        return entries
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/tests/ui_and_conv/test_shell_run_placeholders.py
+++ b/tests/ui_and_conv/test_shell_run_placeholders.py
@@ -10,7 +10,7 @@ import pytest
 import kimi_cli.ui.shell as shell_module
 from kimi_cli.soul import Soul
 from kimi_cli.ui.shell.prompt import PromptMode, UserInput
-from kimi_cli.utils.slashcmd import SlashCommand
+from kimi_cli.utils.slashcmd import SlashCommand, SlashCommandCall
 from kimi_cli.wire.types import TextPart
 
 
@@ -70,6 +70,33 @@ def _make_fake_soul():
 
 def _noop(app: object, args: str) -> None:
     pass
+
+
+@pytest.mark.asyncio
+async def test_shell_slash_alias_tracks_canonical_command(monkeypatch) -> None:
+    tracked: list[tuple[str, dict[str, object]]] = []
+    fake_command = SlashCommand(
+        name="help",
+        description="help command",
+        func=_noop,
+        aliases=["h"],
+    )
+
+    monkeypatch.setattr(
+        "kimi_cli.telemetry.track",
+        lambda event, **properties: tracked.append((event, properties)),
+    )
+    monkeypatch.setattr(
+        shell_module.shell_slash_registry,
+        "find_command",
+        lambda name: fake_command if name == "h" else None,
+    )
+
+    shell = shell_module.Shell(cast(Soul, _make_fake_soul()))
+
+    await shell._run_slash_command(SlashCommandCall(name="h", args="", raw_input="/h"))
+
+    assert ("input_command", {"command": "help"}) in tracked
 
 
 @pytest.fixture

--- a/tests/ui_and_conv/test_shell_slash_commands.py
+++ b/tests/ui_and_conv/test_shell_slash_commands.py
@@ -13,7 +13,11 @@ from kosong.message import Message
 
 from kimi_cli.cli import Reload
 from kimi_cli.session import Session
-from kimi_cli.ui.shell.slash import ShellSlashCmdFunc, shell_mode_registry
+from kimi_cli.ui.shell.slash import (
+    ShellSlashCmdFunc,
+    _expanded_command_items,
+    shell_mode_registry,
+)
 from kimi_cli.ui.shell.slash import registry as shell_slash_registry
 from kimi_cli.utils.slashcmd import SlashCommand
 from kimi_cli.wire.types import TextPart
@@ -94,6 +98,44 @@ class TestNewCommandRegistration:
         from kimi_cli.soul.slash import registry as soul_slash_registry
 
         assert soul_slash_registry.find_command("new") is None
+
+
+class TestAliasRegistration:
+    """Verify shell aliases resolve to their canonical commands."""
+
+    def test_agent_mode_aliases_resolve_to_canonical_commands(self) -> None:
+        help_cmd = shell_slash_registry.find_command("h")
+        quit_cmd = shell_slash_registry.find_command("quit")
+        status_cmd = shell_slash_registry.find_command("status")
+
+        assert help_cmd is not None
+        assert quit_cmd is not None
+        assert status_cmd is not None
+        assert help_cmd.name == "help"
+        assert quit_cmd.name == "exit"
+        assert status_cmd.name == "usage"
+
+    def test_help_items_expand_aliases_as_separate_rows(self) -> None:
+        command = SlashCommand(
+            name="clear",
+            description="Clear the context",
+            func=lambda _shell, _args: None,
+            aliases=["reset", "reset"],
+        )
+
+        assert _expanded_command_items([command]) == [
+            ("/clear", "Clear the context"),
+            ("/clear (reset)", "Clear the context"),
+        ]
+
+    def test_shell_mode_aliases_resolve_to_canonical_commands(self) -> None:
+        help_cmd = shell_mode_registry.find_command("h")
+        quit_cmd = shell_mode_registry.find_command("quit")
+
+        assert help_cmd is not None
+        assert quit_cmd is not None
+        assert help_cmd.name == "help"
+        assert quit_cmd.name == "exit"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui_and_conv/test_slash_completer.py
+++ b/tests/ui_and_conv/test_slash_completer.py
@@ -48,8 +48,8 @@ def _completions(completer: SlashCommandCompleter, text: str):
     return list(completer.get_completions(document, event))
 
 
-def test_exact_command_match_hides_completions():
-    """Exact matches should not show completions."""
+def test_exact_command_match_keeps_completion_visible():
+    """Exact command matches should stay visible while the cursor is in the slash token."""
     completer = SlashCommandCompleter(
         [
             _make_command("mcp"),
@@ -58,23 +58,36 @@ def test_exact_command_match_hides_completions():
         ]
     )
 
-    texts = _completion_texts(completer, "/mcp")
+    completions = _completions(completer, "/mcp")
 
-    assert not texts
+    assert completions[0].text == "/mcp "
+    assert completions[0].display_text == "/mcp"
+    assert "/mcp-server" in [completion.text for completion in completions]
 
 
-def test_exact_alias_match_hides_completions():
-    """Exact alias matches should not show completions."""
+def test_exact_single_command_match_adds_space_to_avoid_noop_completion():
+    completer = SlashCommandCompleter([_make_command("help")])
+
+    completions = _completions(completer, "/help")
+
+    assert len(completions) == 1
+    assert completions[0].text == "/help "
+    assert completions[0].display_text == "/help"
+
+
+def test_exact_alias_match_shows_canonical_completion():
+    """Exact alias matches should offer the canonical command."""
     completer = SlashCommandCompleter(
         [
             _make_command("help", aliases=["h"]),
-            _make_command("history"),
         ]
     )
 
-    texts = _completion_texts(completer, "/h")
+    completions = _completions(completer, "/h")
 
-    assert not texts
+    assert len(completions) == 1
+    assert completions[0].text == "/help"
+    assert completions[0].display_text == "/help (h)"
 
 
 def test_should_complete_only_for_root_slash_token():
@@ -83,6 +96,7 @@ def test_should_complete_only_for_root_slash_token():
     assert not SlashCommandCompleter.should_complete(Document(text="test /he", cursor_position=8))
     assert not SlashCommandCompleter.should_complete(Document(text="@src", cursor_position=4))
     assert not SlashCommandCompleter.should_complete(Document(text="/he next", cursor_position=8))
+    assert not SlashCommandCompleter.should_complete(Document(text="/help ", cursor_position=6))
 
 
 def test_completion_display_uses_canonical_command_name():
@@ -101,6 +115,20 @@ def test_completion_display_uses_canonical_command_name():
     assert completions[0].display_meta_text == "help command"
 
 
+def test_alias_completion_display_uses_canonical_name_and_alias_hint():
+    completer = SlashCommandCompleter(
+        [
+            _make_command("clear", aliases=["reset"]),
+        ]
+    )
+
+    completions = _completions(completer, "/re")
+
+    assert len(completions) == 1
+    assert completions[0].text == "/clear"
+    assert completions[0].display_text == "/clear (reset)"
+
+
 def test_skill_completion_path_still_returns_registered_skill_command():
     completer = SlashCommandCompleter(
         [
@@ -110,7 +138,7 @@ def test_skill_completion_path_still_returns_registered_skill_command():
     )
 
     assert _completion_texts(completer, "/skill:de") == ["/skill:demo"]
-    assert _completion_texts(completer, "/skill:demo") == []
+    assert _completion_texts(completer, "/skill:demo") == ["/skill:demo "]
 
 
 def test_flow_completion_path_still_returns_registered_flow_command():
@@ -122,7 +150,7 @@ def test_flow_completion_path_still_returns_registered_flow_command():
     )
 
     assert _completion_texts(completer, "/flow:de") == ["/flow:demo"]
-    assert _completion_texts(completer, "/flow:demo") == []
+    assert _completion_texts(completer, "/flow:demo") == ["/flow:demo "]
 
 
 def test_btw_is_available_in_agent_slash_completion_menu():

--- a/tests/utils/test_slash_command.py
+++ b/tests/utils/test_slash_command.py
@@ -19,22 +19,33 @@ def check_slash_commands(registry: SlashCommandRegistry[Any], snapshot: Any):
     """Check slash commands match snapshot."""
     import json
 
-    # Use the public list_commands() API and build the alias mapping
-    alias_to_cmd: dict[str, SlashCommand[Any]] = {}
-    for cmd in registry.list_commands():
-        alias_to_cmd[cmd.name] = cmd
-        for alias in cmd.aliases:
-            alias_to_cmd[alias] = cmd
-
     pretty_commands = json.dumps(
         {
-            alias: f"{cmd.slash_name()}: {cmd.description}"
-            for (alias, cmd) in sorted(alias_to_cmd.items())
+            trigger: f"{cmd.display_name(trigger)}: {cmd.description}"
+            for (trigger, cmd) in sorted(registry.iter_command_entries(), key=lambda item: item[0])
         },
         indent=2,
         sort_keys=True,
     )
     assert pretty_commands == snapshot
+
+
+def _noop(app: object, args: str) -> None:
+    pass
+
+
+def test_slash_command_display_name() -> None:
+    cmd = SlashCommand(
+        name="help",
+        description="Show help.",
+        func=_noop,
+        aliases=["h", "?"],
+    )
+
+    assert cmd.display_name() == "/help"
+    assert cmd.display_name("help") == "/help"
+    assert cmd.display_name("h") == "/help (h)"
+    assert cmd.display_name("?") == "/help (?)"
 
 
 def test_parse_slash_command_call():
@@ -164,17 +175,17 @@ def test_slash_command_registration(test_registry: SlashCommandRegistry[Any]) ->
         test_registry,
         snapshot("""\
 {
-  "?": "/help (h, ?): Show help.",
+  "?": "/help (?): Show help.",
   "basic": "/basic: Basic command.",
-  "dedup_test": "/dedup_test (dup, dup): Test deduplication.",
-  "dup": "/dedup_test (dup, dup): Test deduplication.",
-  "find": "/search (s, find): Search items.",
-  "h": "/help (h, ?): Show help.",
-  "help": "/help (h, ?): Show help.",
+  "dedup_test": "/dedup_test: Test deduplication.",
+  "dup": "/dedup_test (dup): Test deduplication.",
+  "find": "/search (find): Search items.",
+  "h": "/help (h): Show help.",
+  "help": "/help: Show help.",
   "no_doc": "/no_doc: ",
   "run": "/run: Run something.",
-  "s": "/search (s, find): Search items.",
-  "search": "/search (s, find): Search items.",
+  "s": "/search (s): Search items.",
+  "search": "/search: Search items.",
   "whitespace_doc": "/whitespace_doc: "
 }\
 """),


### PR DESCRIPTION
## Summary

This PR improves the shell slash command system so that aliases are fully resolved to their canonical commands. Users can now invoke slash commands via aliases, and the UI clearly shows when an alias match is being used. Telemetry also tracks canonical names rather than raw alias inputs.

---

### 1. Slash command alias resolution

**Problem:** Slash command aliases were partially supported but not consistently resolved. Invoking a command via its alias could bypass telemetry tracking or fail to match the correct handler.

**What was done:**
- Index available slash commands by both primary name and aliases in `Shell`.
- Added `_find_available_slash_command()` to resolve aliases to canonical `SlashCommand` instances.
- Telemetry now records the canonical `command.name` even when invoked via alias.

### 2. Alias display in completer and help output

**Problem:** The shell completer and help text did not distinguish between canonical names and aliases, making it unclear when an alias was matched.

**What was done:**
- Added `SlashCommand.display_name(trigger)` to render `/name (alias)` for alias matches.
- Updated `SlashCommandCompleter` to show alias matches with the new display format.
- Updated `/help` output to expand aliases as separate entries.
- Fixed the `/usage` alias from `"/status"` to `"status"`.

### 3. Registry and test infrastructure

**Problem:** The slash command registry lacked utilities to iterate over both canonical and alias entries.

**What was done:**
- Added `SlashCommandRegistry.iter_command_entries()` to yield `(trigger, command)` pairs.
- Updated all affected tests to cover alias resolution, completer behavior, and telemetry tracking.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->