### PR TITLE
[codex] docs: clarify hooks notification example

### DIFF
--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -15,7 +15,7 @@ Example use cases:
 - **Code formatting**: Automatically run `prettier` or `black` after file edits
 - **Security checks**: Block dangerous shell commands (like `rm -rf /`)
 - **Sensitive file protection**: Prevent modification of `.env` and similar files
-- **Desktop notifications**: Send alerts when human approval is needed
+- **Desktop notifications**: Send alerts when background tasks complete, fail, or time out
 - **Task verification**: Check for incomplete tasks before session ends
 
 ## Supported Hook Events
@@ -36,7 +36,7 @@ Kimi Code CLI supports 13 lifecycle events:
 | `SubagentStop` | When subagent ends | Agent name | `agent_name`, `response` |
 | `PreCompact` | Before context compaction | Trigger reason | `trigger`, `token_count` |
 | `PostCompact` | After context compaction | Trigger reason | `trigger`, `estimated_token_count` |
-| `Notification` | When notification is delivered | Sink name | `sink`, `notification_type`, `title`, `body`, `severity` |
+| `Notification` | When notification is delivered | Notification type | `sink`, `notification_type`, `title`, `body`, `severity` |
 
 ## Configuring Hooks
 
@@ -56,17 +56,21 @@ matcher = "WriteFile|StrReplaceFile"
 command = ".kimi/hooks/protect-env.sh"
 timeout = 10
 
-# Desktop notification when approval needed
+# Desktop notification when a background task ends
 [[hooks]]
 event = "Notification"
-matcher = "permission_prompt"
-command = "osascript -e 'display notification \"Kimi needs attention\" with title \"Kimi CLI\"'"
+matcher = "task\\.(completed|failed|timed_out|killed|lost)"
+command = "osascript -e 'display notification \"Background task finished\" with title \"Kimi CLI\"'"
 
 # Verify tasks complete before stopping
 [[hooks]]
 event = "Stop"
 command = ".kimi/hooks/check-complete.sh"
 ```
+
+::: warning Note
+Approval requests are not `Notification` events, so `matcher = "permission_prompt"` does not fire. If you only need a coarse alert before selected tool calls, use `PreToolUse`, but it runs before matching tool calls and is not the same as an actual approval request.
+:::
 
 ### Configuration Fields
 

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -15,7 +15,7 @@ Hook 是一种在特定事件发生时触发的机制。你可以配置一个 sh
 - **代码格式化**：在文件编辑后自动运行 `prettier` 或 `black`
 - **安全检查**：阻止危险的 shell 命令（如 `rm -rf /`）
 - **敏感文件保护**：防止修改 `.env` 等配置文件
-- **桌面通知**：在需要人工审批时发送通知
+- **桌面通知**：在后台任务完成、失败或超时时发送通知
 - **任务验证**：在会话结束前检查是否有未完成的任务
 
 ## 支持的 Hook 事件
@@ -36,7 +36,7 @@ Kimi Code CLI 支持 13 种生命周期事件：
 | `SubagentStop` | 子 Agent 结束时 | Agent 名称 | `agent_name`, `response` |
 | `PreCompact` | 上下文压缩前 | 触发原因 | `trigger`, `token_count` |
 | `PostCompact` | 上下文压缩后 | 触发原因 | `trigger`, `estimated_token_count` |
-| `Notification` | 通知发送到 sink 时 | sink 名称 | `sink`, `notification_type`, `title`, `body`, `severity` |
+| `Notification` | 通知发送到 sink 时 | 通知类型 | `sink`, `notification_type`, `title`, `body`, `severity` |
 
 ## 配置 Hooks
 
@@ -56,17 +56,21 @@ matcher = "WriteFile|StrReplaceFile"
 command = ".kimi/hooks/protect-env.sh"
 timeout = 10
 
-# 需要审批时发送桌面通知
+# 后台任务结束时发送桌面通知
 [[hooks]]
 event = "Notification"
-matcher = "permission_prompt"
-command = "osascript -e 'display notification \"Kimi needs attention\" with title \"Kimi CLI\"'"
+matcher = "task\\.(completed|failed|timed_out|killed|lost)"
+command = "osascript -e 'display notification \"Background task finished\" with title \"Kimi CLI\"'"
 
 # 会话结束前检查任务完成情况
 [[hooks]]
 event = "Stop"
 command = ".kimi/hooks/check-complete.sh"
 ```
+
+::: warning 注意
+审批请求不是 `Notification` 事件，`matcher = "permission_prompt"` 不会触发。若只想在某类工具调用前提醒，可以使用 `PreToolUse`，但它会在工具调用前触发，并不等同于实际出现了审批请求。
+:::
 
 ### 配置字段
 


### PR DESCRIPTION
## Summary

- Replace the non-functional `Notification` hook example that used `permission_prompt`
- Document that `Notification` matchers use notification types, not sink names
- Clarify that approval requests are not currently emitted as `Notification` hook events

## Why

The documented `matcher = "permission_prompt"` example never fires because approval requests are handled through the approval runtime and wire request path, not through the notification manager.

This is a draft because #2335 already covers the core fix for #2330. The extra bit here is the explicit approval-request clarification and the use-case wording update.

## Validation

- Parsed both updated TOML snippets with `tomllib`
- Ran `bun run build` in `docs/`
