### PR TITLE
refactor(toolset): always load MCP tools in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- MCP: Switch MCP tool loading to a background-only flow — `KimiToolset.load_mcp_tools()` no longer accepts `in_background`; await `wait_for_mcp_tools()` to observe connection failures
+
 ## 1.44.0 (2026-05-13)
 
 - Shell: Add slash command alias resolution — aliases such as `/h`, `?`, and `status` now resolve to their canonical commands (`/help`, `/usage`); the completer and help output display alias matches as `/name (alias)` for clarity

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- MCP: Switch MCP tool loading to a background-only flow — `KimiToolset.load_mcp_tools()` no longer accepts `in_background`; await `wait_for_mcp_tools()` to observe connection failures
+
 ## 1.44.0 (2026-05-13)
 
 - Shell: Add slash command alias resolution — aliases such as `/h`, `?`, and `status` now resolve to their canonical commands (`/help`, `/usage`); the completer and help output display alias matches as `/name (alias)` for clarity

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,8 @@
 
 ## 未发布
 
+- MCP：将 MCP 工具加载切换为仅后台执行的流程——`KimiToolset.load_mcp_tools()` 不再接受 `in_background`；如需观察连接失败，请等待 `wait_for_mcp_tools()`
+
 ## 1.44.0 (2026-05-13)
 
 - Shell：新增斜杠命令别名解析——别名（如 `/h`、`?`、`status`）现在能正确解析到对应的正式命令（`/help`、`/usage`）；补全器和帮助输出会将别名匹配项显示为 `/name (alias)`，方便识别

--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -479,7 +479,7 @@ async def load_agent(
                 except pydantic.ValidationError as e:
                     raise MCPConfigError(f"Invalid MCP config: {e}") from e
         if start_mcp_loading:
-            await toolset.load_mcp_tools(validated_mcp_configs, runtime, in_background=True)
+            await toolset.load_mcp_tools(validated_mcp_configs, runtime)
         else:
             toolset.defer_mcp_tool_loading(validated_mcp_configs, runtime)
 

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -464,7 +464,7 @@ class KimiToolset:
 
         mcp_configs, runtime = self._deferred_mcp_load
         self._deferred_mcp_load = None
-        await self.load_mcp_tools(mcp_configs, runtime, in_background=True)
+        await self.load_mcp_tools(mcp_configs, runtime)
         return True
 
     def load_tools(self, tool_paths: list[str], dependencies: dict[type[Any], Any]) -> None:
@@ -527,16 +527,11 @@ class KimiToolset:
                 args.append(dependencies[param.annotation])
         return tool_cls(*args)
 
-    # TODO(rc): remove `in_background` parameter and always load in background
-    async def load_mcp_tools(
-        self, mcp_configs: list[MCPConfig], runtime: Runtime, in_background: bool = True
-    ) -> None:
+    async def load_mcp_tools(self, mcp_configs: list[MCPConfig], runtime: Runtime) -> None:
         """
-        Load MCP tools from specified MCP configs.
+        Start MCP tool loading in the background.
 
-        Raises:
-            MCPRuntimeError(KimiCLIException, RuntimeError): When any MCP server cannot be
-                connected.
+        Await wait_for_mcp_tools() to observe connection failures.
         """
         import fastmcp
         from fastmcp.mcp_config import MCPConfig, RemoteMCPServer
@@ -549,14 +544,13 @@ class KimiToolset:
             return await has_mcp_oauth_tokens(server_url)
 
         def _toast_mcp(message: str) -> None:
-            if in_background:
-                toast(
-                    message,
-                    duration=10.0,
-                    topic="mcp",
-                    immediate=True,
-                    position="right",
-                )
+            toast(
+                message,
+                duration=10.0,
+                topic="mcp",
+                immediate=True,
+                position="right",
+            )
 
         def _mark_oauth_unauthorized(server_name: str) -> None:
             logger.warning(
@@ -649,10 +643,7 @@ class KimiToolset:
                     status="pending", client=client, tools=[]
                 )
 
-        if in_background:
-            self._mcp_loading_task = asyncio.create_task(_connect())
-        else:
-            await _connect()
+        self._mcp_loading_task = asyncio.create_task(_connect())
 
     def has_pending_mcp_tools(self) -> bool:
         """Return True if the background MCP tool-loading task is still running."""

--- a/tests/cli/test_mcp_oauth.py
+++ b/tests/cli/test_mcp_oauth.py
@@ -105,7 +105,8 @@ async def test_load_mcp_tools_treats_unreadable_oauth_storage_as_unauthorized(
         }
     )
 
-    await toolset.load_mcp_tools([mcp_config], runtime, in_background=False)
+    await toolset.load_mcp_tools([mcp_config], runtime)
+    await toolset.wait_for_mcp_tools()
 
     snapshot = toolset.mcp_status_snapshot()
     assert snapshot is not None

--- a/tests/core/test_load_agent.py
+++ b/tests/core/test_load_agent.py
@@ -214,11 +214,12 @@ async def test_load_agent_registers_builtin_subagent_types(runtime: Runtime):
         assert builtin_type.agent_file.samefile(builtin_type_yaml)
 
 
-async def test_load_agent_starts_mcp_in_background(runtime: Runtime, monkeypatch):
-    called: dict[str, bool] = {}
+async def test_load_agent_starts_mcp_loading_by_default(runtime: Runtime, monkeypatch):
+    load_called = False
 
-    async def fake_load_mcp_tools(self, mcp_configs, runtime, in_background: bool = True):
-        called["in_background"] = in_background
+    async def fake_load_mcp_tools(self, mcp_configs, runtime):
+        nonlocal load_called
+        load_called = True
 
     monkeypatch.setattr(KimiToolset, "load_mcp_tools", fake_load_mcp_tools)
 
@@ -234,13 +235,13 @@ async def test_load_agent_starts_mcp_in_background(runtime: Runtime, monkeypatch
 
         await load_agent(agent_yaml, runtime, mcp_configs=[{"mcpServers": {}}])
 
-    assert called == {"in_background": True}
+    assert load_called is True
 
 
 async def test_load_agent_can_defer_mcp_loading(runtime: Runtime, monkeypatch):
     called: dict[str, bool] = {}
 
-    async def fake_load_mcp_tools(self, mcp_configs, runtime, in_background: bool = True):
+    async def fake_load_mcp_tools(self, mcp_configs, runtime):
         called["load_called"] = True
 
     def fake_defer_mcp_tool_loading(self, mcp_configs, runtime):


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->


## Description

  - Resolve the existing TODO to remove `in_background` from `KimiToolset.load_mcp_tools()`
  - Make MCP server connection work always run in the background
  - Update callers, tests, and changelog entries for the background-only MCP loading flow

  `await load_mcp_tools()` now means MCP loading has been scheduled. Callers that need to observe connection failures should await `wait_for_mcp_tools()`.
<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog.
- [x] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->