### PR TITLE
fix(update): use filter='data' on tarfile.extractall (CVE-2007-4559 / PEP 706)

### DIFF
--- a/src/kimi_cli/ui/shell/update.py
+++ b/src/kimi_cli/ui/shell/update.py
@@ -301,7 +301,7 @@ async def _do_update(*, print: bool, check_only: bool) -> UpdateResult:
             _print("[grey50]Extracting...[/grey50]")
             try:
                 with tarfile.open(tar_path, "r:gz") as tar:
-                    tar.extractall(tmpdir)
+                    tar.extractall(tmpdir, filter="data")
                 binary_path = None
                 for root, _, files in os.walk(tmpdir):
                     if "kimi" in files:


### PR DESCRIPTION
Resolves part of #2273 (the tarfile defense-in-depth piece).

## Change

One-line addition of `filter="data"` to the auto-updater's `tarfile.extractall` call:

```diff
- tar.extractall(tmpdir)
+ tar.extractall(tmpdir, filter="data")  # PEP 706
```

## Why

- Python 3.12 deprecated `extractall()` without an explicit `filter=` argument; Python 3.14 (which `.python-version` pins) emits a `DeprecationWarning`, and a future release will raise.
- `filter="data"` is the [PEP 706](https://peps.python.org/pep-0706/)-recommended default for trusted sources. It silences the deprecation, future-proofs the call, and provides defense-in-depth path-traversal protection (CVE-2007-4559 family).
- Consistent with the existing zip-slip protections at `src/kimi_cli/cli/plugin.py:73-77` and `src/kimi_cli/vis/api/sessions.py:648-657` — the auto-updater was the lone outlier.

## Scope

Strictly the 1-line `filter` addition. The larger SHA-256 / signature manifest piece of #2273 is intentionally **not** in this PR — that needs maintainer alignment on manifest format and is followed up separately in the issue.

## Verification

- File: `src/kimi_cli/ui/shell/update.py:304`
- Code path: only invoked from the bundled-binary auto-updater (`_do_update`), not user-facing tar extraction.
- No behavior change for legitimate tarballs Moonshot publishes; rejects malicious entries that would escape `tmpdir` or set absolute paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->