### PR TITLE
docs(readme): surface install command in Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,25 @@ Kimi Code CLI is an AI agent that runs in the terminal, helping you complete sof
 
 ## Getting Started
 
-See [Getting Started](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html) for how to install and start using Kimi Code CLI.
+Install Kimi Code CLI:
+
+```sh
+# Linux / macOS
+curl -LsSf https://code.kimi.com/install.sh | bash
+```
+
+```powershell
+# Windows (PowerShell)
+Invoke-RestMethod https://code.kimi.com/install.ps1 | Invoke-Expression
+```
+
+If you already have [uv](https://docs.astral.sh/uv/) installed:
+
+```sh
+uv tool install --python 3.13 kimi-cli
+```
+
+Then run `kimi` in your terminal. For login setup, ACP / VS Code integration, and other installation options, see the [full Getting Started guide](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html).
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

The current `## Getting Started` section of the README contains no install command, only an inline link to the docs page. A first-time visitor has to click through and scroll past the "What is Kimi Code CLI" intro to reach the actual `curl ... | bash` command — two redirects + one scroll for a single install.

This PR surfaces the canonical install commands (Linux/macOS, Windows, and the `uv tool install` alternative) directly in the README, pulled verbatim from `docs/en/guides/getting-started.md` so the README stays in sync with the docs as the single source of truth. The link to the full guide remains for login setup, ACP / VS Code integration, and the rest.

## Test plan

- [x] `make format` is a no-op on a docs-only change.
- [x] Rendered the new section in GitHub's markdown preview locally.
- [x] Install commands match `docs/en/guides/getting-started.md` line-for-line — no invented commands.

Fixes #2271
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->