### PR TITLE
docs(readme): add Prerequisites subsection to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ See more features in the [Documentation](https://moonshotai.github.io/kimi-cli/e
 
 ## Development
 
+### Prerequisites
+
+- **[uv](https://docs.astral.sh/uv/getting-started/installation/)** — Python package and venv manager used by `make prepare` and the test/run targets.
+- **Python** — pinned by `.python-version` and installed by `uv sync` if missing. `pyproject.toml` accepts Python 3.12+; CI uses the pinned version.
+- **make** — runs the build/test/check targets in `Makefile`. Pre-installed on most Linux/macOS systems; on Windows, install via WSL, MSYS2, or chocolatey.
+- **Node.js + npm** — required for `make build-web` and `make build` (which embeds the web UI). Not needed for Python-only changes.
+- **Git Bash (Windows only)** — kimi-cli's Shell tool requires `bash.exe` from [Git for Windows](https://git-scm.com/download/win); without it, the agent's Shell tool will not start.
+- **Nix (optional)** — a `flake.nix` is provided. `nix develop` drops you into a shell with the above installed.
+
+### Setup
+
 To develop Kimi Code CLI, run:
 
 ```sh


### PR DESCRIPTION
## Summary

The `## Development` section opens with `make prepare`, but neither the README nor `CONTRIBUTING.md` lists the tools a contributor needs installed first. New contributors hit one of:

- `make: command not found` (Windows without WSL / build-tools)
- `uv: command not found` (no link in the Development section)
- `make build-web` failing because Node.js / npm isn't installed
- on Windows, the agent's Shell tool refuses to start because Git Bash isn't installed (`src/kimi_cli/utils/environment.py`'s `GitBashNotFoundError`)
- confusion over the `.python-version` pin vs. `pyproject.toml`'s `>=3.12`

This PR adds a `### Prerequisites` subsection at the top of `## Development` that lists each tool with a one-line install pointer. The existing `make prepare` line moves under a `### Setup` heading directly below.

I deliberately did **not** hardcode the Python version into the README — the wording points to `.python-version` and `pyproject.toml` so the prerequisite list won't rot when the pin moves.

## Test plan

- [x] `make format` is a no-op on a docs-only change.
- [x] Rendered in GitHub markdown preview locally — anchor links and bullet hierarchy render correctly.
- [x] Verified `.python-version` says `3.14` and `pyproject.toml` says `requires-python = ">=3.12"` — the README wording is consistent with both.
- [x] Verified `src/kimi_cli/utils/environment.py` does raise `GitBashNotFoundError` on Windows — the Git Bash bullet reflects real behavior, not folklore.

Fixes #2274
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->