### PR TITLE
feat(toolset): improve dedup with sparse reminders and canonical args

### DIFF
--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -759,10 +759,10 @@ class KimiCLI:
             WelcomeInfoItem(
                 name="\nTip",
                 value=(
-                    "Spot a bug or have feedback? Type /feedback right in this session"
-                    " — every report makes Kimi better."
+                    "We just released Kimi Code — our new coding agent. "
+                    "Check it out at https://moonshotai.github.io/kimi-code"
                 ),
-                level=WelcomeInfoItem.Level.INFO,
+                level=WelcomeInfoItem.Level.WARN,
             )
         )
         async with self._env():

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -11,7 +11,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from kosong.tooling import (
     CallableTool,
@@ -83,6 +83,7 @@ def get_current_tool_call_or_none() -> ToolCall | None:
 
 
 type ToolType = CallableTool | CallableTool2[Any]
+type ToolCallKey = tuple[str, str]
 
 
 if TYPE_CHECKING:
@@ -91,7 +92,7 @@ if TYPE_CHECKING:
         _: Toolset = kimi_toolset
 
 
-_REMINDER_TEXT = (
+_REMINDER_TEXT_1 = (
     "\n\n<system-reminder>\n"
     "You are repeating the exact same tool call with identical parameters."
     " Please carefully analyze the previous result. If the task is not yet complete,"
@@ -100,7 +101,56 @@ _REMINDER_TEXT = (
 )
 
 
-def _append_reminder_to_return_value(return_value: Any) -> Any:
+def _make_reminder_text_2(tool_name: str, repeat_count: int, canonical_args: str) -> str:
+    return (
+        "\n\n<system-reminder>\n"
+        "You have repeatedly called the same tool with identical parameters many times.\n"
+        "Repeated tool call detected:\n"
+        f"- tool: {tool_name}\n"
+        f"- repeated_times: {repeat_count}\n"
+        f"- arguments: {canonical_args}\n"
+        "The previous repeated calls did not make progress. Do not call this exact same tool "
+        "with the exact same arguments again.\n"
+        "Carefully inspect the latest tool result and choose a different next action, "
+        "different parameters, or finish the task if enough evidence has been gathered."
+        "\n</system-reminder>"
+    )
+
+
+def _sort_json_value(value: object) -> object:
+    if isinstance(value, list):
+        return [_sort_json_value(item) for item in cast("list[object]", value)]
+    if isinstance(value, dict):
+        value_dict = cast("dict[str, object]", value)
+        return {key: _sort_json_value(value_dict[key]) for key in sorted(value_dict)}
+    return value
+
+
+def _canonical_tool_arguments(arguments: Any) -> str:
+    try:
+        return json.dumps(
+            _sort_json_value(arguments),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError):
+        return str(arguments)
+
+
+def _canonical_tool_arguments_text(arguments: str) -> str:
+    try:
+        return _canonical_tool_arguments(json.loads(arguments, strict=False))
+    except json.JSONDecodeError:
+        return arguments
+
+
+def _normalize_call_key(tool_name: str, arguments: str) -> ToolCallKey:
+    return (tool_name, _canonical_tool_arguments_text(arguments))
+
+
+def _append_reminder_to_return_value(
+    return_value: Any, reminder_text: str = _REMINDER_TEXT_1
+) -> Any:
     """Append dedup reminder text to a ToolReturnValue output."""
     from kosong.tooling import ToolReturnValue
 
@@ -108,16 +158,15 @@ def _append_reminder_to_return_value(return_value: Any) -> Any:
         return return_value
 
     output = return_value.output
-    reminder = _REMINDER_TEXT
 
     if isinstance(output, str):
-        new_output = output + reminder
+        new_output = output + reminder_text
     else:
         new_output = list(output)
         if new_output and isinstance(new_output[-1], TextPart):
-            new_output[-1] = TextPart(text=new_output[-1].text + reminder)
+            new_output[-1] = TextPart(text=new_output[-1].text + reminder_text)
         else:
-            new_output.append(TextPart(text=reminder))
+            new_output.append(TextPart(text=reminder_text))
 
     return return_value.model_copy(update={"output": new_output})
 
@@ -132,9 +181,13 @@ class KimiToolset:
         self._hook_engine: HookEngine = HookEngine()
 
         # Deduplication state
-        self._previous_step_calls: list[tuple[str, str]] = []
-        self._current_step_calls: list[tuple[str, str]] = []
-        self._current_step_tasks: dict[tuple[str, str], asyncio.Task[ToolResult]] = {}
+        self._previous_step_calls: list[ToolCallKey] = []
+        self._current_step_calls: list[ToolCallKey] = []
+        self._current_step_tasks: dict[ToolCallKey, asyncio.Task[ToolResult]] = {}
+        self._seen_call_keys: set[ToolCallKey] = set()
+        self._consecutive_key: ToolCallKey | None = None
+        self._consecutive_count: int = 0
+        self._step_closed: bool = False
         self._dedup_triggered: bool = False
         self._step_no: int = 0
         self._turn_id: str = ""
@@ -183,16 +236,50 @@ class KimiToolset:
         turn_id: str = "",
     ) -> None:
         """Called before each step to set up deduplication state."""
-        self._previous_step_calls = previous_calls
+        self._previous_step_calls = [
+            _normalize_call_key(tool_name, arguments) for tool_name, arguments in previous_calls
+        ]
         self._current_step_calls = []
         self._current_step_tasks = {}
+        self._step_closed = False
         self._dedup_triggered = False
         self._step_no = step_no
         self._turn_id = turn_id
+        if not self._previous_step_calls:
+            self._seen_call_keys = set()
+            self._consecutive_key = None
+            self._consecutive_count = 0
+        else:
+            self._seen_call_keys.update(self._previous_step_calls)
+            if self._consecutive_key is None and self._consecutive_count == 0:
+                self._advance_consecutive_streak(self._previous_step_calls)
 
     def end_step(self) -> list[tuple[str, str]]:
         """Called after each step to capture the calls made in this step."""
+        if not self._step_closed:
+            self._advance_consecutive_streak(self._current_step_calls)
+            self._seen_call_keys.update(self._current_step_calls)
+            self._step_closed = True
         return list(self._current_step_calls)
+
+    def _advance_consecutive_streak(self, calls: list[ToolCallKey]) -> None:
+        for call_key in calls:
+            if call_key == self._consecutive_key:
+                self._consecutive_count += 1
+            else:
+                self._consecutive_key = call_key
+                self._consecutive_count = 1
+
+    def _projected_streak_for_call(self, call_index: int) -> int:
+        consecutive_key = self._consecutive_key
+        consecutive_count = self._consecutive_count
+        for call_key in self._current_step_calls[: call_index + 1]:
+            if call_key == consecutive_key:
+                consecutive_count += 1
+            else:
+                consecutive_key = call_key
+                consecutive_count = 1
+        return consecutive_count
 
     @property
     def dedup_triggered(self) -> bool:
@@ -202,9 +289,31 @@ class KimiToolset:
     def handle(self, tool_call: ToolCall) -> HandleResult:
         token = current_tool_call.set(tool_call)
         try:
-            call_key = (tool_call.function.name, tool_call.function.arguments or "{}")
+            tool_name = tool_call.function.name
 
-            # Same-step dedup: wait for the original task and copy its result
+            if tool_name not in self._tool_dict:
+                return ToolResult(
+                    tool_call_id=tool_call.id,
+                    return_value=ToolNotFoundError(tool_name),
+                )
+
+            try:
+                arguments: JsonType = json.loads(tool_call.function.arguments or "{}", strict=False)
+            except json.JSONDecodeError as e:
+                logger.warning(
+                    "Tool call JSON parse error: {tool_name} (call_id={call_id}): {error}",
+                    tool_name=tool_name,
+                    call_id=tool_call.id,
+                    error=e,
+                )
+                return ToolResult(tool_call_id=tool_call.id, return_value=ToolParseError(str(e)))
+
+            canonical_args = _canonical_tool_arguments(arguments)
+            call_key = (tool_name, canonical_args)
+            call_index = len(self._current_step_calls)
+            self._current_step_calls.append(call_key)
+
+            # Same-step dedup: wait for the original task and copy its result.
             if call_key in self._current_step_tasks:
                 from kimi_cli.telemetry import track
 
@@ -213,9 +322,9 @@ class KimiToolset:
                     session_id=_get_session_id(),
                     turn_id=self._turn_id,
                     step_no=self._step_no,
-                    tool_name=tool_call.function.name,
+                    tool_name=tool_name,
                     dup_type="same_step",
-                    args_hash=hashlib.sha256(call_key[1].encode()).hexdigest()[:8],
+                    args_hash=hashlib.sha256(canonical_args.encode()).hexdigest()[:8],
                 )
                 original_task = self._current_step_tasks[call_key]
 
@@ -228,7 +337,8 @@ class KimiToolset:
 
                 return asyncio.create_task(_await_dup())
 
-            is_cross_step_dup = call_key in self._previous_step_calls
+            is_cross_step_dup = call_key in self._seen_call_keys
+            reminder_text: str | None = None
             if is_cross_step_dup:
                 from kimi_cli.telemetry import track
 
@@ -237,30 +347,18 @@ class KimiToolset:
                     session_id=_get_session_id(),
                     turn_id=self._turn_id,
                     step_no=self._step_no,
-                    tool_name=tool_call.function.name,
+                    tool_name=tool_name,
                     dup_type="cross_step",
-                    args_hash=hashlib.sha256(call_key[1].encode()).hexdigest()[:8],
+                    args_hash=hashlib.sha256(canonical_args.encode()).hexdigest()[:8],
                 )
                 self._dedup_triggered = True
+                repeat_count = self._projected_streak_for_call(call_index)
+                if repeat_count == 3:
+                    reminder_text = _REMINDER_TEXT_1
+                elif repeat_count in (5, 8):
+                    reminder_text = _make_reminder_text_2(tool_name, repeat_count, canonical_args)
 
-            if tool_call.function.name not in self._tool_dict:
-                return ToolResult(
-                    tool_call_id=tool_call.id,
-                    return_value=ToolNotFoundError(tool_call.function.name),
-                )
-
-            tool = self._tool_dict[tool_call.function.name]
-
-            try:
-                arguments: JsonType = json.loads(tool_call.function.arguments or "{}", strict=False)
-            except json.JSONDecodeError as e:
-                logger.warning(
-                    "Tool call JSON parse error: {tool_name} (call_id={call_id}): {error}",
-                    tool_name=tool_call.function.name,
-                    call_id=tool_call.id,
-                    error=e,
-                )
-                return ToolResult(tool_call_id=tool_call.id, return_value=ToolParseError(str(e)))
+            tool = self._tool_dict[tool_name]
 
             async def _call():
                 tool_input_dict = arguments if isinstance(arguments, dict) else {}
@@ -270,11 +368,11 @@ class KimiToolset:
 
                 results = await self._hook_engine.trigger(
                     "PreToolUse",
-                    matcher_value=tool_call.function.name,
+                    matcher_value=tool_name,
                     input_data=events.pre_tool_use(
                         session_id=_get_session_id(),
                         cwd=str(Path.cwd()),
-                        tool_name=tool_call.function.name,
+                        tool_name=tool_name,
                         tool_input=tool_input_dict,
                         tool_call_id=tool_call.id,
                     ),
@@ -297,18 +395,18 @@ class KimiToolset:
                     tool_elapsed = time.monotonic() - t0
                     logger.exception(
                         "Tool execution failed: {tool_name} (call_id={call_id})",
-                        tool_name=tool_call.function.name,
+                        tool_name=tool_name,
                         call_id=tool_call.id,
                     )
                     # --- PostToolUseFailure (fire-and-forget) ---
                     _hook_task = asyncio.create_task(
                         self._hook_engine.trigger(
                             "PostToolUseFailure",
-                            matcher_value=tool_call.function.name,
+                            matcher_value=tool_name,
                             input_data=events.post_tool_use_failure(
                                 session_id=_get_session_id(),
                                 cwd=str(Path.cwd()),
-                                tool_name=tool_call.function.name,
+                                tool_name=tool_name,
                                 tool_input=tool_input_dict,
                                 error=str(e),
                                 tool_call_id=tool_call.id,
@@ -323,7 +421,7 @@ class KimiToolset:
                     _error_type = type(e).__name__
                     track(
                         "tool_call",
-                        tool_name=tool_call.function.name,
+                        tool_name=tool_name,
                         outcome="error",
                         duration_ms=int(tool_elapsed * 1000),
                         error_type=_error_type,
@@ -336,7 +434,7 @@ class KimiToolset:
                 tool_elapsed = time.monotonic() - t0
                 logger.info(
                     "Tool {tool_name} completed in {elapsed:.1f}s (call_id={call_id})",
-                    tool_name=tool_call.function.name,
+                    tool_name=tool_name,
                     elapsed=tool_elapsed,
                     call_id=tool_call.id,
                 )
@@ -345,7 +443,7 @@ class KimiToolset:
                 if isinstance(ret, ToolError):
                     _track_tool_call(
                         "tool_call",
-                        tool_name=tool_call.function.name,
+                        tool_name=tool_name,
                         outcome="error",
                         duration_ms=int(tool_elapsed * 1000),
                         error_type=type(ret).__name__,
@@ -354,7 +452,7 @@ class KimiToolset:
                 else:
                     _track_tool_call(
                         "tool_call",
-                        tool_name=tool_call.function.name,
+                        tool_name=tool_name,
                         outcome="success",
                         duration_ms=int(tool_elapsed * 1000),
                         dup_type="cross_step" if is_cross_step_dup else "normal",
@@ -364,11 +462,11 @@ class KimiToolset:
                 _hook_task = asyncio.create_task(
                     self._hook_engine.trigger(
                         "PostToolUse",
-                        matcher_value=tool_call.function.name,
+                        matcher_value=tool_name,
                         input_data=events.post_tool_use(
                             session_id=_get_session_id(),
                             cwd=str(Path.cwd()),
-                            tool_name=tool_call.function.name,
+                            tool_name=tool_name,
                             tool_input=tool_input_dict,
                             tool_output=str(ret)[:2000],
                             tool_call_id=tool_call.id,
@@ -380,21 +478,21 @@ class KimiToolset:
                 return ToolResult(tool_call_id=tool_call.id, return_value=ret)
 
             task = asyncio.create_task(_call())
-            if is_cross_step_dup:
+            if reminder_text is not None:
 
                 async def _wrap_with_reminder(
                     inner_task: asyncio.Task[ToolResult],
+                    text: str,
                 ) -> ToolResult:
                     tr = await inner_task
                     return ToolResult(
                         tool_call_id=tr.tool_call_id,
-                        return_value=_append_reminder_to_return_value(tr.return_value),
+                        return_value=_append_reminder_to_return_value(tr.return_value, text),
                     )
 
-                task = asyncio.create_task(_wrap_with_reminder(task))
+                task = asyncio.create_task(_wrap_with_reminder(task, reminder_text))
 
             self._current_step_tasks[call_key] = task
-            self._current_step_calls.append(call_key)
             return task
         finally:
             current_tool_call.reset(token)

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -534,21 +534,8 @@ async def feedback(app: Shell, args: str):
             _fallback_to_issues()
 
 
-@registry.command(aliases=["reset"])
-async def clear(app: Shell, args: str):
-    """Clear the context"""
-    if ensure_kimi_soul(app) is None:
-        return
-    from kimi_cli.telemetry import track
-
-    track("clear")
-    await app.run_soul_command("/clear")
-    raise Reload()
-
-
-@registry.command
-async def new(app: Shell, args: str):
-    """Start a new session"""
+async def _do_new_session(app: Shell, args: str) -> None:
+    """Shared implementation for /new and /clear."""
     soul = ensure_kimi_soul(app)
     if soul is None:
         return
@@ -565,6 +552,18 @@ async def new(app: Shell, args: str):
     track("session_new")
     console.print("[green]New session created. Switching...[/green]")
     raise Reload(session_id=session.id)
+
+
+@registry.command(aliases=["reset"])
+async def clear(app: Shell, args: str) -> None:
+    """Start a new session (alias for /new)"""
+    await _do_new_session(app, args)
+
+
+@registry.command
+async def new(app: Shell, args: str) -> None:
+    """Start a new session"""
+    await _do_new_session(app, args)
 
 
 @registry.command(name="title", aliases=["rename"])

--- a/tests/core/test_startup_progress.py
+++ b/tests/core/test_startup_progress.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -114,6 +116,43 @@ async def test_kimi_cli_create_reports_startup_phases(session, config, monkeypat
         "Restoring conversation...",
     ]
     write_system_prompt.assert_awaited_once_with("Test system prompt")
+
+
+@pytest.mark.asyncio
+async def test_run_shell_adds_new_coding_agent_download_tip(runtime, monkeypatch) -> None:
+    from kimi_cli.ui.shell import WelcomeInfoItem
+
+    captured: dict[str, object] = {}
+
+    class FakeShell:
+        def __init__(self, soul, *, welcome_info=None, prefill_text=None) -> None:
+            captured["soul"] = soul
+            captured["welcome_info"] = list(welcome_info or [])
+            captured["prefill_text"] = prefill_text
+
+        async def run(self, command: str | None = None) -> bool:
+            captured["command"] = command
+            return True
+
+    @contextlib.asynccontextmanager
+    async def fake_env():
+        yield
+
+    monkeypatch.setattr("kimi_cli.ui.shell.Shell", FakeShell)
+
+    soul = SimpleNamespace(model_name="kimi-code", name="Kimi Code CLI")
+    cli = KimiCLI(soul, runtime, {})  # type: ignore[arg-type]
+    monkeypatch.setattr(cli, "_env", fake_env)
+
+    assert await cli.run_shell(command="status") is True
+
+    welcome_info = cast("list[WelcomeInfoItem]", captured["welcome_info"])
+    tip = welcome_info[-1]
+    assert tip == WelcomeInfoItem(
+        name="\nTip",
+        value="We just released Kimi Code — our new coding agent. Check it out at https://moonshotai.github.io/kimi-code",
+        level=WelcomeInfoItem.Level.WARN,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -227,11 +227,44 @@ async def test_same_step_dedup():
     assert tr_1.tool_call_id == "tc-dedup-1"
     assert tr_2.tool_call_id == "tc-dedup-2"
 
-    assert ts.end_step() == [("ToolA", args)]
+    assert ts.end_step() == [("ToolA", '{"value":"x"}'), ("ToolA", '{"value":"x"}')]
 
 
-async def test_cross_step_duplicate_appends_reminder():
-    """A tool call identical to one in the previous step should execute and append reminder in output."""
+async def test_same_step_dedup_canonicalizes_argument_key_order():
+    """Equivalent JSON objects with different key order should share the original result."""
+    ts = _make_toolset()
+    ts.begin_step([])
+
+    tool_call_1 = ToolCall(
+        id="tc-canonical-1",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments='{"a": 1, "b": 2}',
+        ),
+    )
+    tool_call_2 = ToolCall(
+        id="tc-canonical-2",
+        function=ToolCall.FunctionBody(
+            name="ToolA",
+            arguments='{"b": 2, "a": 1}',
+        ),
+    )
+
+    result_1 = ts.handle(tool_call_1)
+    result_2 = ts.handle(tool_call_2)
+    assert isinstance(result_1, asyncio.Task)
+    assert isinstance(result_2, asyncio.Task)
+
+    tr_1 = await result_1
+    tr_2 = await result_2
+
+    assert tr_1.return_value.output == "a"
+    assert tr_2.return_value.output == "a"
+    assert ts.end_step() == [("ToolA", '{"a":1,"b":2}'), ("ToolA", '{"a":1,"b":2}')]
+
+
+async def test_cross_step_duplicate_does_not_append_reminder_below_three_consecutive():
+    """The second consecutive identical call is tracked but not reminded yet."""
     ts = _make_toolset()
     args = json.dumps({"value": "x"})
     ts.begin_step([("ToolA", args)])
@@ -249,10 +282,70 @@ async def test_cross_step_duplicate_appends_reminder():
     tr = await result
     output = tr.return_value.output
     assert isinstance(output, str)
-    assert output.startswith("a")
-    assert "You are repeating the exact same tool call" in output
+    assert output == "a"
     assert ts.dedup_triggered is True
-    assert ts.end_step() == [("ToolA", args)]
+    assert ts.end_step() == [("ToolA", '{"value":"x"}')]
+
+
+async def test_cross_step_duplicate_appends_reminder_at_three_consecutive():
+    """The first reminder is sparse and appears only at the third consecutive call."""
+    ts = _make_toolset()
+    args = json.dumps({"value": "x"})
+    previous_calls: list[tuple[str, str]] = []
+
+    for i in range(2):
+        ts.begin_step(previous_calls, step_no=i + 1)
+        result = ts.handle(
+            ToolCall(
+                id=f"tc-repeat-prior-{i}",
+                function=ToolCall.FunctionBody(name="ToolA", arguments=args),
+            )
+        )
+        assert isinstance(result, asyncio.Task)
+        tr = await result
+        assert "system-reminder" not in tr.return_value.output
+        previous_calls = ts.end_step()
+
+    ts.begin_step(previous_calls, step_no=3)
+    result = ts.handle(
+        ToolCall(
+            id="tc-repeat-third",
+            function=ToolCall.FunctionBody(name="ToolA", arguments=args),
+        )
+    )
+    assert isinstance(result, asyncio.Task)
+    tr = await result
+    output = tr.return_value.output
+    assert isinstance(output, str)
+    assert "You are repeating the exact same tool call" in output
+    assert "repeated_times" not in output
+
+
+async def test_cross_step_duplicate_uses_sparse_stronger_reminders():
+    """The stronger reminder appears at the fifth repeat and includes canonical args."""
+    ts = _make_toolset()
+    args = '{"b": 2, "a": 1}'
+    previous_calls: list[tuple[str, str]] = []
+    last_output = ""
+
+    for i in range(5):
+        ts.begin_step(previous_calls, step_no=i + 1)
+        result = ts.handle(
+            ToolCall(
+                id=f"tc-repeat-{i}",
+                function=ToolCall.FunctionBody(name="ToolA", arguments=args),
+            )
+        )
+        assert isinstance(result, asyncio.Task)
+        tr = await result
+        last_output = tr.return_value.output
+        previous_calls = ts.end_step()
+
+    assert isinstance(last_output, str)
+    assert "You have repeatedly called the same tool" in last_output
+    assert "repeated_times: 5" in last_output
+    assert "tool: ToolA" in last_output
+    assert 'arguments: {"a":1,"b":2}' in last_output
 
 
 async def test_non_duplicate_allowed():
@@ -274,7 +367,7 @@ async def test_non_duplicate_allowed():
     tr = await result
     assert tr.return_value.output == "a"
     assert ts.dedup_triggered is False
-    assert ts.end_step() == [("ToolA", args)]
+    assert ts.end_step() == [("ToolA", '{"value":"y"}')]
 
 
 def test_begin_end_step():
@@ -349,7 +442,7 @@ async def test_cross_step_dedup_not_triggered_after_back_to_the_future():
     assert isinstance(result1, asyncio.Task)
     await result1
     last_calls = ts.end_step()
-    assert last_calls == [("ToolA", args)]
+    assert last_calls == [("ToolA", '{"value":"x"}')]
 
     # Simulate back_to_the_future: caller clears last_calls
     last_calls = []


### PR DESCRIPTION
## Summary

This PR improves the tool call deduplication system with smarter repeat detection and sparse reminders, makes `/clear` a true alias for `/new` in the shell UI, and updates the welcome tip.

---

### 1. Tool Call Deduplication Improvements

**Problem:** The previous deduplication system appended a reminder on every cross-step duplicate call, which could be noisy. It also did not normalize JSON argument key order, causing identical calls with different key orderings to be treated as distinct.

**What was done:**
- Canonicalize tool arguments by sorting JSON keys for stable dedup comparison
- Track consecutive repeat streaks across steps instead of treating each step independently
- Use sparse reminders: gentle reminder at the 3rd consecutive repeat, stronger detailed reminder at 5th and 8th repeats showing tool name, repeat count, and canonical arguments
- Expand test coverage for canonicalization and sparse reminder thresholds

### 2. Shell UI Improvements

**Problem:** `/clear` and `/new` had overlapping but slightly different implementations.

**What was done:**
- Extract shared `_do_new_session` helper in shell slash commands
- Make `/clear` a proper alias for `/new` with consistent session reset behavior
- Update welcome tip to promote Kimi Code download link

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
