### PR TITLE
fix(shell): redirect MCP server stderr to log file and show error in /mcp

### DIFF
--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -435,6 +435,7 @@ class KimiToolset:
                 name=name,
                 status=info.status,
                 tools=tuple(tool.name for tool in info.tools),
+                error=info.error,
             )
             for name, info in self._mcp_servers.items()
         )
@@ -539,9 +540,11 @@ class KimiToolset:
                 connected.
         """
         import fastmcp
-        from fastmcp.mcp_config import MCPConfig, RemoteMCPServer
+        from fastmcp.client.transports import StdioTransport
+        from fastmcp.mcp_config import MCPConfig, RemoteMCPServer, StdioMCPServer
 
         from kimi_cli.mcp_oauth import create_mcp_oauth, has_mcp_oauth_tokens
+        from kimi_cli.share import get_share_dir
         from kimi_cli.ui.shell.prompt import toast
 
         async def _check_oauth_tokens(server_url: str) -> bool:
@@ -587,6 +590,7 @@ class KimiToolset:
                     self.add(tool)
 
                 server_info.status = "connected"
+                server_info.error = None
                 logger.info("Connected MCP server: {server_name}", server_name=server_name)
                 return server_name, None
             except Exception as e:
@@ -596,6 +600,7 @@ class KimiToolset:
                     error=e,
                 )
                 server_info.status = "failed"
+                server_info.error = str(e)
                 return server_name, e
 
         async def _connect():
@@ -644,7 +649,20 @@ class KimiToolset:
                         continue
                     server_config = server_config.model_copy(update={"auth": auth})
 
-                client = fastmcp.Client(MCPConfig(mcpServers={server_name: server_config}))
+                if isinstance(server_config, StdioMCPServer):
+                    log_dir = get_share_dir() / "mcp-logs"
+                    log_dir.mkdir(parents=True, exist_ok=True)
+                    transport = StdioTransport(
+                        command=server_config.command,
+                        args=server_config.args,
+                        env=server_config.env,
+                        cwd=server_config.cwd,
+                        keep_alive=server_config.keep_alive,
+                        log_file=log_dir / f"{server_name}.log",
+                    )
+                    client = fastmcp.Client(transport)
+                else:
+                    client = fastmcp.Client(MCPConfig(mcpServers={server_name: server_config}))
                 self._mcp_servers[server_name] = MCPServerInfo(
                     status="pending", client=client, tools=[]
                 )
@@ -686,6 +704,7 @@ class MCPServerInfo:
     status: Literal["pending", "connecting", "connected", "failed", "unauthorized"]
     client: fastmcp.Client[Any] | None
     tools: list[MCPTool[Any]]
+    error: str | None = None
 
 
 class MCPTool[T: ClientTransport](CallableTool):

--- a/src/kimi_cli/ui/shell/mcp_status.py
+++ b/src/kimi_cli/ui/shell/mcp_status.py
@@ -31,6 +31,13 @@ def render_mcp_console(snapshot: MCPStatusSnapshot) -> RenderableType:
             server_text += f" [grey50]({server.status})[/grey50]"
 
         lines: list[RenderableType] = [Text.from_markup(server_text)]
+        if server.error:
+            lines.append(
+                BulletColumns(
+                    Text.from_markup(f"[red]Error: {server.error}[/red]"),
+                    bullet_style="red",
+                )
+            )
         for tool_name in server.tools:
             lines.append(
                 BulletColumns(
@@ -66,6 +73,8 @@ def render_mcp_prompt(snapshot: MCPStatusSnapshot, *, now: float | None = None) 
         detail = _prompt_server_detail(server)
         if detail:
             fragments.append((colors.detail, detail))
+        if server.error:
+            fragments.append((colors.failed, f" Error: {server.error}"))
         fragments.append(("", "\n"))
 
     return FormattedText(fragments)

--- a/src/kimi_cli/wire/types.py
+++ b/src/kimi_cli/wire/types.py
@@ -161,6 +161,7 @@ class MCPServerSnapshot(BaseModel):
     name: str
     status: Literal["pending", "connecting", "connected", "failed", "unauthorized"]
     tools: tuple[str, ...] = ()
+    error: str | None = None
 
 
 class MCPStatusSnapshot(BaseModel):


### PR DESCRIPTION
## Problem

When connecting to MCP stdio servers, their stderr logs are written directly to the terminal, overwriting the prompt_toolkit input box and making the shell UI look broken.

## Changes

1. **Redirect MCP stderr to log files** — For stdio MCP servers, manually create `StdioTransport` with `log_file=~/.kimi/mcp-logs/{name}.log` instead of letting it default to `sys.stderr`.
2. **Show error in `/mcp`** — Store connection errors in `MCPServerInfo`, pass them to `MCPServerSnapshot`, and render them in the `/mcp` command output so users can see the exact failure reason without digging into log files.

## Verification

- MCP-related tests pass (25 passed).
- Manually verified that `/mcp` displays `Error: ...` when a server fails to connect.