### PR TITLE
fix: avoid shared rotating logs on Windows

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -22,14 +22,18 @@ from kimi_cli.config import Config, LLMModel, LLMProvider, load_config
 from kimi_cli.constant import VERSION
 from kimi_cli.llm import augment_provider_with_env_vars, create_llm, model_display_name
 from kimi_cli.session import Session
-from kimi_cli.share import get_share_dir
 from kimi_cli.soul import RunCancelled, run_soul
 from kimi_cli.soul.agent import Runtime, load_agent
 from kimi_cli.soul.context import Context
 from kimi_cli.soul.kimisoul import KimiSoul
 from kimi_cli.utils.aioqueue import QueueShutDown
 from kimi_cli.utils.envvar import get_env_bool
-from kimi_cli.utils.logging import logger, open_original_stderr, redirect_stderr_to_logger
+from kimi_cli.utils.logging import (
+    get_log_file_path,
+    logger,
+    open_original_stderr,
+    redirect_stderr_to_logger,
+)
 from kimi_cli.utils.path import shorten_home
 from kimi_cli.wire import Wire, WireUISide
 from kimi_cli.wire.types import ApprovalRequest, ApprovalResponse, ContentPart, WireMessage
@@ -58,7 +62,7 @@ def enable_logging(debug: bool = False, *, redirect_stderr: bool = True) -> None
     if debug:
         logger.enable("kosong")
     logger.add(
-        get_share_dir() / "logs" / "kimi.log",
+        get_log_file_path(),
         # FIXME: configure level for different modules
         level="TRACE" if debug else "INFO",
         format=(

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -864,9 +864,9 @@ def kimi(
             # In debug mode, show full traceback for quick diagnosis.
             _emit_fatal_error(traceback.format_exc())
         else:
-            from kimi_cli.share import get_share_dir
+            from kimi_cli.utils.logging import get_log_file_path
 
-            log_path = get_share_dir() / "logs" / "kimi.log"
+            log_path = get_log_file_path()
             # In non-debug mode, print a concise error and point users to logs.
             _emit_fatal_error(
                 f"{exc}\n"

--- a/src/kimi_cli/utils/logging.py
+++ b/src/kimi_cli/utils/logging.py
@@ -7,9 +7,18 @@ import os
 import sys
 import threading
 from collections.abc import Iterator
+from pathlib import Path
 from typing import IO
 
 from kimi_cli import logger
+from kimi_cli.share import get_share_dir
+
+
+def get_log_file_path() -> Path:
+    logs_dir = get_share_dir() / "logs"
+    if sys.platform == "win32":
+        return logs_dir / f"kimi.{os.getpid()}.log"
+    return logs_dir / "kimi.log"
 
 
 class StderrRedirector:

--- a/tests/e2e/test_cli_error_output.py
+++ b/tests/e2e/test_cli_error_output.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -35,17 +36,18 @@ def _run_kimi(args: list[str], *, share_dir: Path) -> subprocess.CompletedProces
 def _normalize_cli_error_output(text: str) -> str:
     """Normalize Rich/Click error boxes across platforms for snapshot tests."""
     text = text.replace("\r\n", "\n")
+    text = re.sub(r"kimi\.\d+\.log", "kimi.log", text)
     lines: list[str] = []
     in_box = False
     for line in text.splitlines():
-        if line.startswith(("╭", "┌")) and "Error" in line:
+        if line.startswith(("╭", "┌", "+-")) and "Error" in line:
             in_box = True
             lines.append("Error:")
             continue
-        if in_box and line.startswith(("╰", "└")):
+        if in_box and line.startswith(("╰", "└", "+-")):
             in_box = False
             continue
-        if in_box and line.startswith(("│", "┃")) and line.endswith(("│", "┃")):
+        if in_box and line.startswith(("│", "┃", "|")) and line.endswith(("│", "┃", "|")):
             inner = line[1:-1].strip()
             if inner:
                 lines.append(inner)

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,16 @@
+from kimi_cli.utils import logging as logging_utils
+
+
+def test_get_log_file_path_keeps_shared_log_off_windows(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+    monkeypatch.setattr(logging_utils.sys, "platform", "linux")
+
+    assert logging_utils.get_log_file_path() == tmp_path / "logs" / "kimi.log"
+
+
+def test_get_log_file_path_uses_process_log_on_windows(monkeypatch, tmp_path):
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(tmp_path))
+    monkeypatch.setattr(logging_utils.sys, "platform", "win32")
+    monkeypatch.setattr(logging_utils.os, "getpid", lambda: 12345)
+
+    assert logging_utils.get_log_file_path() == tmp_path / "logs" / "kimi.12345.log"


### PR DESCRIPTION
## Summary
- use per-process log files on Windows (`kimi.<pid>.log`) so concurrent CLI/web/worker processes do not rotate the same open `kimi.log`
- keep the existing shared `kimi.log` path on non-Windows platforms
- point fatal-error messages at the effective log path and keep CLI error snapshots stable across Rich box styles

## To verify
- `uv run pytest tests\e2e\test_cli_error_output.py tests\utils\test_logging.py -q`
- `uv run python -m py_compile src\kimi_cli\app.py src\kimi_cli\cli\__init__.py src\kimi_cli\utils\logging.py tests\utils\test_logging.py tests\e2e\test_cli_error_output.py`
- `uv run ruff check src\kimi_cli\app.py src\kimi_cli\cli\__init__.py src\kimi_cli\utils\logging.py tests\utils\test_logging.py tests\e2e\test_cli_error_output.py`
- `uv run ruff format --check src\kimi_cli\app.py src\kimi_cli\cli\__init__.py src\kimi_cli\utils\logging.py tests\utils\test_logging.py tests\e2e\test_cli_error_output.py`
- `git diff --check`

Fixes #2348

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->