### PR TITLE
docs: update evolution banner to announce rebuilt CLI release

### DIFF
--- a/docs/.vitepress/theme/EvolutionBanner.vue
+++ b/docs/.vitepress/theme/EvolutionBanner.vue
@@ -41,8 +41,8 @@ function dismiss() {
 const isZh = computed(() => lang.value.startsWith('zh'))
 const message = computed(() =>
   isZh.value
-    ? 'Kimi Code CLI 已升级为 Kimi Code，了解更多 →'
-    : 'Kimi Code CLI is evolving into Kimi Code. Learn more →',
+    ? 'Kimi Code CLI 重构升级版已发布，迭代更快   了解更多➡️'
+    : 'Kimi Code CLI rebuilt & upgraded version released — faster iterations. Learn more ➡️',
 )
 const closeLabel = computed(() => (isZh.value ? '关闭' : 'Dismiss'))
 </script>


### PR DESCRIPTION
## Summary
- 把文档站顶部 banner 文案从「Kimi Code CLI 已升级为 Kimi Code」改为宣告重构升级版发布
- 中英文两个版本同步更新；链接保持指向 `MoonshotAI/kimi-code`

## Test plan
- [ ] 本地起 `bun run docs:dev`，确认中文与英文站点 banner 文案显示正确
- [ ] 点击 banner 跳转链接仍正常
- [ ] 关闭按钮仍可隐藏 banner，刷新后保持隐藏

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary
- Changed the banner copy at the top of the documentation site from "Kimi Code CLI has been upgraded to Kimi Code" to announce the release of the reconstructed and upgraded version
- Both Chinese and English versions are updated simultaneously; the link remains pointing to `MoonshotAI/kimi-code`

## Test plan
- [ ] Run `bun run docs:dev` locally to confirm that the Chinese and English site banner copywriting is displayed correctly
- [ ] Clicking the banner to jump to the link is still normal
- [ ] The close button can still hide the banner, and it will remain hidden after refreshing.
