### PR TITLE
fix(net): honour system proxy env vars in aiohttp sessions

### DIFF
--- a/src/kimi_cli/utils/aiohttp.py
+++ b/src/kimi_cli/utils/aiohttp.py
@@ -21,4 +21,7 @@ def new_client_session(
     return aiohttp.ClientSession(
         connector=aiohttp.TCPConnector(ssl=_ssl_context),
         timeout=timeout or _DEFAULT_TIMEOUT,
+        # Honour HTTP_PROXY/HTTPS_PROXY (and NO_PROXY) from the environment, like
+        # curl does. aiohttp ignores them unless trust_env is set.
+        trust_env=True,
     )

--- a/tests/utils/test_aiohttp_timeout.py
+++ b/tests/utils/test_aiohttp_timeout.py
@@ -17,6 +17,16 @@ async def test_default_session_has_timeout():
         assert session.timeout.sock_connect == 15
 
 
+async def test_session_trusts_env_for_proxy():
+    """new_client_session() must honour HTTP(S)_PROXY env vars (trust_env=True).
+
+    Without this, tools like FetchURL/WebSearch can't reach the network behind a
+    proxy even though curl can. See #2455.
+    """
+    async with new_client_session() as session:
+        assert session.trust_env is True
+
+
 async def test_custom_timeout_override():
     """Callers can override the default timeout."""
     import aiohttp


### PR DESCRIPTION
## Problem

Behind a proxy, `FetchURL` (and `WebSearch`) fail to reach the network even though `curl` in the same environment works — with `HTTP_PROXY`/`HTTPS_PROXY` set, `curl -I https://www.google.com` returns 200 but FetchURL errors out. (Fixes #2455)

## Root cause

All outbound HTTP goes through `new_client_session()` in `kimi_cli/utils/aiohttp.py`, which builds an `aiohttp.ClientSession` **without** `trust_env=True`. Unlike curl/httpx, aiohttp ignores `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (and `.netrc`) from the environment unless `trust_env=True` is set, so the proxy is never used.

## Fix

Set `trust_env=True` in `new_client_session()`. Because every caller (FetchURL, WebSearch, auth, telemetry, …) goes through this single helper, this one change makes them all honour the system proxy.

## Tests

Added `test_session_trusts_env_for_proxy` in `tests/utils/test_aiohttp_timeout.py` asserting `session.trust_env is True`.

`uv run pytest tests/utils/test_aiohttp_timeout.py` → 4 passed. `ruff format`/`check` clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->