### PR TITLE
fix(build): correct module-name type in pyproject.toml files

### DIFF
--- a/packages/kaos/pyproject.toml
+++ b/packages/kaos/pyproject.toml
@@ -24,7 +24,7 @@ requires = ["uv_build>=0.8.5,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kaos"]
+module-name = "kaos"
 source-exclude = ["tests/**/*"]
 
 [tool.ruff]

--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -14,4 +14,4 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_code"]
+module-name = "kimi_code"

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -39,7 +39,7 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kosong"]
+module-name = "kosong"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_cli"]
+module-name = "kimi_cli"
 source-exclude = ["examples/**/*", "tests/**/*", "src/kimi_cli/deps/**/*"]
 
 [tool.uv.workspace]

--- a/sdks/kimi-sdk/pyproject.toml
+++ b/sdks/kimi-sdk/pyproject.toml
@@ -23,7 +23,7 @@ requires = ["uv_build>=0.8.5,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-module-name = ["kimi_sdk"]
+module-name = "kimi_sdk"
 source-exclude = ["tests/**/*"]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

The `module-name` field in `[tool.uv.build-backend]` should use string syntax for these single-module packages.

## Regression History

This is a regression for the root package configuration:

- **Commit `b75c9973`** (2025-11-17) fixed the root `pyproject.toml` by changing `module-name = ["kimi_cli"]` to `module-name = "kimi_cli"`.
- **Commit `d2dfc94c`** (`chore(dep): move kaos package to separate repo`) later changed the root configuration back to `module-name = ["kimi_cli"]` while removing `kaos` from the same list.

The workspace package files have the same invalid single-module list syntax, so this PR corrects all affected `uv_build` package configs together.

## Problem

The incorrect list syntax causes `uv run` to fail with:

```text
TOML parse error at line 57, column 15
   |
57 | module-name = ["kimi_cli"]
   |               ^^^^^^^^^^^^
invalid type: sequence, expected a string
```

## Root Cause

According to the [uv build backend settings documentation](https://docs.astral.sh/uv/reference/settings/#module-name):

- Single module packages should use string syntax, for example `module-name = "sklearn"`.
- List syntax, for example `module-name = ["foo", "bar"]`, is for namespace packages with multiple modules.

These packages each expose a single root module, so they should use string format.

## Changes

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | `module-name = ["kimi_cli"]` | `module-name = "kimi_cli"` |
| `packages/kaos/pyproject.toml` | `module-name = ["kaos"]` | `module-name = "kaos"` |
| `packages/kimi-code/pyproject.toml` | `module-name = ["kimi_code"]` | `module-name = "kimi_code"` |
| `packages/kosong/pyproject.toml` | `module-name = ["kosong"]` | `module-name = "kosong"` |
| `sdks/kimi-sdk/pyproject.toml` | `module-name = ["kimi_sdk"]` | `module-name = "kimi_sdk"` |

## Test Plan

- [x] `uv run python -c "print('works')"`
- [x] `uv sync`
- [x] `uv build`
