### PR TITLE
fix(kosong): omit reasoning_effort instead of sending null when thinking is off

### DIFF
--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -138,6 +138,14 @@ class OpenAILegacy:
             if has_think_part:
                 reasoning_effort = "medium"
 
+        # `with_thinking("off")` resolves to `None`, but passing an explicit `None` makes the
+        # OpenAI SDK serialize `"reasoning_effort": null`. That is invalid in the chat-completions
+        # schema: strict validators reject it (HTTP 400 -> retry/rate-limit loop) and lenient
+        # backends treat it as "reasoning on by default". Use the `omit` sentinel so the field is
+        # dropped from the payload instead. See: https://github.com/MoonshotAI/kimi-cli/issues/2465
+        if reasoning_effort is None:
+            reasoning_effort = omit
+
         try:
             response = await self.client.chat.completions.create(
                 model=self.model,

--- a/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_openai_legacy.py
@@ -342,6 +342,27 @@ async def test_openai_legacy_with_thinking():
         assert body["reasoning_effort"] == snapshot("high")
 
 
+async def test_openai_legacy_with_thinking_off_omits_reasoning_effort():
+    """`with_thinking("off")` must omit reasoning_effort from the payload rather than send
+    `reasoning_effort: null`, which strict OpenAI-compatible validators reject (HTTP 400) and
+    lenient backends treat as "reasoning on".
+
+    Reproduces: https://github.com/MoonshotAI/kimi-cli/issues/2465
+    """
+    with respx.mock(base_url="https://api.openai.com") as mock:
+        mock.post("/v1/chat/completions").mock(
+            return_value=Response(200, json=make_chat_completion_response())
+        )
+        provider = OpenAILegacy(model="gpt-4.1", api_key="test-key", stream=False).with_thinking(
+            "off"
+        )
+        stream = await provider.generate("", [], [Message(role="user", content="Hi")])
+        async for _ in stream:
+            pass
+        body = json.loads(mock.calls.last.request.content.decode())
+        assert "reasoning_effort" not in body
+
+
 async def test_openai_legacy_auto_reasoning_effort_when_history_has_think_part():
     """When reasoning_effort is not set but history contains ThinkPart and reasoning_key is
     configured, reasoning_effort should be auto-set to avoid server validation errors.


### PR DESCRIPTION
## Summary

`OpenAILegacy.with_thinking("off")` maps to a Python `None` (`thinking_effort_to_reasoning_effort("off")`), which was passed straight to `client.chat.completions.create(reasoning_effort=...)`. The OpenAI SDK serializes an explicit `None` as `"reasoning_effort": null` — only the `omit` sentinel is dropped from the payload.

That `null` is wrong in two ways (per #2465):
- It is not a valid value in the chat-completions schema — strict validators (e.g. Synthetic.new / TypeBox) reject it with HTTP 400, which drives a retry/rate-limit loop.
- Lenient backends (e.g. Ollama Cloud) accept `null` but treat it as "reasoning on by default", so thinking is **not** actually disabled.

The existing auto-enable guard only handled `Omit`, so a `None` from `with_thinking("off")` flowed straight through.

## Fix

In `generate()`, normalize a `None` `reasoning_effort` to the `omit` sentinel before the API call, so the field is dropped from the payload entirely when thinking is off.

## Test

Added `test_openai_legacy_with_thinking_off_omits_reasoning_effort` asserting `reasoning_effort` is absent from the request body after `with_thinking("off")`. It fails before the fix (body contains `reasoning_effort: null`) and passes after. Full `test_openai_legacy.py` suite green; `ruff` clean.

Closes #2465

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->