### PR TITLE
fix: respect system proxy settings in FetchURL

### DIFF
--- a/src/kimi_cli/utils/aiohttp.py
+++ b/src/kimi_cli/utils/aiohttp.py
@@ -21,4 +21,5 @@ def new_client_session(
     return aiohttp.ClientSession(
         connector=aiohttp.TCPConnector(ssl=_ssl_context),
         timeout=timeout or _DEFAULT_TIMEOUT,
+        trust_env=True,
     )


### PR DESCRIPTION
## Summary

- `FetchURL` ignored the system proxy because `aiohttp.ClientSession` does **not** read `HTTP_PROXY`/`HTTPS_PROXY` (and their lowercase variants) environment variables by default. This caused requests to fail with `Connection reset by peer` in environments where direct connections are blocked and a proxy (e.g. `http://127.0.0.1:7890`) is mandatory, even though `curl` works fine in the same shell.
- Fixed by adding `trust_env=True` to the `aiohttp.ClientSession(...)` constructor in `new_client_session()` (`src/kimi_cli/utils/aiohttp.py`). With `trust_env=True`, aiohttp honors the standard proxy environment variables, so `FetchURL` behaves like `curl` and respects the configured system proxy.

## Root cause

`aiohttp.ClientSession` defaults to `trust_env=False`, meaning it ignores `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`. The shared `new_client_session()` helper is used by both `fetch_with_http_get` and `_fetch_with_service` in `src/kimi_cli/tools/web/fetch.py`, so neither path was able to use the proxy.

## Test plan

- [x] With `HTTP_PROXY`/`HTTPS_PROXY` set, `FetchURL` successfully fetches `https://www.youtube.com` and `https://www.google.com` (previously failed with `Connection reset by peer`).
- [x] Without proxy env vars set, `FetchURL` continues to work as before (direct connection).
- [x] `NO_PROXY` is respected when `trust_env=True`.

Fixes #2455
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->