### PR TITLE
fix(soul): make LLMNotSet error message actionable for fresh installs

### DIFF
--- a/src/kimi_cli/soul/__init__.py
+++ b/src/kimi_cli/soul/__init__.py
@@ -24,7 +24,10 @@ class LLMNotSet(Exception):
     """Raised when the LLM is not set."""
 
     def __init__(self) -> None:
-        super().__init__("LLM not set")
+        super().__init__(
+            "LLM not set. Run `kimi login` to sign in, "
+            "or set a model in your config file (~/.kimi/config.toml)."
+        )
 
 
 class LLMNotSupported(Exception):

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -9,7 +9,10 @@ def test_soul_exceptions(llm: LLM):
     try:
         raise LLMNotSet()
     except LLMNotSet as e:
-        assert str(e) == snapshot("LLM not set")
+        assert str(e) == snapshot(
+            "LLM not set. Run `kimi login` to sign in, "
+            "or set a model in your config file (~/.kimi/config.toml)."
+        )
 
     try:
         raise LLMNotSupported(llm, ["image_in"])


### PR DESCRIPTION

## Summary

Closes #2456

Fresh installs (via Homebrew `brew install kimi-cli`) show `LLM not set` when running any command before `kimi login`. The error message gives no guidance on what to do next.

## Change

Updated `LLMNotSet` exception default message from:
```
LLM not set
```
to:
```
LLM not set. Run `kimi login` to sign in, or set a model in your config file (~/.kimi/config.toml).
```

This benefits the print UI (`--print`) and CLI error paths which currently only show the bare message. The shell UI already overrides this with its own contextual message (`send "/login" to login`), so shell users are unaffected.

## Files changed

- `src/kimi_cli/soul/__init__.py`: Updated `LLMNotSet.__init__` message
- `tests/core/test_exceptions.py`: Updated inline snapshot

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->