### PR TITLE
feat(agent): support loading CLAUDE.md alongside AGENTS.md (#2401)

### DIFF
--- a/src/kimi_cli/soul/agent.py
+++ b/src/kimi_cli/soul/agent.py
@@ -112,6 +112,10 @@ async def load_agents_md(work_dir: KaosPath) -> str | None:
         kimi_path = d / ".kimi" / "AGENTS.md"
         # AGENTS.md and agents.md are mutually exclusive (uppercase wins)
         root_candidates = [d / "AGENTS.md", d / "agents.md"]
+        # .claude/CLAUDE.md — Claude project-local config (for Claude Code compatibility, #2401)
+        claude_kimi_path = d / ".claude" / "CLAUDE.md"
+        # CLAUDE.md and claude.md are mutually exclusive (uppercase wins)
+        claude_candidates = [d / "CLAUDE.md", d / "claude.md"]
 
         candidates: list[KaosPath] = []
         if await kimi_path.is_file():
@@ -119,6 +123,12 @@ async def load_agents_md(work_dir: KaosPath) -> str | None:
         for rc in root_candidates:
             if await rc.is_file():
                 candidates.append(rc)
+                break
+        if await claude_kimi_path.is_file():
+            candidates.append(claude_kimi_path)
+        for cc in claude_candidates:
+            if await cc.is_file():
+                candidates.append(cc)
                 break
 
         for path in candidates:


### PR DESCRIPTION
Closes #2401

## Summary

Adds discovery of `CLAUDE.md` and `.claude/CLAUDE.md` files in the `load_agents_md()` function, so projects that already have Claude Code configuration are automatically picked up by Kimi CLI.

## What changed

In `src/kimi_cli/soul/agent.py:load_agents_md()`, added two new candidate file checks per directory:

1. `.claude/CLAUDE.md` — Claude project-local config (analogous to `.kimi/AGENTS.md`)
2. `CLAUDE.md` / `claude.md` — standard Claude config (analogous to `AGENTS.md` / `agents.md`), mutually exclusive with uppercase winning

## Priority order (unchanged for existing files, new entries at the end)

1. `.kimi/AGENTS.md` (highest)
2. `AGENTS.md` or `agents.md`
3. `.claude/CLAUDE.md` (new)
4. `CLAUDE.md` or `claude.md` (new)

## Why

Many developers use both Claude Code and Kimi CLI. Projects with existing `CLAUDE.md` files no longer need to duplicate content into `AGENTS.md`. This respects the "it just works" principle — Kimi CLI automatically picks up project context from whichever convention the project already uses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->