### PR TITLE
feat(hooks): surface PostToolUse hook stderr to LLM context

### DIFF
--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -458,22 +458,34 @@ class KimiToolset:
                         dup_type="cross_step" if is_cross_step_dup else "normal",
                     )
 
-                # --- PostToolUse (fire-and-forget) ---
-                _hook_task = asyncio.create_task(
-                    self._hook_engine.trigger(
-                        "PostToolUse",
-                        matcher_value=tool_name,
-                        input_data=events.post_tool_use(
-                            session_id=_get_session_id(),
-                            cwd=str(Path.cwd()),
-                            tool_name=tool_name,
-                            tool_input=tool_input_dict,
-                            tool_output=str(ret)[:2000],
-                            tool_call_id=tool_call.id,
-                        ),
-                    )
+                # --- PostToolUse (awaited, not fire-and-forget) ---
+                # Hooks run after the tool completes. Their stderr is appended
+                # to the tool result message so the LLM can see and act on it.
+                hook_results = await self._hook_engine.trigger(
+                    "PostToolUse",
+                    matcher_value=tool_name,
+                    input_data=events.post_tool_use(
+                        session_id=_get_session_id(),
+                        cwd=str(Path.cwd()),
+                        tool_name=tool_name,
+                        tool_input=tool_input_dict,
+                        tool_output=str(ret)[:2000],
+                        tool_call_id=tool_call.id,
+                    ),
                 )
-                _hook_task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+
+                # Collect non-empty stderr from hooks for LLM visibility
+                hook_stderr_lines: list[str] = []
+                for hr in hook_results:
+                    if hr.stderr.strip():
+                        hook_stderr_lines.append(hr.stderr.strip())
+
+                if hook_stderr_lines:
+                    hook_output = "\n".join(hook_stderr_lines)
+                    if ret.message:
+                        ret.message = f"{ret.message}\n\n[post-tool-use-hooks]\n{hook_output}"
+                    else:
+                        ret.message = f"[post-tool-use-hooks]\n{hook_output}"
 
                 return ToolResult(tool_call_id=tool_call.id, return_value=ret)
 


### PR DESCRIPTION
This change converts the PostToolUse hook from fire-and-forget to awaited, allowing hook stderr to be collected and appended to the tool result message. This gives the LLM visibility into hook output immediately after a tool call.

## Changes
- Replace `asyncio.create_task` fire-and-forget with `await hook_engine.trigger()`
- Collect non-empty stderr from hook results
- Append collected stderr to `ret.message` with a `[post-tool-use-hooks]` header

## Motivation
Currently PostToolUse hooks run in the background and their output is discarded. This makes it impossible for hooks that emit diagnostic or advisory output to feed that information back to the LLM. For example, a PostToolUse hook that validates file changes, checks for stale documentation references, or runs linting can now surface its findings directly in the tool result message that the LLM receives.

## Potential use cases
- **Documentation drift detection**: A hook can warn when code edits have caused documentation line-number references to become stale.
- **Linting / style checks**: A hook can run formatting or linting tools after file writes and report issues to the LLM.
- **Policy / compliance checks**: A hook can validate that edited files meet project conventions and surface violations.

In all cases, the LLM sees the hook output in the same turn and can act on it (e.g., fix docs, reformat code) without requiring an extra user round-trip.

## Backwards compatibility
- PostToolUseFailure remains fire-and-forget (no change)
- Hook stdout and action semantics are unchanged
- Hooks that produce no stderr behave exactly as before