### PR TITLE
fix(hook): fix UserPromptSubmit payload to capture input text instead of empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Core: Fix `UserPromptSubmit` hook receiving empty prompt text for non-string user input — content part lists (images, attachments) now have their text extracted via `Message.extract_text` instead of being replaced with `""`
+
 ## 1.44.0 (2026-05-13)
 
 - Shell: Add slash command alias resolution — aliases such as `/h`, `?`, and `status` now resolve to their canonical commands (`/help`, `/usage`); the completer and help output display alias matches as `/name (alias)` for clarity

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Core: Fix `UserPromptSubmit` hook receiving empty prompt text for non-string user input — content part lists (images, attachments) now have their text extracted via `Message.extract_text` instead of being replaced with `""`
+
 ## 1.44.0 (2026-05-13)
 
 - Shell: Add slash command alias resolution — aliases such as `/h`, `?`, and `status` now resolve to their canonical commands (`/help`, `/usage`); the completer and help output display alias matches as `/name (alias)` for clarity

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- Core：修复 `UserPromptSubmit` hook 在用户输入为非字符串内容时收到空 prompt 文本的问题——包含图片、附件等 ContentPart 列表的输入现在通过 `Message.extract_text` 提取可读文本，而非被替换为空字符串
+
 ## 1.44.0 (2026-05-13)
 
 - Shell：新增斜杠命令别名解析——别名（如 `/h`、`?`、`status`）现在能正确解析到对应的正式命令（`/help`、`/usage`）；补全器和帮助输出会将别名匹配项显示为 `/name (alias)`，方便识别

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -605,7 +605,11 @@ class KimiSoul:
             # they are not user input, and a user-configured prompt-blocking
             # hook would drop the notification and hang the wait loop.
             if not skip_user_prompt_hook:
-                text_input_for_hook = user_input if isinstance(user_input, str) else ""
+                if isinstance(user_input, str):
+                    text_input_for_hook = user_input
+                else:
+                    user_message = Message(role="user", content=user_input)
+                    text_input_for_hook = user_message.extract_text(" ").strip()
 
                 hook_results = await self._hook_engine.trigger(
                     "UserPromptSubmit",

--- a/tests/core/test_kimisoul_hooks.py
+++ b/tests/core/test_kimisoul_hooks.py
@@ -1,0 +1,50 @@
+"""Tests for KimiSoul lifecycle hook integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+import kimi_cli.soul.kimisoul as kimisoul_module
+from kosong.tooling.empty import EmptyToolset
+
+from kimi_cli.hooks.config import HookDef
+from kimi_cli.hooks.engine import HookEngine
+from kimi_cli.soul.agent import Agent, Runtime
+from kimi_cli.soul.context import Context
+from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.wire.types import TextPart
+
+
+@pytest.mark.asyncio
+async def test_user_prompt_submit_extracts_text_from_content_parts(
+    runtime: Runtime, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """UserPromptSubmit hook receives extracted text when input is list[ContentPart]."""
+    captured_payloads: list[dict] = []
+
+    async def _capture_trigger(event: str, *, matcher_value: str = "", input_data: dict | None = None) -> list:
+        captured_payloads.append(input_data or {})
+        return []
+
+    agent = Agent(
+        name="Test Agent",
+        system_prompt="Test system prompt.",
+        toolset=EmptyToolset(),
+        runtime=runtime,
+    )
+    soul = KimiSoul(agent, context=Context(file_backend=tmp_path / "history.jsonl"))
+    soul._turn = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monkeypatch.setattr(kimisoul_module, "wire_send", lambda _msg: None)
+
+    hook_engine = HookEngine([HookDef(event="UserPromptSubmit", command="echo ok", timeout=5)])
+    monkeypatch.setattr(hook_engine, "trigger", _capture_trigger)
+    soul.set_hook_engine(hook_engine)
+
+    await soul.run([TextPart(text="hello world")])
+
+    user_prompt_payloads = [p for p in captured_payloads if p.get("hook_event_name") == "UserPromptSubmit"]
+    assert len(user_prompt_payloads) == 1
+    assert user_prompt_payloads[0].get("prompt") == "hello world"


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #2303 #1779

## Description

<!-- Please describe your changes in detail. -->

Fixes the `UserPromptSubmit` hook payload so that the `prompt` field contains the actual user input text instead of an empty string.

**Problem:**
The shell UI passes user input as `list[ContentPart]` to `soul.run()`. The existing code only checked `isinstance(user_input, str)`, causing `text_input_for_hook` to always fall back to `""`. As a result:
- The `prompt` field in the `UserPromptSubmit` hook payload was always empty.
- Regex-based `matcher` filters on prompt text never matched.

**Fix:**
When `user_input` is not a string, extract the text from the `ContentPart` list using the same `Message.extract_text()` approach already used by the agent turn loop:

```python
if isinstance(user_input, str):
    text_input_for_hook = user_input
else:
    user_message = Message(role="user", content=user_input)
    text_input_for_hook = user_message.extract_text(" ").strip()
```

This ensures plain-text input (and any text extractable from multimodal input) is correctly passed to the hook engine for both payload generation and matcher evaluation. As a result, the payload.prompt can contain the message sent by the user (or adjusted message when SubagentStart is called).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.