### PR TITLE
docs: announce evolution to Kimi Code successor project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 [Kimi Code](https://www.kimi.com/code/) | [Documentation](https://moonshotai.github.io/kimi-cli/en/) | [文档](https://moonshotai.github.io/kimi-cli/zh/)
 
+> [!IMPORTANT]
+> **Kimi Code CLI is evolving into [Kimi Code](https://github.com/MoonshotAI/kimi-code)** — the next-generation terminal AI agent from the same team. Installing Kimi Code automatically migrates your configuration and sessions. This project will be gradually wound down; the docs and existing installations remain available.
+
 Kimi Code CLI is an AI agent that runs in the terminal, helping you complete software development tasks and terminal operations. It can read and edit code, execute shell commands, search and fetch web pages, and autonomously plan and adjust actions during execution.
 
 ## Getting Started

--- a/docs/.vitepress/theme/EvolutionBanner.vue
+++ b/docs/.vitepress/theme/EvolutionBanner.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+
+const STORAGE_KEY = 'kimi-cli-evolution-banner-dismissed'
+const TARGET_URL = 'https://github.com/MoonshotAI/kimi-code'
+const HTML_CLASS = 'has-evolution-banner'
+
+const { lang } = useData()
+
+const dismissed = ref(true)
+const hydrated = ref(false)
+
+function applyHtmlClass(active: boolean) {
+  if (typeof document === 'undefined') return
+  document.documentElement.classList.toggle(HTML_CLASS, active)
+}
+
+onMounted(() => {
+  dismissed.value = localStorage.getItem(STORAGE_KEY) === '1'
+  hydrated.value = true
+})
+
+watch([dismissed, hydrated], () => {
+  applyHtmlClass(hydrated.value && !dismissed.value)
+}, { immediate: true })
+
+onUnmounted(() => {
+  applyHtmlClass(false)
+})
+
+function dismiss() {
+  dismissed.value = true
+  try {
+    localStorage.setItem(STORAGE_KEY, '1')
+  } catch {
+    // ignore (private mode etc.)
+  }
+}
+
+const isZh = computed(() => lang.value.startsWith('zh'))
+const message = computed(() =>
+  isZh.value
+    ? 'Kimi Code CLI 已升级为 Kimi Code，了解更多 →'
+    : 'Kimi Code CLI is evolving into Kimi Code. Learn more →',
+)
+const closeLabel = computed(() => (isZh.value ? '关闭' : 'Dismiss'))
+</script>
+
+<template>
+  <div v-if="hydrated && !dismissed" class="evolution-banner">
+    <a
+      class="evolution-banner__link"
+      :href="TARGET_URL"
+      target="_blank"
+      rel="noopener"
+    >
+      {{ message }}
+    </a>
+    <button
+      class="evolution-banner__close"
+      type="button"
+      :aria-label="closeLabel"
+      @click="dismiss"
+    >
+      ×
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.evolution-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 44px;
+  background: var(--vp-c-bg-soft);
+  border-bottom: 1px solid var(--vp-c-divider);
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.evolution-banner__link {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.evolution-banner__link:hover {
+  color: var(--vp-c-brand-2);
+  text-decoration: underline;
+}
+
+.evolution-banner__close {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 0;
+  color: var(--vp-c-text-2);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.evolution-banner__close:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-default-soft);
+}
+
+@media (max-width: 640px) {
+  .evolution-banner {
+    font-size: 12px;
+    padding: 0 40px;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
+import EvolutionBanner from './EvolutionBanner.vue'
 import './style.css'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'layout-top': () => h(EvolutionBanner),
+    })
+  },
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -11,3 +11,9 @@
   --vp-c-brand-3: rgb(92, 158, 255);
   --vp-c-brand-soft: rgba(52, 118, 246, 0.16);
 }
+
+/* Evolution banner: VitePress's --vp-layout-top-height drives the offset of
+   VPNav, VPSidebar, VPLocalNav, VPContent, VPDoc, VPHero and VPNavScreen. */
+html.has-evolution-banner {
+  --vp-layout-top-height: 36px;
+}

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -24,6 +24,10 @@ If you encounter issues or have suggestions, please provide feedback on [GitHub 
 
 ## Installation
 
+::: tip Try the next-generation project
+Kimi Code CLI is evolving into [Kimi Code](https://github.com/MoonshotAI/kimi-code). Installing Kimi Code **automatically migrates** your configuration and sessions. New users are encouraged to install Kimi Code directly; the instructions below still work, and existing users don't need to migrate immediately.
+:::
+
 Run the installation script to complete the installation. The script will first install [uv](https://docs.astral.sh/uv/) (a Python package manager), then install Kimi Code CLI via uv:
 
 ```sh

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -24,7 +24,7 @@ If you encounter issues or have suggestions, please provide feedback on [GitHub 
 
 ## Installation
 
-::: tip Try the next-generation project
+::: tip
 Kimi Code CLI is evolving into [Kimi Code](https://github.com/MoonshotAI/kimi-code). Installing Kimi Code **automatically migrates** your configuration and sessions. New users are encouraged to install Kimi Code directly; the instructions below still work, and existing users don't need to migrate immediately.
 :::
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -6,9 +6,11 @@ hero:
   tagline: Technical Preview
   actions:
     - theme: brand
-      text: Getting Started
-      link: /en/guides/getting-started
+      text: Go to Kimi Code (Recommended)
+      link: https://github.com/MoonshotAI/kimi-code
     - theme: alt
-      text: GitHub
-      link: https://github.com/MoonshotAI/kimi-cli
+      text: Stay with Kimi Code CLI
+      link: /en/guides/getting-started
 ---
+
+> **Kimi Code CLI is evolving into [Kimi Code](https://github.com/MoonshotAI/kimi-code)** — the next-generation terminal AI agent from the same team, with a smoother experience. Installing Kimi Code **automatically migrates** your configuration and sessions. This project will be gradually wound down; the docs and existing installations remain available.

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -25,7 +25,7 @@ Kimi Code CLI 支持以下几种使用方式：
 ## 安装
 
 
-::: tip 推荐前往新项目
+::: tip
 Kimi Code CLI 已升级为 [Kimi Code](https://github.com/MoonshotAI/kimi-code)，安装 Kimi Code 后会**自动迁移**你的配置与会话。新用户建议直接安装 Kimi Code；
 :::
 

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -24,6 +24,11 @@ Kimi Code CLI 支持以下几种使用方式：
 
 ## 安装
 
+
+::: tip 推荐前往新项目
+Kimi Code CLI 已升级为 [Kimi Code](https://github.com/MoonshotAI/kimi-code)，安装 Kimi Code 后会**自动迁移**你的配置与会话。新用户建议直接安装 Kimi Code；
+:::
+
 运行安装脚本即可完成安装。脚本会先安装 [uv](https://docs.astral.sh/uv/)（Python 包管理工具），再通过 uv 安装 Kimi Code CLI：
 
 ```sh

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -6,9 +6,11 @@ hero:
   tagline: 技术预览版
   actions:
     - theme: brand
-      text: 开始使用
-      link: /zh/guides/getting-started
+      text: 前往 Kimi Code（推荐）
+      link: https://github.com/MoonshotAI/kimi-code
     - theme: alt
-      text: GitHub
-      link: https://github.com/MoonshotAI/kimi-cli
+      text: 继续使用 Kimi Code CLI
+      link: /zh/guides/getting-started
 ---
+
+> **Kimi Code CLI 已升级为 [Kimi Code](https://github.com/MoonshotAI/kimi-code)** —— 这是我们打造的下一代终端 AI Agent，由同一团队带来更顺滑的体验。安装 Kimi Code 即可**自动迁移**你的配置与会话。本项目将逐步停止维护，文档与已安装版本仍可正常使用。


### PR DESCRIPTION
## Summary

- Add a gentle migration notice across the README, VitePress home pages, and getting-started guides (zh + en), letting users know the project has evolved into [Kimi Code](https://github.com/MoonshotAI/kimi-code)
- Add a dismissible site-top banner on the docs site (locale-aware, remembers dismissed state via localStorage)

## 概述

- 在 README、VitePress 中英文首页、中英文 getting-started 文档加入温和提示，告知用户项目已升级为 [Kimi Code](https://github.com/MoonshotAI/kimi-code)
- 文档站新增可关闭的顶部 banner（跟随 locale 自动切换中英文），通过 localStorage 记忆关闭状态