### PR TITLE
fix(tools): fail StrReplaceFile when a multi-edit hunk is unmatched

### DIFF
--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -142,6 +142,20 @@ class StrReplaceFile(CallableTool2[Params]):
             # requested changes without the model noticing.
             total_replacements = 0
             for index, edit in enumerate(edits):
+                # Reject an empty old string: `str.count('')` returns
+                # `len(content) + 1` (never 0), so the occurrence check below
+                # cannot catch it, and `str.replace('', new)` would splice
+                # `new` between every character.
+                if edit.old == "":
+                    detail = (
+                        "old string must not be empty."
+                        if len(edits) == 1
+                        else f"Edit #{index + 1}'s old string must not be empty."
+                    )
+                    return ToolError(
+                        message=f"No replacements were made. {detail}",
+                        brief="Empty old string",
+                    )
                 occurrences = content.count(edit.old)
                 if occurrences == 0:
                     detail = (
@@ -163,12 +177,18 @@ class StrReplaceFile(CallableTool2[Params]):
                 content = self._apply_edit(content, edit)
                 total_replacements += occurrences if edit.replace_all else 1
 
-            # Defensive: an edit whose old string equals its new string matches
-            # but changes nothing, so guard the no-op case explicitly.
+            # Every edit matched (validated above) but the result is identical
+            # to the original — e.g. an edit whose old string equals its new
+            # string, or edits that cancel out. Report a no-op rather than the
+            # misleading "old string was not found", which would send the model
+            # re-reading the file for a string that is actually present.
             if content == original_content:
                 return ToolError(
-                    message="No replacements were made. The old string was not found in the file.",
-                    brief="No replacements made",
+                    message=(
+                        "No replacements were made: the edit(s) matched but left the file "
+                        "unchanged (an old string equals its new string, or the edits cancel out)."
+                    ),
+                    brief="No changes made",
                 )
 
             diff_blocks: list[DisplayBlock] = await build_diff_blocks(

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -134,11 +134,37 @@ class StrReplaceFile(CallableTool2[Params]):
             original_content = content
             edits = [params.edit] if isinstance(params.edit, Edit) else params.edit
 
-            # Apply all edits
-            for edit in edits:
+            # Apply edits sequentially. Each edit applies to the result of the
+            # previous one, so a later edit may legitimately target text an
+            # earlier edit introduced. Validate that every edit's old string is
+            # present at its turn and fail the whole call otherwise: silently
+            # skipping a non-matching edit while still reporting success drops
+            # requested changes without the model noticing.
+            total_replacements = 0
+            for index, edit in enumerate(edits):
+                occurrences = content.count(edit.old)
+                if occurrences == 0:
+                    detail = (
+                        "The old string was not found in the file."
+                        if len(edits) == 1
+                        else (
+                            f"Edit #{index + 1}'s old string was not found "
+                            "(an earlier edit in this call may have changed that text)."
+                        )
+                    )
+                    return ToolError(
+                        message=(
+                            f"No replacements were made. {detail} "
+                            "The file contents may be out of date; "
+                            "use the Read tool to reload it."
+                        ),
+                        brief="No replacements made",
+                    )
                 content = self._apply_edit(content, edit)
+                total_replacements += occurrences if edit.replace_all else 1
 
-            # Check if any changes were made
+            # Defensive: an edit whose old string equals its new string matches
+            # but changes nothing, so guard the no-op case explicitly.
             if content == original_content:
                 return ToolError(
                     message="No replacements were made. The old string was not found in the file.",
@@ -168,14 +194,6 @@ class StrReplaceFile(CallableTool2[Params]):
 
             # Write the modified content back to the file
             await p.write_text(content, errors="replace")
-
-            # Count changes for success message
-            total_replacements = 0
-            for edit in edits:
-                if edit.replace_all:
-                    total_replacements += original_content.count(edit.old)
-                else:
-                    total_replacements += 1 if edit.old in original_content else 0
 
             return ToolReturnValue(
                 is_error=False,

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -246,3 +246,52 @@ async def test_replace_empty_strings(
     assert not result.is_error
     assert "successfully edited" in result.message
     assert await file_path.read_text() == "Hello !"
+
+
+async def test_replace_multiple_edits_one_not_found_is_atomic(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """A multi-edit where one edit's old string is missing must fail the whole
+    call, not silently apply the matching edits and report success."""
+    file_path = temp_work_dir / "test.txt"
+    original_content = "Hello world! Goodbye world!"
+    await file_path.write_text(original_content)
+
+    result = await str_replace_file_tool(
+        Params(
+            path=str(file_path),
+            edit=[
+                Edit(old="Hello", new="Hi"),
+                Edit(old="does-not-exist", new="x"),
+            ],
+        )
+    )
+
+    assert result.is_error
+    assert "No replacements were made" in result.message
+    # The whole batch fails atomically — the file is left untouched even though
+    # the first edit on its own would have matched.
+    assert await file_path.read_text() == original_content
+
+
+async def test_replace_sequential_dependent_edits_count(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """Edits apply in sequence, so a later edit can target text an earlier edit
+    introduced, and the reported replacement count reflects what actually ran."""
+    file_path = temp_work_dir / "test.txt"
+    await file_path.write_text("foo")
+
+    result = await str_replace_file_tool(
+        Params(
+            path=str(file_path),
+            edit=[
+                Edit(old="foo", new="bar"),
+                Edit(old="bar", new="baz"),
+            ],
+        )
+    )
+
+    assert not result.is_error
+    assert await file_path.read_text() == "baz"
+    assert "2 total replacement(s)" in result.message

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -295,3 +295,41 @@ async def test_replace_sequential_dependent_edits_count(
     assert not result.is_error
     assert await file_path.read_text() == "baz"
     assert "2 total replacement(s)" in result.message
+
+
+async def test_replace_noop_reports_unchanged_not_missing(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """An edit whose old string equals its new string matches but changes
+    nothing. The error must say the file was left unchanged, not the misleading
+    "old string was not found" (which would send the model re-reading the file
+    for a string that is actually present)."""
+    file_path = temp_work_dir / "test.txt"
+    original_content = "Hello world!"
+    await file_path.write_text(original_content)
+
+    result = await str_replace_file_tool(
+        Params(path=str(file_path), edit=Edit(old="world", new="world"))
+    )
+
+    assert result.is_error
+    assert "left the file unchanged" in result.message
+    assert "not found" not in result.message
+    assert await file_path.read_text() == original_content
+
+
+async def test_replace_rejects_empty_old_string(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """An empty old string must be rejected. `str.count('')` is never 0 and
+    `str.replace('', new)` would splice new between every character, so the
+    occurrence check cannot guard it — reject it explicitly instead."""
+    file_path = temp_work_dir / "test.txt"
+    original_content = "Hello world!"
+    await file_path.write_text(original_content)
+
+    result = await str_replace_file_tool(Params(path=str(file_path), edit=Edit(old="", new="X")))
+
+    assert result.is_error
+    assert "must not be empty" in result.message
+    assert await file_path.read_text() == original_content


### PR DESCRIPTION
## Problem

`StrReplaceFile` applies edits with `str.replace` and then only errors when the **entire** result is unchanged:

```python
for edit in edits:
    content = self._apply_edit(content, edit)

if content == original_content:
    return ToolError(message="No replacements were made. ...")
```

So in a **multi-edit** call where some edits match and others don't, the non-matching edits are silently skipped and the tool still reports success:

```python
# content = "Hello world! Goodbye world!"
edit = [Edit(old="Hello", new="Hi"), Edit(old="does-not-exist", new="x")]
# -> result.is_error == False
# -> message: "Applied 2 edit(s) with 1 total replacement(s)."
# -> file becomes "Hi world! Goodbye world!"  (edit #2 silently dropped)
```

The model is told all hunks landed when one never did — a silent loss of requested changes. This is easy to hit when the file has drifted from what the model last read (the same situation behind the frequent `old_string not found` confusion), because a partially-stale batch *looks* like it succeeded.

A second, smaller bug: the reported replacement **count** was computed against the *original* content for every edit, so it's wrong for sequential dependent edits (e.g. `foo`→`bar` then `bar`→`baz` reported `1` instead of `2`, since `"bar"` isn't in the original `"foo"`).

## Fix

Apply edits sequentially and validate each edit's `old` string is present **at its turn** (a later edit may legitimately target text an earlier edit introduced). If any edit doesn't match, fail the whole call **without writing**, so a multi-edit is atomic and the failure is surfaced with the offending edit index. The replacement count is now tallied as edits actually apply, fixing the sequential-edit count too.

Behavior preserved:
- Single edit that matches / doesn't match → unchanged (still `"No replacements were made"`).
- Independent multi-edits that all match → unchanged.
- The no-op case (`old == new`) is still guarded.

## Tests

Added `test_replace_multiple_edits_one_not_found_is_atomic` (asserts the batch fails and the file is left untouched) and `test_replace_sequential_dependent_edits_count` (dependent edits apply and the count is correct). Full `tests/tools/test_str_replace_file.py` passes (15), plus the plan-mode/additional-dirs suites (19). `ruff check` / `ruff format` clean.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->