### PR TITLE
fix(update): set filter="data" on tarfile.extractall in auto-updater

### DIFF
--- a/src/kimi_cli/ui/shell/update.py
+++ b/src/kimi_cli/ui/shell/update.py
@@ -301,7 +301,7 @@ async def _do_update(*, print: bool, check_only: bool) -> UpdateResult:
             _print("[grey50]Extracting...[/grey50]")
             try:
                 with tarfile.open(tar_path, "r:gz") as tar:
-                    tar.extractall(tmpdir)
+                    tar.extractall(tmpdir, filter="data")  # PEP 706
                 binary_path = None
                 for root, _, files in os.walk(tmpdir):
                     if "kimi" in files:


### PR DESCRIPTION
## Summary

Partial fix for #2273 — addresses the third sub-item (defense-in-depth on the extractor) without touching the sha256-manifest piece, which needs a CDN-side change to publish `.sha256` sidecars and is best handled by the maintainers.

`src/kimi_cli/ui/shell/update.py` extracted the downloaded update tarball with bare `tar.extractall(tmpdir)`. PEP 706 deprecated this call shape: Python 3.12 emits `DeprecationWarning` and a future release will raise. `filter="data"` is the recommended default — it rejects absolute paths, parent-traversal members, device nodes, setuid bits, and symlinks pointing outside the extraction tree, which is exactly the right default for an auto-updater that goes on to `chmod +x` the extracted file.

The codebase's other two archive-extraction sites (`cli/plugin.py:77` and `vis/api/sessions.py:657`) already have explicit path-traversal checks before `extractall`; the auto-updater was the lone outlier. This brings it in line.

## What this PR does NOT cover

The other two items in #2273 (sha256 manifest verification, optional signature verification) require publishing a `.sha256` sidecar (or `manifest.json`) alongside each `kimi-{version}-{target}.tar.gz` on `cdn.kimi.com`. That's a CDN/release-pipeline change, not a code-only one — I'd rather leave it to a follow-up where the publishing side and the verifying side can land together. Happy to send that follow-up PR once the team confirms the manifest format and CDN path.

## Test plan

- [x] One-line code change, no behavior change on well-formed tarballs (the canonical kimi-cli release artifacts are flat archives of a `kimi` binary, which `filter="data"` does not modify).
- [x] `filter="data"` is the safest of the three PEP 706 filters and the documented recommendation for untrusted sources.
- [x] `grep -rn "extractall" src/` confirms this was the only unfiltered site.

Refs #2273
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->