### PR TITLE
chore(release): bump kimi-cli to 1.48.0 and kosong to 0.54.0

### DIFF
--- a/packages/kimi-code/pyproject.toml
+++ b/packages/kimi-code/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "kimi-code"
-version = "1.47.0"
+version = "1.48.0"
 description = "Kimi Code is a CLI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["kimi-cli==1.47.0"]
+dependencies = ["kimi-cli==1.48.0"]
 
 [project.scripts]
 kimi-code = "kimi_cli.__main__:main"

--- a/packages/kosong/pyproject.toml
+++ b/packages/kosong/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kosong"
-version = "0.53.0"
+version = "0.54.0"
 description = "The LLM abstraction layer for modern AI agent applications."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kimi-cli"
-version = "1.47.0"
+version = "1.48.0"
 description = "Kimi Code CLI is your next CLI agent."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -9,7 +9,7 @@ dependencies = [
     "aiofiles>=24.0,<26.0",
     "aiohttp==3.13.3",
     "typer==0.21.1",
-    "kosong[contrib]==0.53.0",
+    "kosong[contrib]==0.54.0",
     # loguru stays >=0.6.0 because notify-py (via batrachian-toad) caps it at <=0.6.0 on 3.14+.
     "loguru>=0.6.0,<0.8",
     "prompt-toolkit==3.0.52",

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.47.0"
+version = "1.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1374,7 +1374,7 @@ dev = [
 
 [[package]]
 name = "kimi-code"
-version = "1.47.0"
+version = "1.48.0"
 source = { editable = "packages/kimi-code" }
 dependencies = [
     { name = "kimi-cli" },
@@ -1420,7 +1420,7 @@ dev = [
 
 [[package]]
 name = "kosong"
-version = "0.53.0"
+version = "0.54.0"
 source = { editable = "packages/kosong" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump kimi-cli to 1.48.0
- Bump kosong to 0.54.0
- Update the root `kosong[contrib]` pin to 0.54.0 and sync the `kimi-code` wrapper to 1.48.0
- Changelog entries intentionally omitted for this release (internal changes)

## Validation
- uv run python scripts/check_version_tag.py --pyproject pyproject.toml --expected-version 1.48.0
- uv run python scripts/check_version_tag.py --pyproject packages/kimi-code/pyproject.toml --expected-version 1.48.0
- uv run python scripts/check_version_tag.py --pyproject packages/kosong/pyproject.toml --expected-version 0.54.0
- uv run python scripts/check_kimi_dependency_versions.py --root-pyproject pyproject.toml --kosong-pyproject packages/kosong/pyproject.toml --pykaos-pyproject packages/kaos/pyproject.toml
- make check

## Post-merge
After this PR lands, create and push the release tags:

```sh
git tag 1.48.0
git tag kosong-0.54.0
git push origin 1.48.0 kosong-0.54.0
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->