### PR TITLE
fix(install.sh): source uv env script after upstream installer

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,16 +4,28 @@ set -euo pipefail
 install_uv() {
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL https://astral.sh/uv/install.sh | sh
-    return
-  fi
-
-  if command -v wget >/dev/null 2>&1; then
+  elif command -v wget >/dev/null 2>&1; then
     wget -qO- https://astral.sh/uv/install.sh | sh
-    return
+  else
+    echo "Error: curl or wget is required to install uv." >&2
+    exit 1
   fi
 
-  echo "Error: curl or wget is required to install uv." >&2
-  exit 1
+  # The upstream uv installer writes an env script at
+  # ${XDG_BIN_HOME:-$HOME/.local/bin}/env and edits shell rc files for
+  # future sessions, but does not modify PATH in the running shell.
+  # Without sourcing it, the `command -v uv` check below fails on systems
+  # where ~/.local/bin is not already on PATH (fresh containers, fresh
+  # user accounts), and the script aborts with "uv not found after
+  # installation". Source it so the rest of THIS script can find uv.
+  local uv_env="${XDG_BIN_HOME:-$HOME/.local/bin}/env"
+  if [ -f "$uv_env" ]; then
+    # shellcheck disable=SC1090
+    . "$uv_env"
+  else
+    # Fallback for older uv installers that don't write an env script.
+    export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+  fi
 }
 
 if command -v uv >/dev/null 2>&1; then
@@ -29,3 +41,13 @@ if ! command -v "$UV_BIN" >/dev/null 2>&1; then
 fi
 
 "$UV_BIN" tool install --python 3.13 kimi-cli
+
+# uv installs `kimi` into ${XDG_BIN_HOME:-$HOME/.local/bin}. If that directory
+# is not on the user's interactive-shell PATH yet, `kimi` will appear missing
+# until they restart their shell or source the env script. Print the hint so
+# they don't conclude the install silently failed.
+kimi_bin_dir="${XDG_BIN_HOME:-$HOME/.local/bin}"
+echo
+echo "Installed kimi to $kimi_bin_dir/kimi."
+echo "If 'kimi' is not found, restart your shell, or run:"
+echo "    . \"$kimi_bin_dir/env\""


### PR DESCRIPTION
## Summary

`scripts/install.sh` pipes `https://astral.sh/uv/install.sh` into `sh`, which writes the `uv` binary to `${XDG_BIN_HOME:-$HOME/.local/bin}` and an env script alongside it, then edits shell rc files for future sessions. It does **not** export `PATH` in the running shell — that's why upstream prints "Run 'source ...' to add uv to your PATH" at the end.

The current install.sh then immediately runs `command -v uv`. On systems where `~/.local/bin` is not already on the subshell's PATH (fresh container images, fresh user accounts, minimal distros), this check fails and the script aborts with `Error: uv not found after installation.` — even though uv was installed correctly. `scripts/install.ps1` already handles this on Windows by refreshing the session PATH.

This PR brings install.sh to parity by sourcing the env script uv just wrote, with a fallback to prepending `~/.local/bin` to PATH for older uv installers that may not write one. It also adds a closing hint pointing the user at the env file in case their next interactive shell can't find `kimi` yet — addressing the secondary "soft failure" mode where install completes but `kimi --version` returns `command not found`.

## Test plan

- [x] `bash -n scripts/install.sh` — syntax OK.
- [x] `shellcheck scripts/install.sh` — clean.
- [x] Verified upstream uv installer writes to `${XDG_BIN_HOME:-$HOME/.local/bin}/env` (source: https://releases.astral.sh/installers/uv/latest/uv-installer.sh).
- [ ] CI smoke test in `debian:stable-slim` / `alpine` would deterministically prove the fix; happy to add it in a follow-up PR if the team wants one.

## Caveats

I did not execute the full installer end-to-end on this machine (uv is already installed, so the `install_uv` branch wouldn't fire). The fix is structurally identical to the working logic in `install.ps1` and mirrors what every "curl | sh" installer of this shape does (rustup's `~/.cargo/env`, nvm's source line, etc.).

Fixes #2272
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->