### PR TITLE
fix: avoid resending web uploads after restart

### DIFF
--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -503,6 +503,11 @@ class SessionProcess:
         # Mark files as sent
         for file in files:
             self._sent_files.add(file.name)
+        with contextlib.suppress(Exception):
+            sent_marker.write_text(
+                json.dumps(sorted(self._sent_files), ensure_ascii=False),
+                encoding="utf-8",
+            )
 
     async def _handle_in_message(self, message: JSONRPCInMessage) -> str | None:
         """Handle inbound message to worker, encoding uploaded files."""

--- a/tests/web/test_uploaded_files.py
+++ b/tests/web/test_uploaded_files.py
@@ -1,0 +1,37 @@
+"""Tests for web runner upload handling."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from kosong.message import TextPart
+
+from kimi_cli.web.runner import process as process_module
+from kimi_cli.web.runner.process import SessionProcess
+
+
+@pytest.mark.asyncio
+async def test_uploaded_files_marker_survives_process_restart(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_dir = tmp_path / "session"
+    uploads = session_dir / "uploads"
+    uploads.mkdir(parents=True)
+    (uploads / "note.txt").write_text("hello", encoding="utf-8")
+
+    session = SimpleNamespace(kimi_cli_session=SimpleNamespace(dir=session_dir))
+    monkeypatch.setattr(process_module, "load_session_by_id", lambda _session_id: session)
+
+    first_process = SessionProcess(uuid4())
+    first_parts = [part async for part in first_process._encode_uploaded_files()]
+
+    assert any(isinstance(part, TextPart) and "note.txt" in part.text for part in first_parts)
+    assert json.loads((uploads / ".sent").read_text(encoding="utf-8")) == ["note.txt"]
+
+    restarted_process = SessionProcess(uuid4())
+    restarted_parts = [part async for part in restarted_process._encode_uploaded_files()]
+
+    assert restarted_parts == []


### PR DESCRIPTION
﻿## Summary
- persist the web upload `.sent` marker after normal upload encoding
- reuse that marker on a restarted `SessionProcess` so already-sent uploads are not attached to a later text-only prompt
- add a regression test for the process-restart path

Fixes #2279.

## To verify
- `uv run pytest tests\web\test_uploaded_files.py -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run pytest tests\web -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check src\kimi_cli\web\runner\process.py tests\web\test_uploaded_files.py`
- `uv run ruff format --check src\kimi_cli\web\runner\process.py tests\web\test_uploaded_files.py`
- `uv run python -m py_compile src\kimi_cli\web\runner\process.py tests\web\test_uploaded_files.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->