### PR TITLE
fix: source uv env during bash install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,16 +4,28 @@ set -euo pipefail
 install_uv() {
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL https://astral.sh/uv/install.sh | sh
+    refresh_uv_env
     return
   fi
 
   if command -v wget >/dev/null 2>&1; then
     wget -qO- https://astral.sh/uv/install.sh | sh
+    refresh_uv_env
     return
   fi
 
   echo "Error: curl or wget is required to install uv." >&2
   exit 1
+}
+
+refresh_uv_env() {
+  local uv_env="${XDG_BIN_HOME:-$HOME/.local/bin}/env"
+  if [ -f "$uv_env" ]; then
+    # shellcheck disable=SC1090
+    . "$uv_env"
+  else
+    export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+  fi
 }
 
 if command -v uv >/dev/null 2>&1; then


### PR DESCRIPTION
﻿## Summary
- source uv's generated env file immediately after the bash installer installs uv
- fall back to adding the uv bin dir to PATH when the env file is absent

Fixes #2272.

## To verify
- `C:\Program Files\Git\bin\bash.exe -n scripts/install.sh`
- smoke-tested `scripts/install.sh` with a fake uv installer where uv is installed outside the initial PATH and then invoked by the same script
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->