### PR TITLE
fix(web): open archived sessions from sidebar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,8 +96,10 @@ function App() {
   } = sessionsHook;
 
   const currentSession = useMemo(
-    () => sessions.find((session) => session.sessionId === selectedSessionId),
-    [sessions, selectedSessionId],
+    () =>
+      sessions.find((session) => session.sessionId === selectedSessionId) ??
+      archivedSessions.find((session) => session.sessionId === selectedSessionId),
+    [sessions, archivedSessions, selectedSessionId],
   );
 
   const [streamStatus, setStreamStatus] = useState<ChatStatus>("ready");
@@ -226,23 +228,32 @@ function App() {
 
   // Validate session exists once session list loads, clear URL if not found
   useEffect(() => {
-    if (sessions.length === 0 || !selectedSessionId) {
+    if ((sessions.length === 0 && archivedSessions.length === 0) || !selectedSessionId) {
       return;
     }
 
-    if (searchQuery.trim() || hasMoreSessions) {
+    if (searchQuery.trim() || hasMoreSessions || hasMoreArchivedSessions || isLoadingArchived) {
       return;
     }
 
-    const sessionExists = sessions.some(
-      (s) => s.sessionId === selectedSessionId,
-    );
+    const sessionExists =
+      sessions.some((s) => s.sessionId === selectedSessionId) ||
+      archivedSessions.some((s) => s.sessionId === selectedSessionId);
     if (!sessionExists) {
       console.log("[App] Session from URL not found, clearing selection");
       updateUrlWithSession(null);
       selectSession("");
     }
-  }, [sessions, selectedSessionId, selectSession, hasMoreSessions, searchQuery]);
+  }, [
+    sessions,
+    archivedSessions,
+    selectedSessionId,
+    selectSession,
+    hasMoreSessions,
+    hasMoreArchivedSessions,
+    isLoadingArchived,
+    searchQuery,
+  ]);
 
   // Update URL when selected session changes
   useEffect(() => {


### PR DESCRIPTION
﻿## Summary
- let archived sessions resolve as the current session when selected
- keep the URL/session validator from clearing a selected archived session
- wait for archived-session pagination/loading before deciding a selected session is missing

Fixes #2312

## To verify
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->