### PR TITLE
fix(shell): hide context usage until warning threshold

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -884,6 +884,7 @@ _RUNNING_REFRESH_INTERVAL = 0.1
 _GIT_BRANCH_TTL = 5.0
 _GIT_STATUS_TTL = 15.0
 _TIP_ROTATE_INTERVAL = 30.0
+_CONTEXT_USAGE_WARNING_THRESHOLD = 0.80
 _MAX_CWD_COLS = 30
 _MAX_BRANCH_COLS = 22
 
@@ -2204,7 +2205,7 @@ class CustomPromptSession:
         if tip_text and _display_width(tip_text) <= remaining:
             fragments.append((tc.tip, tip_text))
 
-        # ── line 2: toast (left) + context (right) — always rendered ──────
+        # ── line 2: toast (left) + optional warning/status text (right) ──────
         fragments.append(("", "\n"))
 
         right_text = self._render_right_span(status)
@@ -2224,8 +2225,9 @@ class CustomPromptSession:
         else:
             left_width = 0
 
-        fragments.append(("", " " * max(0, columns - left_width - right_width)))
-        fragments.append(("", right_text))
+        if right_text:
+            fragments.append(("", " " * max(0, columns - left_width - right_width)))
+            fragments.append(("", right_text))
 
         return FormattedText(fragments)
 
@@ -2250,10 +2252,12 @@ class CustomPromptSession:
     @staticmethod
     def _render_right_span(status: StatusSnapshot) -> str:
         current_toast = _current_toast("right")
-        if current_toast is None:
-            return format_context_status(
-                status.context_usage,
-                status.context_tokens,
-                status.max_context_tokens,
-            )
-        return current_toast.message
+        if current_toast is not None:
+            return current_toast.message
+        if status.context_usage < _CONTEXT_USAGE_WARNING_THRESHOLD:
+            return ""
+        return format_context_status(
+            status.context_usage,
+            status.context_tokens,
+            status.max_context_tokens,
+        )

--- a/tests/ui_and_conv/test_prompt_tips.py
+++ b/tests/ui_and_conv/test_prompt_tips.py
@@ -434,12 +434,30 @@ def test_mode_drops_model_name_and_dot_on_very_narrow_terminal(monkeypatch: Any)
 # ── Line 2 structural correctness ─────────────────────────────────────────────
 
 
-def test_toolbar_line2_context_appears_on_line2_not_line1(monkeypatch: Any) -> None:
+def test_toolbar_line2_hides_context_below_warning_threshold(monkeypatch: Any) -> None:
     prompt_session = _make_toolbar_session(tips=[])
+    prompt_session._status_provider = lambda: StatusSnapshot(
+        context_usage=0.42,
+        context_tokens=3_000,
+        max_context_tokens=10_000,
+    )
     lines = _render_toolbar_lines(prompt_session, 80, monkeypatch)
 
-    assert "context: 0.0%" in lines[2]
-    assert "context: 0.0%" not in lines[1]
+    assert "context:" not in lines[2]
+    assert "context:" not in lines[1]
+
+
+def test_toolbar_line2_context_appears_at_warning_threshold(monkeypatch: Any) -> None:
+    prompt_session = _make_toolbar_session(tips=[])
+    prompt_session._status_provider = lambda: StatusSnapshot(
+        context_usage=0.80,
+        context_tokens=8_000,
+        max_context_tokens=10_000,
+    )
+    lines = _render_toolbar_lines(prompt_session, 80, monkeypatch)
+
+    assert "context: 80.0% (8k/10k)" in lines[2]
+    assert "context: 80.0% (8k/10k)" not in lines[1]
 
 
 def test_toolbar_line2_left_toast_appears_on_line2_not_line1(monkeypatch: Any) -> None:
@@ -619,7 +637,7 @@ def test_running_prompt_uses_shared_toolbar_and_separator_layout(monkeypatch: An
     rendered_toolbar = prompt_session._render_bottom_toolbar()
     plain_toolbar = "".join(fragment[1] for fragment in rendered_toolbar)
     assert "tip" in plain_toolbar
-    assert "context: 0.0%" in plain_toolbar
+    assert "context:" not in plain_toolbar
 
 
 def test_modal_prompt_hides_normal_separator_and_prompt_label(monkeypatch) -> None:


### PR DESCRIPTION
## Related Issue

Resolve #2291

## Description

- Stop rendering the shell bottom toolbar context usage meter while usage is below the warning threshold.
- Keep the context meter visible once usage reaches 80%, where the user may need to act.
- Preserve right-side toast behavior so transient status messages still appear in the same toolbar area.

## Verification

- RED: `uv run pytest tests/ui_and_conv/test_prompt_tips.py -k "context or running_prompt_uses_shared_toolbar" -vv` failed before the implementation because low context usage was still rendered.
- GREEN: `uv run pytest tests/ui_and_conv/test_prompt_tips.py -k "context or running_prompt_uses_shared_toolbar" -vv`
- `uv run pytest tests/ui_and_conv/test_prompt_tips.py tests/core/test_status_formatting.py -vv`
- `uv run ruff check src/kimi_cli/ui/shell/prompt.py tests/ui_and_conv/test_prompt_tips.py`
- `uv run ruff format --check src/kimi_cli/ui/shell/prompt.py tests/ui_and_conv/test_prompt_tips.py`
- `uv run pyright src/kimi_cli/ui/shell/prompt.py tests/ui_and_conv/test_prompt_tips.py`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog. (N/A: small UI behavior fix; no user docs/changelog generated.)
- [ ] I have run `make gen-docs` to update the user documentation. (N/A: no docs generation needed.)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->