### PR TITLE
fix(install): source uv env after installing uv (mirrors install.ps1)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,16 +4,25 @@ set -euo pipefail
 install_uv() {
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL https://astral.sh/uv/install.sh | sh
-    return
-  fi
-
-  if command -v wget >/dev/null 2>&1; then
+  elif command -v wget >/dev/null 2>&1; then
     wget -qO- https://astral.sh/uv/install.sh | sh
-    return
+  else
+    echo "Error: curl or wget is required to install uv." >&2
+    exit 1
   fi
 
-  echo "Error: curl or wget is required to install uv." >&2
-  exit 1
+  # The upstream uv installer writes ${XDG_BIN_HOME:-$HOME/.local/bin}/env and
+  # prints "Run 'source ...' to add uv to your PATH" — but it does not source
+  # the file itself. Source it here so the rest of THIS script (and the user's
+  # immediate `kimi` invocation) can find uv on PATH.
+  uv_env="${XDG_BIN_HOME:-$HOME/.local/bin}/env"
+  if [ -f "$uv_env" ]; then
+    # shellcheck disable=SC1090
+    . "$uv_env"
+  else
+    # Fallback for older uv installers that may not write an env script.
+    export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+  fi
 }
 
 if command -v uv >/dev/null 2>&1; then


### PR DESCRIPTION
Resolves #2272.

## Change

Source uv's env script (`${XDG_BIN_HOME:-$HOME/.local/bin}/env`) after the upstream uv installer runs, with a PATH-export fallback for older uv versions. Mirrors what `install.ps1` already does on Windows (refreshes PATH from machine + user env after installing uv).

## Why

The bash installer pipes `https://astral.sh/uv/install.sh` into `sh`. The upstream uv installer puts the binary in `${XDG_BIN_HOME:-$HOME/.local/bin}` and writes shell rc entries for **future** shells — it does NOT export `PATH` in the current shell session, which is why it ends with the message:

> To add $HOME/.local/bin to your PATH, either restart your shell or run:
> source $HOME/.local/bin/env

Two failure modes follow from kimi-cli's installer not sourcing that file:

1. **Hard fail (script aborts).** On systems where `~/.local/bin` is not on the bash subshell's PATH (fresh containers, fresh user accounts), `command -v "$UV_BIN"` returns non-zero right after `install_uv`, and the script exits with `Error: uv not found after installation.`
2. **Soft fail.** When `~/.local/bin` *is* already on PATH, `uv tool install` succeeds but the user's *interactive* shell may not have sourced the env yet, so the next `kimi` invocation returns `command not found`.

The Windows installer doesn't have this bug because it explicitly refreshes the session PATH from machine + user env vars after installing uv. This PR brings install.sh to parity.

## Diff

```diff
 install_uv() {
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL https://astral.sh/uv/install.sh | sh
-    return
-  fi
-
-  if command -v wget >/dev/null 2>&1; then
+  elif command -v wget >/dev/null 2>&1; then
     wget -qO- https://astral.sh/uv/install.sh | sh
-    return
+  else
+    echo "Error: curl or wget is required to install uv." >&2
+    exit 1
   fi

-  echo "Error: curl or wget is required to install uv." >&2
-  exit 1
+  # The upstream uv installer writes ${XDG_BIN_HOME:-$HOME/.local/bin}/env and
+  # prints "Run 'source ...' to add uv to your PATH" — but it does not source
+  # the file itself. Source it here so the rest of THIS script (and the user's
+  # immediate `kimi` invocation) can find uv on PATH.
+  uv_env="${XDG_BIN_HOME:-$HOME/.local/bin}/env"
+  if [ -f "$uv_env" ]; then
+    # shellcheck disable=SC1090
+    . "$uv_env"
+  else
+    # Fallback for older uv installers that may not write an env script.
+    export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+  fi
 }
```

## Verification

- Passes `shellcheck scripts/install.sh` (with the existing `SC1090` disable directive for the dynamic `.` source).
- The control flow change (drop `return` + `if`/`if` → `elif`/`else`) is semantically identical to the original on the curl/wget/no-tool branches: same exit code, same error message.
- `XDG_BIN_HOME` fallback handles non-default uv install dirs.

## Honest scope

I have not run the installer end-to-end on a fresh container myself in this session (would require piping `curl | bash` from an external CDN). The fix is grounded in code reading + the upstream uv installer's documented behavior (the source at `https://releases.astral.sh/installers/uv/latest/uv-installer.sh` shows it writing to `$INFERRED_HOME/.local/bin/env` and editing `~/.profile`). If desired, a follow-up CI smoke test in `debian:stable-slim` would catch this class of bug regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->