### PR TITLE
fix: handle double-encoded JSON in tool call arguments (Moonshot API)

### DIFF
--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -298,7 +298,19 @@ class KimiToolset:
                 )
 
             try:
-                arguments: JsonType = json.loads(tool_call.function.arguments or "{}", strict=False)
+                raw = tool_call.function.arguments or "{}"
+                if isinstance(raw, dict):
+                    arguments: JsonType = raw
+                else:
+                    arguments = json.loads(raw, strict=False)
+                    # Moonshot API quirk: double-encoded JSON strings
+                    if isinstance(arguments, dict):
+                        for k, v in list(arguments.items()):
+                            if isinstance(v, str) and v and v[0] in ("[", "{"):
+                                try:
+                                    arguments[k] = json.loads(v, strict=False)
+                                except (json.JSONDecodeError, ValueError):
+                                    pass
             except json.JSONDecodeError as e:
                 logger.warning(
                     "Tool call JSON parse error: {tool_name} (call_id={call_id}): {error}",


### PR DESCRIPTION
## Summary

Fixes #2406

Moonshot API returns `function.arguments` with double-encoded JSON strings for nested array/object values. After `json.loads` parses the outer JSON, inner values like `todos` remain as strings, causing Pydantic validation failures.

**Affected tools:** `SetTodoList`, `ExitPlanMode`, `StrReplaceFile`, and any tool with array/dict parameters.

## Changes

`src/kimi_cli/soul/toolset.py` — `KimiToolset.handle()`:

1. `isinstance(raw, dict)` check for already-parsed arguments (defensive)
2. Double-encoding detection: re-parse string values that look like JSON arrays/objects

## Testing

Verified locally:
- `SetTodoList` with `todos=[{"title": "test", "status": "in_progress"}]` → ✅ works
- Query mode (omit `todos`) → ✅ works
- `ExitPlanMode` with `options=[...]` → ✅ works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->