### PR TITLE
feat(soul): escalate repeated-tool-call reminders and force-stop on dead-end streak

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -136,7 +136,7 @@ def classify_api_error(e: Exception) -> tuple[str, int | None]:
     return "other", None
 
 
-type StepStopReason = Literal["no_tool_calls", "tool_rejected"]
+type StepStopReason = Literal["no_tool_calls", "tool_rejected", "tool_call_repeat"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -1078,11 +1078,7 @@ class KimiSoul:
             """Single LLM invocation (wrapped by retry + connection recovery)."""
             # ── 2e.4.1. Toolset begin_step ────────────────────────────────────
             if isinstance(self._agent.toolset, KimiToolset):
-                self._agent.toolset.begin_step(
-                    self._last_tool_calls,
-                    step_no=self._current_step_no,
-                    turn_id=self._current_turn_id,
-                )
+                self._agent.toolset.begin_step(self._last_tool_calls)
             # ── 2e.4.2. kosong.step ───────────────────────────────────────────
             # run an LLM step (may be interrupted)
             return await kosong.step(
@@ -1214,6 +1210,12 @@ class KimiSoul:
                     )
                 ],
             )
+
+        if isinstance(self._agent.toolset, KimiToolset) and self._agent.toolset.force_stop_turn:
+            from kimi_cli.telemetry import track
+
+            track("turn_force_stopped", reason="tool_call_repeat", step_no=self._current_step_no)
+            return StepOutcome(stop_reason="tool_call_repeat", assistant_message=result.message)
 
         if result.tool_calls:
             return None

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import importlib
 import inspect
 import json
@@ -117,6 +116,40 @@ def _make_reminder_text_2(tool_name: str, repeat_count: int, canonical_args: str
     )
 
 
+_REMINDER_TEXT_3 = (
+    "\n\n<system-reminder>\n"
+    "You are stuck in a dead end and have repeatedly made the same function call without "
+    "progress.\n"
+    "Stop all function calls immediately. Do not call any tool in your next response.\n"
+    "In analysis, review the current execution state and identify why progress is blocked.\n"
+    "Then return a text-only summary to the user that reports the current problem, what has "
+    "already been tried, and what information or decision is needed next."
+    "\n</system-reminder>"
+)
+
+
+_REPEAT_REMINDER_1_START = 3
+_REPEAT_REMINDER_2_START = 5
+_REPEAT_REMINDER_3_START = 8
+_REPEAT_FORCE_STOP_STREAK = 12
+
+type RepeatAction = Literal["none", "r1", "r2", "r3", "stop"]
+
+
+def _build_repeat_reminder(
+    streak: int, tool_name: str, canonical_args: str
+) -> tuple[RepeatAction, str | None]:
+    if streak >= _REPEAT_FORCE_STOP_STREAK:
+        return "stop", _REMINDER_TEXT_3
+    if streak >= _REPEAT_REMINDER_3_START:
+        return "r3", _REMINDER_TEXT_3
+    if streak >= _REPEAT_REMINDER_2_START:
+        return "r2", _make_reminder_text_2(tool_name, streak, canonical_args)
+    if streak >= _REPEAT_REMINDER_1_START:
+        return "r1", _REMINDER_TEXT_1
+    return "none", None
+
+
 def _sort_json_value(value: object) -> object:
     if isinstance(value, list):
         return [_sort_json_value(item) for item in cast("list[object]", value)]
@@ -189,8 +222,7 @@ class KimiToolset:
         self._consecutive_count: int = 0
         self._step_closed: bool = False
         self._dedup_triggered: bool = False
-        self._step_no: int = 0
-        self._turn_id: str = ""
+        self._force_stop_turn: bool = False
 
     def set_hook_engine(self, engine: HookEngine) -> None:
         self._hook_engine = engine
@@ -228,13 +260,7 @@ class KimiToolset:
             tool.base for tool in self._tool_dict.values() if tool.name not in self._hidden_tools
         ]
 
-    def begin_step(
-        self,
-        previous_calls: list[tuple[str, str]],
-        *,
-        step_no: int = 0,
-        turn_id: str = "",
-    ) -> None:
+    def begin_step(self, previous_calls: list[tuple[str, str]]) -> None:
         """Called before each step to set up deduplication state."""
         self._previous_step_calls = [
             _normalize_call_key(tool_name, arguments) for tool_name, arguments in previous_calls
@@ -243,8 +269,7 @@ class KimiToolset:
         self._current_step_tasks = {}
         self._step_closed = False
         self._dedup_triggered = False
-        self._step_no = step_no
-        self._turn_id = turn_id
+        self._force_stop_turn = False
         if not self._previous_step_calls:
             self._seen_call_keys = set()
             self._consecutive_key = None
@@ -286,6 +311,10 @@ class KimiToolset:
         """Whether a cross-step duplicate was blocked in the current step."""
         return self._dedup_triggered
 
+    @property
+    def force_stop_turn(self) -> bool:
+        return self._force_stop_turn
+
     def handle(self, tool_call: ToolCall) -> HandleResult:
         token = current_tool_call.set(tool_call)
         try:
@@ -315,17 +344,6 @@ class KimiToolset:
 
             # Same-step dedup: wait for the original task and copy its result.
             if call_key in self._current_step_tasks:
-                from kimi_cli.telemetry import track
-
-                track(
-                    "tool_call_dedup_detected",
-                    session_id=_get_session_id(),
-                    turn_id=self._turn_id,
-                    step_no=self._step_no,
-                    tool_name=tool_name,
-                    dup_type="same_step",
-                    args_hash=hashlib.sha256(canonical_args.encode()).hexdigest()[:8],
-                )
                 original_task = self._current_step_tasks[call_key]
 
                 async def _await_dup() -> ToolResult:
@@ -342,21 +360,19 @@ class KimiToolset:
             if is_cross_step_dup:
                 from kimi_cli.telemetry import track
 
+                repeat_count = self._projected_streak_for_call(call_index)
+                action, reminder_text = _build_repeat_reminder(
+                    repeat_count, tool_name, canonical_args
+                )
                 track(
-                    "tool_call_dedup_detected",
-                    session_id=_get_session_id(),
-                    turn_id=self._turn_id,
-                    step_no=self._step_no,
+                    "tool_call_repeat",
                     tool_name=tool_name,
-                    dup_type="cross_step",
-                    args_hash=hashlib.sha256(canonical_args.encode()).hexdigest()[:8],
+                    repeat_count=repeat_count,
+                    action=action,
                 )
                 self._dedup_triggered = True
-                repeat_count = self._projected_streak_for_call(call_index)
-                if repeat_count == 3:
-                    reminder_text = _REMINDER_TEXT_1
-                elif repeat_count in (5, 8):
-                    reminder_text = _make_reminder_text_2(tool_name, repeat_count, canonical_args)
+                if action == "stop":
+                    self._force_stop_turn = True
 
             tool = self._tool_dict[tool_name]
 

--- a/tests/core/test_kimisoul_repeat.py
+++ b/tests/core/test_kimisoul_repeat.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from pathlib import Path
+from typing import Self
+
+import pytest
+from kosong.chat_provider import StreamedMessagePart, ThinkingEffort, TokenUsage
+from kosong.message import Message, ToolCall
+from kosong.tooling import CallableTool2, Tool, ToolOk, ToolReturnValue
+from pydantic import BaseModel
+
+import kimi_cli.soul.kimisoul as kimisoul_module
+from kimi_cli.llm import LLM
+from kimi_cli.soul.agent import Agent, Runtime
+from kimi_cli.soul.context import Context
+from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.soul.toolset import KimiToolset
+
+
+class _Params(BaseModel):
+    value: str = ""
+
+
+class _DummyTool(CallableTool2[_Params]):
+    name = "ToolA"
+    description = "Dummy tool that always succeeds."
+    params = _Params
+
+    async def __call__(self, params: _Params) -> ToolReturnValue:
+        return ToolOk(output="a")
+
+
+class _RepeatStream:
+    def __init__(self, parts: list[StreamedMessagePart]) -> None:
+        self._iter = self._to_stream(parts)
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> StreamedMessagePart:
+        return await self._iter.__anext__()
+
+    async def _to_stream(
+        self, parts: list[StreamedMessagePart]
+    ) -> AsyncIterator[StreamedMessagePart]:
+        for part in parts:
+            yield part
+
+    @property
+    def id(self) -> str | None:
+        return "repeat"
+
+    @property
+    def usage(self) -> TokenUsage | None:
+        return None
+
+
+class _RepeatChatProvider:
+    name = "repeat"
+
+    def __init__(self) -> None:
+        self._n = 0
+
+    @property
+    def model_name(self) -> str:
+        return "repeat"
+
+    @property
+    def thinking_effort(self) -> ThinkingEffort | None:
+        return None
+
+    async def generate(
+        self,
+        system_prompt: str,
+        tools: Sequence[Tool],
+        history: Sequence[Message],
+    ) -> _RepeatStream:
+        self._n += 1
+        tc = ToolCall(
+            id=f"tc-{self._n}",
+            function=ToolCall.FunctionBody(name="ToolA", arguments='{"value":"x"}'),
+        )
+        return _RepeatStream([tc])
+
+    def with_thinking(self, effort: ThinkingEffort) -> Self:
+        return self
+
+
+def _runtime_with_llm(runtime: Runtime, llm: LLM) -> Runtime:
+    return Runtime(
+        config=runtime.config,
+        llm=llm,
+        session=runtime.session,
+        builtin_args=runtime.builtin_args,
+        denwa_renji=runtime.denwa_renji,
+        approval=runtime.approval,
+        labor_market=runtime.labor_market,
+        environment=runtime.environment,
+        notifications=runtime.notifications,
+        background_tasks=runtime.background_tasks,
+        skills=runtime.skills,
+        oauth=runtime.oauth,
+        additional_dirs=runtime.additional_dirs,
+        skills_dirs=runtime.skills_dirs,
+        role=runtime.role,
+    )
+
+
+def _make_soul(runtime: Runtime, llm: LLM, toolset: KimiToolset, tmp_path: Path) -> KimiSoul:
+    agent = Agent(
+        name="Repeat Test Agent",
+        system_prompt="Test system prompt.",
+        toolset=toolset,
+        runtime=_runtime_with_llm(runtime, llm),
+    )
+    return KimiSoul(agent, context=Context(file_backend=tmp_path / "history.jsonl"))
+
+
+@pytest.mark.asyncio
+async def test_turn_force_stops_after_twelve_identical_calls(
+    runtime: Runtime,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toolset = KimiToolset()
+    toolset.add(_DummyTool())
+    llm = LLM(
+        chat_provider=_RepeatChatProvider(),
+        max_context_size=100_000,
+        capabilities=set(),
+    )
+    soul = _make_soul(runtime, llm, toolset, tmp_path)
+
+    monkeypatch.setattr(kimisoul_module, "wire_send", lambda _msg: None)
+
+    async def _noop_checkpoint() -> None:
+        return None
+
+    monkeypatch.setattr(soul, "_checkpoint", _noop_checkpoint)
+    monkeypatch.setattr(soul._denwa_renji, "set_n_checkpoints", lambda _n: None)
+
+    outcome = await soul._turn(Message(role="user", content="go"))
+
+    assert outcome.stop_reason == "tool_call_repeat"
+    assert outcome.step_count == 12

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -6,11 +6,17 @@ import asyncio
 import contextlib
 import json
 
-from kosong.tooling import CallableTool2, ToolOk, ToolReturnValue
+import pytest
+from kosong.tooling import CallableTool2, ToolError, ToolOk, ToolReturnValue
 from kosong.tooling.error import ToolNotFoundError as KosongToolNotFoundError
 from pydantic import BaseModel
 
-from kimi_cli.soul.toolset import KimiToolset
+from kimi_cli.soul.toolset import (
+    _REMINDER_TEXT_1,
+    _REMINDER_TEXT_3,
+    KimiToolset,
+    _build_repeat_reminder,
+)
 from kimi_cli.wire.types import ToolCall, ToolResult
 
 
@@ -294,7 +300,7 @@ async def test_cross_step_duplicate_appends_reminder_at_three_consecutive():
     previous_calls: list[tuple[str, str]] = []
 
     for i in range(2):
-        ts.begin_step(previous_calls, step_no=i + 1)
+        ts.begin_step(previous_calls)
         result = ts.handle(
             ToolCall(
                 id=f"tc-repeat-prior-{i}",
@@ -306,7 +312,7 @@ async def test_cross_step_duplicate_appends_reminder_at_three_consecutive():
         assert "system-reminder" not in tr.return_value.output
         previous_calls = ts.end_step()
 
-    ts.begin_step(previous_calls, step_no=3)
+    ts.begin_step(previous_calls)
     result = ts.handle(
         ToolCall(
             id="tc-repeat-third",
@@ -329,7 +335,7 @@ async def test_cross_step_duplicate_uses_sparse_stronger_reminders():
     last_output = ""
 
     for i in range(5):
-        ts.begin_step(previous_calls, step_no=i + 1)
+        ts.begin_step(previous_calls)
         result = ts.handle(
             ToolCall(
                 id=f"tc-repeat-{i}",
@@ -393,7 +399,7 @@ async def test_begin_step_resets_cancelled_tasks():
     """begin_step() must clear _current_step_tasks so a retry does not await a cancelled task."""
     ts = _make_toolset()
 
-    ts.begin_step([], step_no=1, turn_id="t1")
+    ts.begin_step([])
     args = json.dumps({"value": "x"})
     tc1 = ToolCall(
         id="c1",
@@ -407,7 +413,7 @@ async def test_begin_step_resets_cancelled_tasks():
     result1.cancel()
 
     # Simulate retry: begin_step again for the same step
-    ts.begin_step([], step_no=1, turn_id="t1")
+    ts.begin_step([])
     tc2 = ToolCall(
         id="c2",
         function=ToolCall.FunctionBody(
@@ -430,7 +436,7 @@ async def test_cross_step_dedup_not_triggered_after_back_to_the_future():
 
     # Step 1: execute a tool
     args = json.dumps({"value": "x"})
-    ts.begin_step([], step_no=1, turn_id="t1")
+    ts.begin_step([])
     tc1 = ToolCall(
         id="c1",
         function=ToolCall.FunctionBody(
@@ -448,7 +454,7 @@ async def test_cross_step_dedup_not_triggered_after_back_to_the_future():
     last_calls = []
 
     # Step 2: same call with empty last_calls should execute normally
-    ts.begin_step(last_calls, step_no=2, turn_id="t1")
+    ts.begin_step(last_calls)
     tc2 = ToolCall(
         id="c2",
         function=ToolCall.FunctionBody(
@@ -463,3 +469,167 @@ async def test_cross_step_dedup_not_triggered_after_back_to_the_future():
     # Should NOT have the cross-step reminder appended
     assert tr.return_value.output == "a"
     assert ts.dedup_triggered is False
+
+
+async def _run_consecutive(
+    ts: KimiToolset,
+    count: int,
+    *,
+    args: str = '{"value":"x"}',
+    tool: str = "ToolA",
+) -> ToolResult:
+    previous_calls: list[tuple[str, str]] = []
+    last: ToolResult | None = None
+    for i in range(count):
+        ts.begin_step(previous_calls)
+        result = ts.handle(
+            ToolCall(
+                id=f"tc-repeat-{i}",
+                function=ToolCall.FunctionBody(name=tool, arguments=args),
+            )
+        )
+        assert isinstance(result, asyncio.Task)
+        last = await result
+        previous_calls = ts.end_step()
+    assert last is not None
+    return last
+
+
+def test_build_repeat_reminder_tiers():
+    assert _build_repeat_reminder(1, "ToolA", "{}") == ("none", None)
+    assert _build_repeat_reminder(2, "ToolA", "{}") == ("none", None)
+
+    action, text = _build_repeat_reminder(3, "ToolA", "{}")
+    assert action == "r1"
+    assert text == _REMINDER_TEXT_1
+
+    action, text = _build_repeat_reminder(4, "ToolA", "{}")
+    assert action == "r1"
+    assert text == _REMINDER_TEXT_1
+
+    action, text = _build_repeat_reminder(5, "ToolA", '{"a":1}')
+    assert action == "r2"
+    assert text is not None
+    assert "repeated_times: 5" in text
+    assert "tool: ToolA" in text
+    assert 'arguments: {"a":1}' in text
+
+    action, text = _build_repeat_reminder(7, "ToolA", "{}")
+    assert action == "r2"
+    assert text is not None
+    assert "repeated_times: 7" in text
+
+    action, text = _build_repeat_reminder(8, "ToolA", "{}")
+    assert action == "r3"
+    assert text == _REMINDER_TEXT_3
+
+    action, text = _build_repeat_reminder(11, "ToolA", "{}")
+    assert action == "r3"
+    assert text == _REMINDER_TEXT_3
+
+    action, text = _build_repeat_reminder(12, "ToolA", "{}")
+    assert action == "stop"
+    assert text == _REMINDER_TEXT_3
+
+    action, text = _build_repeat_reminder(20, "ToolA", "{}")
+    assert action == "stop"
+    assert text == _REMINDER_TEXT_3
+
+
+@pytest.mark.parametrize(
+    ("streak", "expected_fragment"),
+    [
+        (3, "You are repeating the exact same tool call"),
+        (4, "You are repeating the exact same tool call"),
+        (5, "You have repeatedly called the same tool"),
+        (6, "You have repeatedly called the same tool"),
+        (7, "You have repeatedly called the same tool"),
+        (8, "stuck in a dead end"),
+        (9, "stuck in a dead end"),
+        (10, "stuck in a dead end"),
+        (11, "stuck in a dead end"),
+        (12, "stuck in a dead end"),
+    ],
+)
+async def test_cross_step_duplicate_injects_reminder_on_every_repeat(
+    streak: int, expected_fragment: str
+):
+    ts = _make_toolset()
+    tr = await _run_consecutive(ts, streak)
+    output = tr.return_value.output
+    assert isinstance(output, str)
+    assert "system-reminder" in output
+    assert expected_fragment in output
+
+
+async def test_cross_step_duplicate_no_reminder_below_three():
+    for count in (1, 2):
+        ts = _make_toolset()
+        tr = await _run_consecutive(ts, count)
+        output = tr.return_value.output
+        assert isinstance(output, str)
+        assert "system-reminder" not in output
+
+
+async def test_cross_step_duplicate_does_not_force_stop_below_twelve():
+    ts = _make_toolset()
+    await _run_consecutive(ts, 11)
+    assert ts.force_stop_turn is False
+
+
+async def test_cross_step_duplicate_force_stops_turn_at_twelve():
+    ts = _make_toolset()
+    tr = await _run_consecutive(ts, 12)
+    assert ts.force_stop_turn is True
+    output = tr.return_value.output
+    assert isinstance(output, str)
+    assert "stuck in a dead end" in output
+
+
+async def test_force_stop_does_not_mark_result_as_error():
+    ts = _make_toolset()
+    tr = await _run_consecutive(ts, 12)
+    assert ts.force_stop_turn is True
+    assert not isinstance(tr.return_value, ToolError)
+    assert isinstance(tr.return_value.output, str)
+    assert tr.return_value.output.startswith("a")
+
+
+async def test_force_stop_resets_each_step():
+    ts = _make_toolset()
+    await _run_consecutive(ts, 12)
+    assert ts.force_stop_turn is True
+
+    ts.begin_step([("ToolA", '{"value":"x"}')])
+    assert ts.force_stop_turn is False
+
+
+async def test_tool_call_repeat_telemetry_matches_kimi_code(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def fake_track(event: str, **props: object) -> None:
+        events.append((event, props))
+
+    monkeypatch.setattr("kimi_cli.telemetry.track", fake_track)
+
+    ts = _make_toolset()
+    previous_calls: list[tuple[str, str]] = []
+    for i in range(5):
+        ts.begin_step(previous_calls)
+        result = ts.handle(
+            ToolCall(
+                id=f"tc-{i}",
+                function=ToolCall.FunctionBody(name="ToolA", arguments='{"value":"x"}'),
+            )
+        )
+        assert isinstance(result, asyncio.Task)
+        await result
+        previous_calls = ts.end_step()
+
+    repeat_events = [(e, p) for e, p in events if e == "tool_call_repeat"]
+    assert [p["repeat_count"] for _, p in repeat_events] == [2, 3, 4, 5]
+    assert [p["action"] for _, p in repeat_events] == ["none", "r1", "r1", "r2"]
+    assert all(p["tool_name"] == "ToolA" for _, p in repeat_events)
+    assert all(set(p) == {"tool_name", "repeat_count", "action"} for _, p in repeat_events)


### PR DESCRIPTION
## Related Issue

<!-- Please link to the issue here. -->

N/A

## Description

Port kimi-code's repeated-tool-call handling into kimi-cli. Once a call is
repeated 3+ times consecutively, a reminder is now injected on every repeat
with escalating tiers (r1/r2/r3), and the turn is force-stopped when the
streak hits 12 so the loop cannot spin on the same call indefinitely. Repeat
telemetry is aligned with kimi-code.

---

### 1. Escalating repeat reminders

**Problem:** The previous dedup only injected a reminder at exactly streak
3/5/8, leaving streaks 4/6/7/9/10/11 with no guidance to the model.

**What was done:**
- Added the r3 (dead-end) reminder text.
- Inject on every repeat from streak 3: r1 (3-4), r2 (5-7), r3 (8+).

### 2. Force-stop on dead-end streak

**Problem:** A stuck model could loop on the same tool call until
`max_steps_per_turn` was hit.

**What was done:**
- `KimiToolset` exposes `force_stop_turn`, set when the streak reaches 12.
- `_step` stops the turn with `stop_reason="tool_call_repeat"` after the
  dead-end reminder is grown into context.

### 3. Telemetry alignment with kimi-code

**Problem:** Repeat telemetry diverged from kimi-code.

**What was done:**
- Emit `tool_call_repeat{tool_name, repeat_count, action}` for every
  consecutive repeat (streak >= 2), with `action` in `none/r1/r2/r3/stop`.
- Drop the same-step dedup telemetry event (kimi-code emits none) and remove
  the now-dead `step_no`/`turn_id` state from the dedup path.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->