### PR TITLE
 fix: prevent idle cursor blink from forcing scroll to bottom in Linux terminals

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1856,7 +1856,22 @@ class CustomPromptSession:
                 while True:
                     app = get_app_or_none()
                     if app is not None:
-                        app.invalidate()
+                        # Only redraw when not idle. Idle redraws cause the
+                        # terminal to scroll to the bottom on every tick in
+                        # some terminal emulators (GNOME Terminal, Konsole).
+                        is_idle = (
+                            self._active_prompt_delegate() is None
+                            and self._active_modal_delegate() is None
+                        )
+                        if not is_idle:
+                            app.invalidate()
+                        else:
+                            # Still clean up expired toasts to avoid leaks.
+                            now = time.monotonic()
+                            for pos in ("left", "right"):
+                                queue = _toast_queues[pos]
+                                while queue and queue[0].expires_at <= now:
+                                    queue.popleft()
 
                     try:
                         asyncio.get_running_loop()

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1862,6 +1862,10 @@ class CustomPromptSession:
                         is_idle = (
                             self._active_prompt_delegate() is None
                             and self._active_modal_delegate() is None
+                            and not (
+                                self._fast_refresh_provider is not None
+                                and self._fast_refresh_provider()
+                            )
                         )
                         if not is_idle:
                             app.invalidate()


### PR DESCRIPTION
 Related Issue：

  Resolve #2422

  Description：

  ## Problem

  When the conversation is complete and the user scrolls up to read history,
  the terminal automatically jumps back to the bottom every ~1 second.
  This makes it impossible to read long outputs without quitting the shell.

  ## Root Cause

  `CustomPromptSession.__enter__()` starts a background `_refresh()` task
  that calls `app.invalidate()` on a timer. When idle, this happens every
  1 second, causing prompt_toolkit to re-render and reposition the cursor
  to the bottom input box. Some Linux terminal emulators (GNOME Terminal,
  Konsole, Deepin Terminal, etc.) auto-scroll the viewport to keep the
  cursor visible, which is why VS Code's xterm.js-based terminal is not
  affected.

  ## Fix

  Skip `app.invalidate()` when the session is truly idle:
  - no agent running
  - no modal (approval/question) active

  In that case, only expire stale toast entries (to avoid leaking memory),
  and rely on natural refresh triggers:
  - user typing (`on_text_changed`)
  - agent output updates
  - modal open/close

  ## Verification

  Tested locally on Linux with GNOME Terminal. With this patch, scrolling up
  to read history no longer snaps back to the bottom.
