### PR TITLE
fix(shell): read clipboard media on BracketedPaste for Windows terminals

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1905,6 +1905,13 @@ class CustomPromptSession:
         buffer.insert_text(token_or_text)
 
     def _handle_bracketed_paste(self, event: KeyPressEvent) -> None:
+        # On Windows, terminals such as Windows Terminal and VS Code's
+        # integrated terminal handle Ctrl+V themselves and emit a
+        # BracketedPaste event. Binary content like images cannot be carried
+        # as text in that event, so try reading media directly from the
+        # system clipboard first.
+        if self._try_paste_media(event):
+            return
         self._insert_pasted_text(event.current_buffer, event.data)
         event.app.invalidate()
 

--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -8,6 +8,7 @@ import random
 import re
 import shlex
 import subprocess
+import sys
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Sequence
@@ -1909,8 +1910,9 @@ class CustomPromptSession:
         # integrated terminal handle Ctrl+V themselves and emit a
         # BracketedPaste event. Binary content like images cannot be carried
         # as text in that event, so try reading media directly from the
-        # system clipboard first.
-        if self._try_paste_media(event):
+        # system clipboard first. Restrict this to Windows to avoid adding
+        # clipboard-read overhead to every text paste on Linux and macOS.
+        if sys.platform == "win32" and self._try_paste_media(event):
             return
         self._insert_pasted_text(event.current_buffer, event.data)
         event.app.invalidate()

--- a/tests/ui_and_conv/test_prompt_clipboard.py
+++ b/tests/ui_and_conv/test_prompt_clipboard.py
@@ -308,7 +308,12 @@ def test_build_user_input_expands_text_placeholders_for_slash_parsing() -> None:
     assert user_input.resolved_command == f"/echo {long_text}"
 
 
-def test_handle_bracketed_paste_placeholderizes_long_text_in_agent_mode() -> None:
+def test_handle_bracketed_paste_placeholderizes_long_text_in_agent_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        shell_prompt,
+        "grab_media_from_clipboard",
+        lambda: None,
+    )
     ps = _make_prompt_session(PromptMode.AGENT)
     buffer = _DummyBuffer()
     app = _DummyApp()
@@ -328,7 +333,12 @@ def test_handle_bracketed_paste_placeholderizes_long_text_in_agent_mode() -> Non
     assert user_input.resolved_command == resolved_text
 
 
-def test_handle_bracketed_paste_keeps_normalized_text_in_shell_mode() -> None:
+def test_handle_bracketed_paste_keeps_normalized_text_in_shell_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        shell_prompt,
+        "grab_media_from_clipboard",
+        lambda: None,
+    )
     ps = _make_prompt_session(PromptMode.SHELL)
     buffer = _DummyBuffer()
     app = _DummyApp()
@@ -341,6 +351,32 @@ def test_handle_bracketed_paste_keeps_normalized_text_in_shell_mode() -> None:
     ps._handle_bracketed_paste(cast(KeyPressEvent, event))
 
     assert buffer.inserted == ["line1\nline2\nline3"]
+    assert app.invalidated is True
+
+
+def test_handle_bracketed_paste_reads_image_from_clipboard(monkeypatch) -> None:
+    """When the terminal turns Ctrl+V into BracketedPaste, image data is not
+    included in event.data, so we must fall back to the system clipboard."""
+    img = Image.new("RGB", (10, 10))
+    monkeypatch.setattr(
+        shell_prompt,
+        "grab_media_from_clipboard",
+        lambda: ClipboardResult(images=(img,), file_paths=()),
+    )
+
+    ps = _make_prompt_session(PromptMode.AGENT, supports_image=True)
+    buffer = _DummyBuffer()
+    app = _DummyApp()
+    event = SimpleNamespace(
+        current_buffer=buffer,
+        app=app,
+        data="",
+    )
+
+    ps._handle_bracketed_paste(cast(KeyPressEvent, event))
+
+    assert len(buffer.inserted) == 1
+    assert buffer.inserted[0].startswith("[image:")
     assert app.invalidated is True
 
 

--- a/tests/ui_and_conv/test_prompt_clipboard.py
+++ b/tests/ui_and_conv/test_prompt_clipboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shlex
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
@@ -354,9 +355,11 @@ def test_handle_bracketed_paste_keeps_normalized_text_in_shell_mode(monkeypatch)
     assert app.invalidated is True
 
 
-def test_handle_bracketed_paste_reads_image_from_clipboard(monkeypatch) -> None:
-    """When the terminal turns Ctrl+V into BracketedPaste, image data is not
-    included in event.data, so we must fall back to the system clipboard."""
+def test_handle_bracketed_paste_reads_image_from_clipboard_on_windows(monkeypatch) -> None:
+    """When the terminal turns Ctrl+V into BracketedPaste on Windows, image
+    data is not included in event.data, so we must fall back to the system
+    clipboard."""
+    monkeypatch.setattr(sys, "platform", "win32")
     img = Image.new("RGB", (10, 10))
     monkeypatch.setattr(
         shell_prompt,
@@ -378,6 +381,33 @@ def test_handle_bracketed_paste_reads_image_from_clipboard(monkeypatch) -> None:
     assert len(buffer.inserted) == 1
     assert buffer.inserted[0].startswith("[image:")
     assert app.invalidated is True
+
+
+def test_handle_bracketed_paste_skips_media_on_non_windows(monkeypatch) -> None:
+    """On Linux and macOS, BracketedPaste should not trigger a system
+    clipboard media read for every text paste."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    calls: list[None] = []
+    monkeypatch.setattr(
+        shell_prompt,
+        "grab_media_from_clipboard",
+        lambda: calls.append(None) or ClipboardResult(images=(), file_paths=()),
+    )
+
+    ps = _make_prompt_session(PromptMode.SHELL)
+    buffer = _DummyBuffer()
+    app = _DummyApp()
+    event = SimpleNamespace(
+        current_buffer=buffer,
+        app=app,
+        data="plain text",
+    )
+
+    ps._handle_bracketed_paste(cast(KeyPressEvent, event))
+
+    assert buffer.inserted == ["plain text"]
+    assert app.invalidated is True
+    assert calls == []
 
 
 async def test_question_delegate_expands_placeholders_on_submit() -> None:


### PR DESCRIPTION
On Windows Terminal and VS Code's integrated terminal, Ctrl+V is handled
by the terminal itself and emitted as a BracketedPaste event. Binary
content like images cannot be carried as text in that event, so paste
would silently fail.

This change makes `_handle_bracketed_paste()` first try `_try_paste_media()`
to read images and files directly from the system clipboard before
falling back to the text payload.

Fixes paste of screenshots and copied image files on Windows.

<!--
Thank you for your contribution to Kimi Code CLI!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

None.

## Description

On Windows, when using terminals that support bracketed paste mode (e.g., Windows Terminal, VS Code integrated terminal), pasting image content via Ctrl+V fails silently because the BracketedPaste event only carries text data.

This PR updates `_handle_bracketed_paste()` in `src/kimi_cli/ui/shell/prompt.py` to attempt reading media directly from the system clipboard via `_try_paste_media()` before falling back to the standard text payload. This enables pasting screenshots and copied image files on Windows.

Tests have been added in `tests/.../test_prompt_clipboard.py`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any. (None applicable)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.