### PR TITLE
fix(string): strip newlines in shorten_middle before the length check

### DIFF
--- a/src/kimi_cli/utils/string.py
+++ b/src/kimi_cli/utils/string.py
@@ -28,10 +28,13 @@ def shorten(text: str, *, width: int, placeholder: str = "…") -> str:
 
 def shorten_middle(text: str, width: int, remove_newline: bool = True) -> str:
     """Shorten the text by inserting ellipsis in the middle."""
-    if len(text) <= width:
-        return text
+    # Strip newlines first: callers rely on this to keep the result on a single
+    # line, and doing it before the length check ensures short multi-line inputs
+    # are flattened too (and that the check sees the post-flattening length).
     if remove_newline:
         text = _NEWLINE_RE.sub(" ", text)
+    if len(text) <= width:
+        return text
     return text[: width // 2] + "..." + text[-width // 2 :]
 
 

--- a/tests/utils/test_shorten.py
+++ b/tests/utils/test_shorten.py
@@ -70,3 +70,34 @@ def test_placeholder_longer_than_cut():
     result = shorten("hello", width=1, placeholder="...")
     assert len(result) <= 1
     assert result == "h"
+
+
+def test_shorten_middle_short_text_unchanged():
+    from kimi_cli.utils.string import shorten_middle
+
+    assert shorten_middle("hello", 50) == "hello"
+
+
+def test_shorten_middle_strips_newlines_in_short_text():
+    """remove_newline must apply even when the text is shorter than width."""
+    from kimi_cli.utils.string import shorten_middle
+
+    result = shorten_middle("ls -la\npwd\necho done", 50)
+    assert "\n" not in result
+    assert result == "ls -la pwd echo done"
+
+
+def test_shorten_middle_can_keep_newlines():
+    from kimi_cli.utils.string import shorten_middle
+
+    result = shorten_middle("a\nb", 50, remove_newline=False)
+    assert result == "a\nb"
+
+
+def test_shorten_middle_long_text_gets_ellipsis():
+    from kimi_cli.utils.string import shorten_middle
+
+    text = "x" * 100
+    result = shorten_middle(text, 50)
+    assert "..." in result
+    assert result == "x" * 25 + "..." + "x" * 25


### PR DESCRIPTION
## Problem

`shorten_middle(text, width, remove_newline=True)` is used by `extract_key_argument` to render a **single-line** summary of a tool call's key argument:

```python
key_argument = shorten_middle(key_argument, width=50)
```

But the function returns early on short input *before* collapsing newlines:

```python
def shorten_middle(text, width, remove_newline=True):
    if len(text) <= width:
        return text                       # <-- newlines never stripped here
    if remove_newline:
        text = _NEWLINE_RE.sub(" ", text)
    return text[: width // 2] + "..." + text[-width // 2 :]
```

So any key argument shorter than `width` that contains a newline — a multi-line Bash command, a Grep pattern, a multi-line SearchWeb query — is returned with its newlines intact, and the tool status line wraps across multiple lines instead of staying on one.

Reproduction (current behavior on `main`):

```python
>>> shorten_middle("ls -la\npwd\necho done", 50)   # 20 chars, well under width
'ls -la\npwd\necho done'   # newlines leak into the single-line summary
```

## Fix

Collapse newlines first, then do the length check and middle-truncation:

```python
def shorten_middle(text, width, remove_newline=True):
    if remove_newline:
        text = _NEWLINE_RE.sub(" ", text)
    if len(text) <= width:
        return text
    return text[: width // 2] + "..." + text[-width // 2 :]
```

The length check now also operates on the post-flattening length, which is what actually gets displayed. Behavior with `remove_newline=False` is unchanged.

## Tests

`shorten_middle` had no tests; added coverage to `tests/utils/test_shorten.py`:
- short text passthrough,
- newline stripping in short text (the bug),
- `remove_newline=False` keeps newlines,
- middle-ellipsis on long text.

## Verification

```
$ uv run pytest tests/utils/test_shorten.py -q
13 passed

$ uv run pytest tests/tools/test_extract_key_argument.py -q   # caller, no regression
9 passed

$ uv run ruff check src/kimi_cli/utils/string.py tests/utils/test_shorten.py
All checks passed!
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->