### PR TITLE
fix(web): handle BrokenPipeError in SessionProcess.send_message

### DIFF
--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -661,8 +661,30 @@ class SessionProcess:
             logger.error(f"{e.__class__.__name__} {e}: Invalid JSONRPC in message: {message}")
             return
 
-        process.stdin.write((message + "\n").encode("utf-8"))
-        await process.stdin.drain()
+        try:
+            process.stdin.write((message + "\n").encode("utf-8"))
+            await process.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError) as e:
+            # Subprocess died between our `start()` check above and the actual write.
+            # `_read_loop` will eventually observe the exit and emit "stopped" /
+            # "crashed", but right now the caller (FastAPI / websocket handler) would
+            # otherwise see a raw exception propagate to the response. Emit an error
+            # status so any attached websocket clients see the failure synchronously.
+            #
+            # If this was a prompt, its id was already registered in
+            # `_in_flight_prompt_ids` above; drop it so the failed turn doesn't
+            # leave the session wedged in `is_busy` forever.
+            if isinstance(in_message, JSONRPCPromptMessage):
+                self._in_flight_prompt_ids.discard(in_message.id)
+            logger.warning(
+                f"send_message: subprocess stdin {e.__class__.__name__}; "
+                f"process likely exited (returncode={process.returncode})"
+            )
+            await self._emit_status(
+                "error",
+                reason="stdin_broken",
+                detail=f"{e.__class__.__name__}: {e}",
+            )
 
 
 class KimiCLIRunner:

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -162,3 +162,52 @@ def test_session_in_error_state_clears_stale_ids_on_new_prompt() -> None:
         sp.clear_in_flight()
 
     assert sp.is_busy is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: send_message broken stdin clears in-flight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_message_broken_pipe_clears_in_flight() -> None:
+    """A BrokenPipeError while writing a prompt to stdin must drop the prompt's
+    in-flight id, so the failed turn doesn't leave the session stuck in 'busy'.
+    """
+    sp = SessionProcess(uuid4())
+
+    # Don't spawn a real subprocess.
+    async def noop_start() -> None:
+        return None
+
+    sp.start = noop_start  # type: ignore[assignment]
+
+    # stdin whose drain() reports the worker is gone.
+    async def broken_drain() -> None:
+        raise BrokenPipeError("worker gone")
+
+    mock_stdin = MagicMock()
+    mock_stdin.drain = broken_drain
+
+    mock_process = MagicMock()
+    mock_process.stdin = mock_stdin
+    mock_process.returncode = 1
+    sp._process = mock_process
+
+    # Keep the message untouched and broadcasts inert.
+    async def passthrough_handle(in_message: object) -> None:
+        return None
+
+    async def noop_broadcast(msg: str) -> None:
+        return None
+
+    sp._handle_in_message = passthrough_handle  # type: ignore[assignment]
+    sp._broadcast = noop_broadcast  # type: ignore[assignment]
+
+    prompt = '{"jsonrpc":"2.0","method":"prompt","id":"p1","params":{"user_input":"hi"}}'
+    await sp.send_message(prompt)
+
+    assert "p1" not in sp._in_flight_prompt_ids
+    assert sp.is_busy is False
+    assert sp.status.state == "error"
+    assert sp.status.reason == "stdin_broken"


### PR DESCRIPTION
## What does this PR do?

`SessionProcess.send_message` in `src/kimi_cli/web/runner/process.py` writes to `process.stdin` and awaits `drain()` without guarding against the subprocess having exited between the `start()` call at the top of the method and the actual write at the bottom:

```python
process.stdin.write((message + "\n").encode("utf-8"))
await process.stdin.drain()
```

In a normal lifecycle `_read_loop` observes the exit and emits a `"stopped"` / `"crashed"` status. But there is a window — subprocess crashes, hits OOM, or is killed by an external signal — where `send_message()` reaches the write before `_read_loop` runs. The result is a raw `BrokenPipeError` (or `ConnectionResetError` on some platforms) propagating up to the FastAPI / websocket handler, surfacing as a 500 to the client with no `error` status emitted to any attached websocket subscribers.

## Fix

Wrap the write + drain pair in a try/except for `BrokenPipeError` and `ConnectionResetError`, log a warning with `process.returncode`, and emit an `"error"` status with `reason="stdin_broken"` so subscribers see the failure synchronously — instead of waiting on `_read_loop` to eventually emit a different terminal status.

No behavior change on the happy path. 14-line addition inside the existing function.

## Repro

In a long-running web session, manually `kill -9` the subprocess (or trigger an OOM in it) and immediately send a message. Without this PR, the next `send_message()` call raises and the websocket clients see only `_read_loop`'s eventual status; the API call itself crashes with a 500.

## Test plan
- [x] `python3.11 -c "import ast; ast.parse(open('.../process.py').read())"` — passes
- [x] Manual code review for happy-path equivalence — the original two-line write/drain is preserved unchanged inside the `try`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->