### PR TITLE
fix(web): tighten app layout spacing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -388,7 +388,7 @@ function App() {
 
   return (
     <PromptInputProvider>
-      <div className="box-border flex h-[100dvh] flex-col bg-background text-foreground px-[calc(0.75rem+var(--safe-left))] pr-[calc(0.75rem+var(--safe-right))] pt-[calc(0.75rem+var(--safe-top))] pb-1 lg:pb-[calc(0.75rem+var(--safe-bottom))] max-lg:h-[100svh] max-lg:overflow-hidden">
+      <div className="box-border flex h-dvh flex-col bg-background text-foreground pl-(--safe-left) pr-(--safe-right) pt-(--safe-top) pb-(--safe-bottom) max-lg:h-svh max-lg:overflow-hidden">
         <div className="mx-auto flex h-full min-h-0 w-full flex-1 flex-col gap-2 max-w-none">
           {isDesktop ? (
             <ResizablePanelGroup

--- a/web/src/features/sessions/sessions.tsx
+++ b/web/src/features/sessions/sessions.tsx
@@ -146,7 +146,7 @@ function SessionsListComponent(
 ) {
   const { className, ...rest } = props;
   return (
-    <div ref={ref} className={cn("flex flex-col space-y-0.5 w-full px-2 mt-1", className)} {...rest} />
+    <div ref={ref} className={cn("flex flex-col gap-1 w-full px-2 mt-1!", className)} {...rest} />
   );
 }
 
@@ -804,10 +804,10 @@ export const SessionsSidebar = memo(function SessionsSidebarComponent({
               <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
               <input
                 type="text"
-                placeholder="Search sessions..."
+                placeholder="Search sessions"
                 value={sessionSearch}
                 onChange={(e) => setSessionSearch(e.target.value)}
-                className="h-8 w-full rounded-md border border-input bg-background pl-8 pr-8 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                className="h-8 w-full rounded-md border border-input bg-background pl-8 pr-8 truncate text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               />
               {sessionSearch && (
                 <button


### PR DESCRIPTION
Summary:
- Remove the app-level outer gutter while preserving safe-area insets.
- Refine sessions sidebar list spacing and search input display.

|  before  | After |
|  ----  | ----  |
| <img width="1229" height="917" alt="image" src="https://github.com/user-attachments/assets/780f09b9-59c6-4804-bf9e-95a266725eab" /> | <img width="1229" height="918" alt="image" src="https://github.com/user-attachments/assets/53906d88-beba-4699-9409-73d788ef6a1e" /> |

Validation:
- npm run lint
- npm run build
- commit hooks: make format-kimi-cli, make check-kimi-cli
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->