### PR TITLE
fix: avoid Windows console font reset

### DIFF
--- a/packages/kaos/src/kaos/local.py
+++ b/packages/kaos/src/kaos/local.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 from asyncio.subprocess import Process as AsyncioProcess
 from collections.abc import AsyncGenerator
 from pathlib import Path, PurePath
@@ -166,13 +167,23 @@ class LocalKaos:
         if not args:
             raise ValueError("At least one argument (the program to execute) is required.")
 
-        process = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
+        if os.name == "nt":
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+        else:
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
         return self.Process(process)
 
 

--- a/packages/kaos/tests/test_local_kaos.py
+++ b/packages/kaos/tests/test_local_kaos.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 import sys
 from collections.abc import Generator
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -183,6 +184,37 @@ async def test_exec_non_zero_exit(local_kaos: LocalKaos):
 
     exit_code = await process.wait()
     assert exit_code == 7
+
+
+async def test_exec_uses_create_no_window_on_windows(
+    local_kaos: LocalKaos, monkeypatch: pytest.MonkeyPatch
+):
+    captured_kwargs: dict[str, object] = {}
+
+    class DummyProcess:
+        stdin = object()
+        stdout = object()
+        stderr = object()
+        pid = 123
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        def kill(self) -> None:
+            pass
+
+    async def fake_create_subprocess_exec(*args: str, **kwargs: object) -> DummyProcess:
+        captured_kwargs.update(kwargs)
+        return DummyProcess()
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    await local_kaos.exec("cmd.exe", "/c", "echo ok")
+
+    assert captured_kwargs["creationflags"] == subprocess.CREATE_NO_WINDOW
 
 
 async def test_exec_wait_timeout(local_kaos: LocalKaos):


### PR DESCRIPTION
﻿Fixes #2197.

## Summary
- pass `CREATE_NO_WINDOW` when `LocalKaos.exec()` creates subprocesses on Windows
- keep the existing subprocess behavior unchanged on non-Windows platforms
- add a focused regression test that verifies the Windows creation flag is passed

## To verify
- `python -m py_compile packages\\kaos\\src\\kaos\\local.py packages\\kaos\\tests\\test_local_kaos.py`
- `uv run ruff check packages\\kaos\\src\\kaos\\local.py packages\\kaos\\tests\\test_local_kaos.py`
- `uv run pyright packages\\kaos\\src\\kaos\\local.py packages\\kaos\\tests\\test_local_kaos.py`
- `uv run pytest packages\\kaos\\tests\\test_local_kaos.py -q -k "exec_uses_create_no_window_on_windows or exec_runs_command_and_streams" --basetemp .tmp\\pytest -p no:cacheprovider`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->