### PR TITLE
fix(mcp): prefix mcp tool names with server name to avoid collisions

### DIFF
--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -698,8 +698,9 @@ class MCPTool[T: ClientTransport](CallableTool):
         runtime: Runtime,
         **kwargs: Any,
     ):
+        tool_name = f"{server_name}_{mcp_tool.name}"
         super().__init__(
-            name=mcp_tool.name,
+            name=tool_name,
             description=(
                 f"This is an MCP (Model Context Protocol) tool from MCP server `{server_name}`.\n\n"
                 f"{mcp_tool.description or 'No description provided.'}"

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -712,7 +712,7 @@ class MCPTool[T: ClientTransport](CallableTool):
         self._client = client
         self._runtime = runtime
         self._timeout = timedelta(milliseconds=runtime.config.mcp.client.tool_call_timeout_ms)
-        self._action_name = f"mcp:{mcp_tool.name}"
+        self._action_name = f"mcp:{tool_name}"
 
     async def __call__(self, *args: Any, **kwargs: Any) -> ToolReturnValue:
         description = f"Call MCP tool `{self._mcp_tool.name}`."


### PR DESCRIPTION
Multiple MCP servers exposing tools with the same name (e.g., 'query' from multiple postgres servers) overwrite each other in _tool_dict.\n\nPrefix tool names with the server name so each tool remains unique and accessible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->