### PR TITLE
fix(kosong): sanitize surrogates before Kimi requests

### DIFF
--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -157,7 +157,9 @@ class Kimi:
     ) -> "KimiStreamedMessage":
         messages: list[ChatCompletionMessageParam] = []
         if system_prompt:
-            messages.append({"role": "system", "content": system_prompt})
+            messages.append(
+                {"role": "system", "content": _sanitize_surrogate_strings(system_prompt)}
+            )
         messages.extend(_convert_message(message) for message in history)
 
         generation_kwargs: dict[str, Any] = {
@@ -329,7 +331,20 @@ def _convert_message(message: Message) -> ChatCompletionMessageParam:
         dumped_message.pop("content", None)
     if reasoning_content:
         dumped_message["reasoning_content"] = reasoning_content
-    return cast(ChatCompletionMessageParam, dumped_message)
+    return cast(ChatCompletionMessageParam, _sanitize_surrogate_strings(dumped_message))
+
+
+def _sanitize_surrogate_strings(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")
+    if isinstance(value, list):
+        return [_sanitize_surrogate_strings(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            _sanitize_surrogate_strings(key): _sanitize_surrogate_strings(item)
+            for key, item in value.items()
+        }
+    return value
 
 
 def _is_effectively_empty_content_parts(content: Sequence[ContentPart]) -> bool:

--- a/packages/kosong/tests/test_chat_provider.py
+++ b/packages/kosong/tests/test_chat_provider.py
@@ -1,4 +1,7 @@
 import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, cast
 
 from kosong.chat_provider import APIStatusError, StreamedMessagePart
 from kosong.chat_provider.chaos import ChaosChatProvider, ChaosConfig
@@ -41,3 +44,32 @@ async def test_chaos_chat_provider():
             raise AssertionError("Expected APIStatusError")
         except APIStatusError:
             pass
+
+
+async def test_kimi_sanitizes_surrogates_before_request():
+    class FakeCompletions:
+        def __init__(self) -> None:
+            self.kwargs: dict[str, Any] = {}
+
+        async def create(self, **kwargs: Any) -> Any:
+            request = dict(kwargs)
+            request["tools"] = list(request["tools"])
+            json.dumps(request, ensure_ascii=False).encode("utf-8")
+            self.kwargs = request
+            return SimpleNamespace()
+
+    completions = FakeCompletions()
+    chat_provider = Kimi(model="dummy", api_key="sk-1234567890")
+    chat_provider.client = cast(
+        Any, SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    )
+
+    await chat_provider.generate(
+        system_prompt="system\udca9",
+        tools=[],
+        history=[Message(role="user", content=[TextPart(text="hello\udca9")])],
+    )
+
+    messages = completions.kwargs["messages"]
+    assert "\ufffd" in messages[0]["content"]
+    assert "\ufffd" in messages[1]["content"]


### PR DESCRIPTION
## Summary
- sanitize lone UTF-16 surrogate code units before sending Kimi chat-completion requests
- cover system prompts and converted message payloads, including history text and tool-call arguments
- add a regression test that JSON-encodes the outgoing request with `ensure_ascii=False`

Fixes #2320

## To verify
- `uv run pytest packages/kosong/tests/test_chat_provider.py -q -p no:cacheprovider`
- `uv run --package kosong --group dev pytest packages/kosong/tests -q -p no:cacheprovider`
- `uv run --package kosong --group dev ruff check packages\kosong\src\kosong\chat_provider\kimi.py packages\kosong\tests\test_chat_provider.py`
- `uv run --package kosong --group dev pyright packages\kosong\src\kosong\chat_provider\kimi.py packages\kosong\tests\test_chat_provider.py`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->