### PR TITLE
fix(kosong): round-trip empty reasoning content

### DIFF
--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -308,8 +308,10 @@ def _convert_message(message: Message) -> ChatCompletionMessageParam:
     message = message.model_copy(deep=True)
     reasoning_content: str = ""
     content: list[ContentPart] = []
+    has_reasoning = False
     for part in message.content:
         if isinstance(part, ThinkPart):
+            has_reasoning = True
             reasoning_content += part.think
         else:
             content.append(part)
@@ -327,7 +329,7 @@ def _convert_message(message: Message) -> ChatCompletionMessageParam:
         # Dropping `content` entirely is always accepted, so do that whenever
         # the visible content is effectively empty alongside a tool call.
         dumped_message.pop("content", None)
-    if reasoning_content:
+    if has_reasoning:
         dumped_message["reasoning_content"] = reasoning_content
     return cast(ChatCompletionMessageParam, dumped_message)
 

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -201,8 +201,10 @@ class OpenAILegacy:
         message = message.model_copy(deep=True)
         reasoning_content: str = ""
         content: list[ContentPart] = []
+        has_reasoning = False
         for part in message.content:
             if isinstance(part, ThinkPart):
+                has_reasoning = True
                 reasoning_content += part.think
             else:
                 content.append(part)
@@ -213,7 +215,7 @@ class OpenAILegacy:
         else:
             message.content = content
         dumped_message = message.model_dump(exclude_none=True)
-        if reasoning_content and self._reasoning_key:
+        if has_reasoning and self._reasoning_key:
             dumped_message[self._reasoning_key] = reasoning_content
         return cast(ChatCompletionMessageParam, dumped_message)
 

--- a/packages/kosong/tests/api_snapshot_tests/test_kimi.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_kimi.py
@@ -36,6 +36,19 @@ TEST_CASES: dict[str, Case] = {
             Message(role="user", content="Thanks!"),
         ],
     },
+    "assistant_with_empty_reasoning": {
+        "history": [
+            Message(role="user", content="What is 2+2?"),
+            Message(
+                role="assistant",
+                content=[
+                    ThinkPart(think=""),
+                    TextPart(text="The answer is 4."),
+                ],
+            ),
+            Message(role="user", content="Thanks!"),
+        ],
+    },
     "assistant_tool_call_without_text": {
         "history": [
             Message(role="user", content="Call the add tool"),
@@ -312,6 +325,18 @@ async def test_kimi_message_conversion():
                             "role": "assistant",
                             "content": "The answer is 4.",
                             "reasoning_content": "Let me think...",
+                        },
+                        {"role": "user", "content": "Thanks!"},
+                    ],
+                    "tools": [],
+                },
+                "assistant_with_empty_reasoning": {
+                    "messages": [
+                        {"role": "user", "content": "What is 2+2?"},
+                        {
+                            "role": "assistant",
+                            "content": "The answer is 4.",
+                            "reasoning_content": "",
                         },
                         {"role": "user", "content": "Thanks!"},
                     ],

--- a/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
@@ -278,6 +278,40 @@ async def test_openai_legacy_reasoning_content():
         )
 
 
+async def test_openai_legacy_empty_reasoning_content_is_round_tripped():
+    with respx.mock(base_url="https://api.openai.com") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        provider = OpenAILegacy(
+            model="deepseek-reasoner",
+            api_key="test-key",
+            stream=False,
+            reasoning_key="reasoning_content",
+        )
+        history = [
+            Message(role="user", content="What is 2+2?"),
+            Message(
+                role="assistant",
+                content=[ThinkPart(think=""), TextPart(text="4.")],
+            ),
+            Message(role="user", content="Thanks!"),
+        ]
+        stream = await provider.generate("", [], history)
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert body["messages"] == [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "4.",
+                "reasoning_content": "",
+            },
+            {"role": "user", "content": "Thanks!"},
+        ]
+
+
 async def test_openai_legacy_generation_kwargs():
     with respx.mock(base_url="https://api.openai.com") as mock:
         mock.post("/v1/chat/completions").mock(


### PR DESCRIPTION
## Summary
- Keep `reasoning_content` when a `ThinkPart` exists even if its text is empty.
- Avoid adding `reasoning_content` to messages that never contained reasoning content.
- Apply the same behavior to Kimi and OpenAI legacy provider conversion paths.

## Tests
- Added regression coverage for empty `reasoning_content` round-tripping.
- `cd packages/kosong && uv run pytest tests/api_snapshot_tests/test_kimi.py tests/api_snapshot_tests/test_openai_legacy.py -v`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->