### PR TITLE
docs: rename project to Kimi CLI and link to Kimi Code CLI successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kimi Code CLI
+# Kimi CLI
 
 [![Commit Activity](https://img.shields.io/github/commit-activity/w/MoonshotAI/kimi-cli)](https://github.com/MoonshotAI/kimi-cli/graphs/commit-activity)
 [![Checks](https://img.shields.io/github/check-runs/MoonshotAI/kimi-cli/main)](https://github.com/MoonshotAI/kimi-cli/actions)
@@ -9,19 +9,19 @@
 [Kimi Code](https://www.kimi.com/code/) | [Documentation](https://moonshotai.github.io/kimi-cli/en/) | [文档](https://moonshotai.github.io/kimi-cli/zh/)
 
 > [!IMPORTANT]
-> **Kimi Code CLI is evolving into [Kimi Code](https://github.com/MoonshotAI/kimi-code)** — the next-generation terminal AI agent from the same team. Installing Kimi Code automatically migrates your configuration and sessions. This project will be gradually wound down; the docs and existing installations remain available.
+> **Kimi CLI is evolving into [Kimi Code CLI](https://github.com/MoonshotAI/kimi-code)** — the next-generation terminal AI agent from the same team. Installing Kimi Code CLI automatically migrates your configuration and sessions. This project will be gradually wound down; the docs and existing installations remain available.
 
-Kimi Code CLI is an AI agent that runs in the terminal, helping you complete software development tasks and terminal operations. It can read and edit code, execute shell commands, search and fetch web pages, and autonomously plan and adjust actions during execution.
+Kimi CLI is an AI agent that runs in the terminal, helping you complete software development tasks and terminal operations. It can read and edit code, execute shell commands, search and fetch web pages, and autonomously plan and adjust actions during execution.
 
 ## Getting Started
 
-See [Getting Started](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html) for how to install and start using Kimi Code CLI.
+See [Getting Started](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html) for how to install and start using Kimi CLI.
 
 ## Key Features
 
 ### Shell command mode
 
-Kimi Code CLI is not only a coding agent, but also a shell. You can switch the shell command mode by pressing `Ctrl-X`. In this mode, you can directly run shell commands without leaving Kimi Code CLI.
+Kimi CLI is not only a coding agent, but also a shell. You can switch the shell command mode by pressing `Ctrl-X`. In this mode, you can directly run shell commands without leaving Kimi CLI.
 
 ![](./docs/media/shell-mode.gif)
 
@@ -30,24 +30,24 @@ Kimi Code CLI is not only a coding agent, but also a shell. You can switch the s
 
 ### VS Code extension
 
-Kimi Code CLI can be integrated with [Visual Studio Code](https://code.visualstudio.com/) via the [Kimi Code VS Code Extension](https://marketplace.visualstudio.com/items?itemName=moonshot-ai.kimi-code).
+Kimi CLI can be integrated with [Visual Studio Code](https://code.visualstudio.com/) via the [Kimi Code VS Code Extension](https://marketplace.visualstudio.com/items?itemName=moonshot-ai.kimi-code).
 
 ![VS Code Extension](./docs/media/vscode.png)
 
 ### IDE integration via ACP
 
-Kimi Code CLI supports [Agent Client Protocol] out of the box. You can use it together with any ACP-compatible editor or IDE.
+Kimi CLI supports [Agent Client Protocol] out of the box. You can use it together with any ACP-compatible editor or IDE.
 
 [Agent Client Protocol]: https://github.com/agentclientprotocol/agent-client-protocol
 
-To use Kimi Code CLI with ACP clients, make sure to run Kimi Code CLI in the terminal and send `/login` to complete the login first. Then, you can configure your ACP client to start Kimi Code CLI as an ACP agent server with command `kimi acp`.
+To use Kimi CLI with ACP clients, make sure to run Kimi CLI in the terminal and send `/login` to complete the login first. Then, you can configure your ACP client to start Kimi CLI as an ACP agent server with command `kimi acp`.
 
-For example, to use Kimi Code CLI with [Zed](https://zed.dev/) or [JetBrains](https://blog.jetbrains.com/ai/2025/12/bring-your-own-ai-agent-to-jetbrains-ides/), add the following configuration to your `~/.config/zed/settings.json` or `~/.jetbrains/acp.json` file:
+For example, to use Kimi CLI with [Zed](https://zed.dev/) or [JetBrains](https://blog.jetbrains.com/ai/2025/12/bring-your-own-ai-agent-to-jetbrains-ides/), add the following configuration to your `~/.config/zed/settings.json` or `~/.jetbrains/acp.json` file:
 
 ```json
 {
   "agent_servers": {
-    "Kimi Code CLI": {
+    "Kimi CLI": {
       "type": "custom",
       "command": "kimi",
       "args": ["acp"],
@@ -57,13 +57,13 @@ For example, to use Kimi Code CLI with [Zed](https://zed.dev/) or [JetBrains](ht
 }
 ```
 
-Then you can create Kimi Code CLI threads in IDE's agent panel.
+Then you can create Kimi CLI threads in IDE's agent panel.
 
 ![](./docs/media/acp-integration.gif)
 
 ### Zsh integration
 
-You can use Kimi Code CLI together with Zsh, to empower your shell experience with AI agent capabilities.
+You can use Kimi CLI together with Zsh, to empower your shell experience with AI agent capabilities.
 
 Install the [zsh-kimi-cli](https://github.com/MoonshotAI/zsh-kimi-cli) plugin via:
 
@@ -85,7 +85,7 @@ After restarting Zsh, you can switch to agent mode by pressing `Ctrl-X`.
 
 ### MCP support
 
-Kimi Code CLI supports MCP (Model Context Protocol) tools.
+Kimi CLI supports MCP (Model Context Protocol) tools.
 
 **`kimi mcp` sub-command group**
 
@@ -113,7 +113,7 @@ kimi mcp auth linear
 
 **Ad-hoc MCP configuration**
 
-Kimi Code CLI also supports ad-hoc MCP server configuration via CLI option.
+Kimi CLI also supports ad-hoc MCP server configuration via CLI option.
 
 Given an MCP config file in the well-known MCP config format like the following:
 
@@ -146,7 +146,7 @@ See more features in the [Documentation](https://moonshotai.github.io/kimi-cli/e
 
 ## Development
 
-To develop Kimi Code CLI, run:
+To develop Kimi CLI, run:
 
 ```sh
 git clone https://github.com/MoonshotAI/kimi-cli.git
@@ -155,17 +155,17 @@ cd kimi-cli
 make prepare  # prepare the development environment
 ```
 
-Then you can start working on Kimi Code CLI.
+Then you can start working on Kimi CLI.
 
 Refer to the following commands after you make changes:
 
 ```sh
-uv run kimi  # run Kimi Code CLI
+uv run kimi  # run Kimi CLI
 
 make format  # format code
 make check  # run linting and type checking
 make test  # run tests
-make test-kimi-cli  # run Kimi Code CLI tests only
+make test-kimi-cli  # run Kimi CLI tests only
 make test-kosong  # run kosong tests only
 make test-pykaos  # run pykaos tests only
 make build-web  # build the web UI and sync it into the package (requires Node.js/npm)


### PR DESCRIPTION
## Description

This repository is the original Python edition of the CLI. To avoid a name collision with the next-generation successor at `MoonshotAI/kimi-code`, this PR makes the naming in the README unambiguous:

- Renames the project's self-references from "Kimi Code CLI" back to "Kimi CLI", consistent with the repo name and the `kimi-cli` PyPI package.
- Updates the evolution banner so the successor is named "Kimi Code CLI", and changes the link anchor text from "Kimi Code" to "Kimi Code CLI" so it clearly points readers (and search crawlers) to the successor under that name.

Result: "Kimi CLI" (this repo, Python) and "Kimi Code CLI" (the successor) are now two distinct, unambiguous identities, consolidating the "Kimi Code CLI" name on the successor repository.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->