### PR TITLE
fix: continue after deferred MCP startup failures

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -28,6 +28,7 @@ from kimi_cli.approval_runtime import (
     set_current_approval_source,
 )
 from kimi_cli.background import build_active_task_snapshot
+from kimi_cli.exception import MCPRuntimeError
 from kimi_cli.hooks.engine import HookEngine
 from kimi_cli.llm import ModelCapability
 from kimi_cli.notifications import (
@@ -532,7 +533,13 @@ class KimiSoul:
         """Wait for any in-flight MCP startup to finish."""
         if not isinstance(self._agent.toolset, KimiToolset):
             return
-        await self._agent.toolset.wait_for_mcp_tools()
+        try:
+            await self._agent.toolset.wait_for_mcp_tools()
+        except MCPRuntimeError as exc:
+            logger.warning(
+                "MCP startup failed; continuing without unavailable servers: {error}",
+                error=exc,
+            )
 
     async def _checkpoint(self):
         await self._context.checkpoint(self._checkpoint_with_user_message)

--- a/tests/core/test_kimisoul_mcp.py
+++ b/tests/core/test_kimisoul_mcp.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import kimi_cli.soul.kimisoul as kimisoul_module
+from kimi_cli.exception import MCPRuntimeError
+from kimi_cli.soul.kimisoul import KimiSoul
+
+
+class _FailingMCPToolset:
+    def __init__(self) -> None:
+        self.waited = False
+
+    async def wait_for_mcp_tools(self) -> None:
+        self.waited = True
+        raise MCPRuntimeError("Failed to connect MCP servers: broken")
+
+
+@pytest.mark.asyncio
+async def test_background_mcp_loading_failure_does_not_stop_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toolset = _FailingMCPToolset()
+    soul = KimiSoul.__new__(KimiSoul)
+    soul._agent = SimpleNamespace(toolset=toolset)
+    monkeypatch.setattr(kimisoul_module, "KimiToolset", _FailingMCPToolset)
+
+    await soul.wait_for_background_mcp_loading()
+
+    assert toolset.waited


### PR DESCRIPTION
## Summary
- keep deferred MCP startup failures from aborting the interactive turn
- log the failed startup and continue without the unavailable MCP servers
- add a regression test for the background MCP wait path

Fixes #2343.

## To verify
- `uv run pytest tests\core\test_kimisoul_mcp.py -q`
- `uv run pytest tests\core\test_kimisoul_mcp.py tests\core\test_kimisoul_steer.py -q`
- `uv run python -m py_compile src\kimi_cli\soul\kimisoul.py tests\core\test_kimisoul_mcp.py`
- `uv run ruff check src\kimi_cli\soul\kimisoul.py tests\core\test_kimisoul_mcp.py`
- `uv run ruff format --check src\kimi_cli\soul\kimisoul.py tests\core\test_kimisoul_mcp.py`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->