### PR TITLE
fix: tolerate non-utf8 worker output

### DIFF
--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -336,11 +336,12 @@ class SessionProcess:
                     else:
                         continue
 
-                await self._broadcast(_decode_worker_output(line).rstrip("\n"))
+                decoded_line = _decode_worker_output(line)
+                await self._broadcast(decoded_line.rstrip("\n"))
 
                 # Handle out message
                 try:
-                    msg = json.loads(line)
+                    msg = json.loads(decoded_line)
                     match msg.get("method"):
                         case "event":
                             msg["params"] = deserialize_wire_message(msg["params"])
@@ -360,7 +361,7 @@ class SessionProcess:
                                     JSONRPCSuccessResponse.model_validate(msg)
                                 )
                 except json.JSONDecodeError:
-                    logger.error(f"Invalid JSONRPC out message: {line}")
+                    logger.error(f"Invalid JSONRPC out message: {decoded_line}")
 
         except asyncio.CancelledError:
             raise

--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -51,6 +51,10 @@ from kimi_cli.wire.serde import deserialize_wire_message
 JSONRPCOutMessageAdapter = TypeAdapter[JSONRPCOutMessage](JSONRPCOutMessage)
 
 
+def _decode_worker_output(data: bytes) -> str:
+    return data.decode("utf-8", errors="replace")
+
+
 class SessionProcess:
     """Manages a single session's KimiCLI subprocess.
 
@@ -306,6 +310,7 @@ class SessionProcess:
                         stderr = await self._process.stderr.read()
                         if not stderr:
                             stderr = b"No stderr"
+                        stderr_text = _decode_worker_output(stderr)
                         # Clear in-flight IDs before broadcasting so that
                         # is_busy is already False when the frontend reacts
                         # to the error and sends a new prompt.
@@ -315,24 +320,23 @@ class SessionProcess:
                                 id=str(uuid4()),
                                 error=JSONRPCErrorObject(
                                     code=self._process.returncode or -1,
-                                    message=stderr.decode("utf-8"),
+                                    message=stderr_text,
                                 ),
                             ).model_dump_json()
                         )
                         logger.warning(
-                            f"Process exited with {self._process.returncode}: "
-                            f"{stderr.decode('utf-8')}"
+                            f"Process exited with {self._process.returncode}: {stderr_text}"
                         )
                         await self._emit_status(
                             "error",
                             reason="process_exit",
-                            detail=stderr.decode("utf-8"),
+                            detail=stderr_text,
                         )
                         break
                     else:
                         continue
 
-                await self._broadcast(line.decode("utf-8").rstrip("\n"))
+                await self._broadcast(_decode_worker_output(line).rstrip("\n"))
 
                 # Handle out message
                 try:

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -162,6 +162,37 @@ async def test_read_loop_eof_handles_non_utf8_stderr() -> None:
     assert sp.status.detail == "windows dash: �"
 
 
+@pytest.mark.asyncio
+async def test_read_loop_skips_non_utf8_stdout_without_error_state() -> None:
+    sp = SessionProcess(uuid4())
+    messages: list[str] = []
+
+    async def capture_broadcast(msg: str) -> None:
+        messages.append(msg)
+
+    sp._broadcast = capture_broadcast  # type: ignore[assignment]
+
+    mock_stdout = asyncio.StreamReader()
+    mock_stdout.feed_data(b"worker progress: \x97\n")
+    mock_stdout.feed_eof()
+
+    mock_stderr = asyncio.StreamReader()
+    mock_stderr.feed_eof()
+
+    mock_process = MagicMock()
+    mock_process.stdout = mock_stdout
+    mock_process.stderr = mock_stderr
+    mock_process.returncode = 0
+
+    sp._process = mock_process
+    sp._expecting_exit = True
+
+    await sp._read_loop()
+
+    assert messages == ["worker progress: �"]
+    assert sp.status.state == "stopped"
+
+
 # ---------------------------------------------------------------------------
 # Tests: error state allows recovery with new prompt
 # ---------------------------------------------------------------------------

--- a/tests/web/test_session_error_recovery.py
+++ b/tests/web/test_session_error_recovery.py
@@ -129,6 +129,39 @@ async def test_read_loop_eof_clears_in_flight_before_broadcast() -> None:
     assert sp.status.state == "error"
 
 
+@pytest.mark.asyncio
+async def test_read_loop_eof_handles_non_utf8_stderr() -> None:
+    sp = SessionProcess(uuid4())
+    messages: list[str] = []
+
+    async def capture_broadcast(msg: str) -> None:
+        messages.append(msg)
+
+    sp._broadcast = capture_broadcast  # type: ignore[assignment]
+
+    mock_stdout = asyncio.StreamReader()
+    mock_stdout.feed_eof()
+
+    mock_stderr = asyncio.StreamReader()
+    mock_stderr.feed_data(b"windows dash: \x97")
+    mock_stderr.feed_eof()
+
+    mock_process = MagicMock()
+    mock_process.stdout = mock_stdout
+    mock_process.stderr = mock_stderr
+    mock_process.returncode = 1
+
+    sp._process = mock_process
+    sp._expecting_exit = False
+
+    await sp._read_loop()
+
+    assert messages
+    assert "windows dash: �" in messages[0]
+    assert sp.status.reason == "process_exit"
+    assert sp.status.detail == "windows dash: �"
+
+
 # ---------------------------------------------------------------------------
 # Tests: error state allows recovery with new prompt
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

Fixes #2313.

The web session runner decoded worker stdout and crash stderr with strict UTF-8. On Windows, child processes can still emit locale-encoded bytes such as cp1252 smart punctuation. A single invalid byte then hides the real worker failure behind a UnicodeDecodeError.

This change decodes worker output with replacement characters at the process boundary, matching the existing uploaded text-file behavior. Wire JSON is still parsed after decoding, but the runner no longer crashes while trying to report a worker error.

## To verify

- `uv run pytest tests\web\test_session_error_recovery.py -q`
- `uv run ruff check src\kimi_cli\web\runner\process.py tests\web\test_session_error_recovery.py`
- `python -m py_compile src\kimi_cli\web\runner\process.py tests\web\test_session_error_recovery.py`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->