### PR TITLE
fix(soul): restore plan-mode tool bindings after /init creates throwaway soul

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -380,6 +380,19 @@ class KimiSoul:
         if isinstance(ask_tool, AskUserQuestion):
             ask_tool.bind_afk(self._approval.is_afk)
 
+    def rebind_plan_mode_tools(self) -> None:
+        """Re-bind plan-mode tool callbacks to this soul.
+
+        Plan-mode tools (``ExitPlanMode``/``EnterPlanMode``/``WriteFile``/
+        ``StrReplaceFile``) live on the shared agent toolset, but their bound
+        callbacks capture a specific soul. If another ``KimiSoul`` that shares
+        this agent is constructed (e.g. the throwaway soul used by ``/init``),
+        its ``__init__`` rebinds those shared instances to itself, leaving them
+        pointed at a dead soul once it is discarded. Call this to restore the
+        bindings to this soul.
+        """
+        self._bind_plan_mode_tools()
+
     def _ensure_plan_session_id(self) -> None:
         """Allocate a stable plan session ID on first activation."""
         if self._plan_session_id is None:

--- a/src/kimi_cli/soul/slash.py
+++ b/src/kimi_cli/soul/slash.py
@@ -41,8 +41,16 @@ async def init(soul: KimiSoul, args: str):
 
     with tempfile.TemporaryDirectory() as temp_dir:
         tmp_context = Context(file_backend=Path(temp_dir) / "context.jsonl")
+        # `tmp_soul` shares `soul.agent`, so constructing it rebinds the shared
+        # plan-mode tool instances (ExitPlanMode/EnterPlanMode/WriteFile/
+        # StrReplaceFile) to `tmp_soul`. Restore `soul`'s bindings afterwards so
+        # plan mode keeps working in the live session once `tmp_soul` is gone
+        # (see #2478).
         tmp_soul = KimiSoul(soul.agent, context=tmp_context)
-        await tmp_soul.run(prompts.INIT)
+        try:
+            await tmp_soul.run(prompts.INIT)
+        finally:
+            soul.rebind_plan_mode_tools()
 
     agents_md = await load_agents_md(soul.runtime.builtin_args.KIMI_WORK_DIR)
     system_message = system(

--- a/tests/core/test_plan_mode.py
+++ b/tests/core/test_plan_mode.py
@@ -922,3 +922,97 @@ class TestPlanOptionValidator:
         )
         assert params.options is not None
         assert len(params.options) == 3
+
+
+# ---------------------------------------------------------------------------
+# Shared-agent plan-mode binding (regression for #2478)
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_with_exit_plan_mode(runtime: Runtime) -> Agent:
+    """Build an agent whose toolset contains a live ExitPlanMode instance."""
+    toolset = KimiToolset()
+    toolset.add(ExitPlanMode())
+    return Agent(
+        name="Test Agent",
+        system_prompt="Test system prompt.",
+        toolset=toolset,
+        runtime=runtime,
+    )
+
+
+class TestSharedAgentPlanModeBinding:
+    """Regression tests for #2478.
+
+    Plan-mode tools live on the shared agent toolset, but their bound callbacks
+    capture a specific soul. Constructing a second ``KimiSoul`` over the same
+    agent (as ``/init`` does with a throwaway soul) rebinds those shared
+    instances to the second soul, so the original soul's ``ExitPlanMode`` would
+    report "Not in plan mode" even while its plan-mode reminder is active.
+    """
+
+    async def test_second_soul_clobbers_binding_and_rebind_restores(
+        self,
+        runtime: Runtime,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+
+        agent = _make_agent_with_exit_plan_mode(runtime)
+        # First soul binds ExitPlanMode to itself; it is not (yet) in plan mode,
+        # so the persisted session state stays False.
+        soul = KimiSoul(agent, context=Context(file_backend=tmp_path / "a.jsonl"))
+
+        # A second soul sharing the agent (as `/init` does) rebinds the shared
+        # ExitPlanMode instance to itself while its own plan_mode is still False.
+        throwaway = KimiSoul(agent, context=Context(file_backend=tmp_path / "b.jsonl"))
+
+        # Only the live soul enters plan mode.
+        await soul.set_plan_mode_from_manual(True)
+        assert soul.plan_mode is True
+
+        exit_tool = agent.toolset.find("ExitPlanMode")
+        assert isinstance(exit_tool, ExitPlanMode)
+        assert exit_tool._plan_mode_checker is not None
+
+        # Bug: the shared tool still points at the throwaway soul (plan_mode
+        # False), so it disagrees with the live soul.
+        assert throwaway.plan_mode is False
+        assert exit_tool._plan_mode_checker() is False
+
+        # Re-binding restores the live soul's binding.
+        soul.rebind_plan_mode_tools()
+        assert exit_tool._plan_mode_checker() is True
+
+    async def test_init_slash_command_preserves_plan_mode_binding(
+        self,
+        runtime: Runtime,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kimi_cli.soul.slash import init as init_command
+
+        monkeypatch.setattr("kimi_cli.tools.plan.heroes.PLANS_DIR", tmp_path)
+
+        agent = _make_agent_with_exit_plan_mode(runtime)
+        soul = KimiSoul(agent, context=Context(file_backend=tmp_path / "history.jsonl"))
+
+        exit_tool = agent.toolset.find("ExitPlanMode")
+        assert isinstance(exit_tool, ExitPlanMode)
+
+        # Stub out the heavy INIT run and AGENTS.md reload so `/init` runs fast.
+        monkeypatch.setattr(KimiSoul, "run", AsyncMock())
+        monkeypatch.setattr(
+            "kimi_cli.soul.slash.load_agents_md",
+            AsyncMock(return_value="Generated AGENTS.md"),
+        )
+
+        await init_command(soul, "")
+
+        # After `/init`, entering plan mode on the live soul must be visible to
+        # the shared ExitPlanMode tool. Without the rebind, the tool would still
+        # be bound to the discarded `/init` soul and report False.
+        await soul.set_plan_mode_from_manual(True)
+        assert exit_tool._plan_mode_checker is not None
+        assert exit_tool._plan_mode_checker() is True


### PR DESCRIPTION
## Bug

Fixes #2478 — when `/init` runs, it creates a throwaway `KimiSoul(soul.agent, ...)` that shares the live soul's agent (and therefore the same **tool instances**). The throwaway soul's `__init__` calls `_bind_plan_mode_tools()`, which rebinds the shared `ExitPlanMode`, `EnterPlanMode`, `WriteFile`, and `StrReplaceFile` instances to closures that reference the throwaway soul's state.

After `/init` completes and the throwaway soul is discarded, those shared tools are left pointing at stale closures whose `_plan_mode` is always `False`. This creates a state split:

- The **plan-mode dynamic injection** (reading `soul.plan_mode` on the live soul) correctly shows "Plan mode is active".
- **`ExitPlanMode`** (reading the stale closure on the dead soul) reports `"Not in plan mode"`.

The workaround "call `EnterPlanMode` again, then `ExitPlanMode`" works because `EnterPlanMode` toggles the stale throwaway soul's `_plan_mode` to `True`.

## Fix

1. **New public `KimiSoul.rebind_plan_mode_tools()` method** in `src/kimi_cli/soul/kimisoul.py` — wraps the existing `_bind_plan_mode_tools()` for external callers.

2. **Call `soul.rebind_plan_mode_tools()` in the `/init` handler** (`src/kimi_cli/soul/slash.py`) inside a `try/finally` so bindings are always restored even if the INIT prompt run fails.

3. **Two regression tests** in `tests/core/test_plan_mode.py`:
   - `test_second_soul_clobbers_binding_and_rebind_restores` — demonstrates that constructing a second soul over a shared agent clobbers the `ExitPlanMode` binding, and `rebind_plan_mode_tools()` restores it.
   - `test_init_slash_command_preserves_plan_mode_binding` — end-to-end: runs the actual `/init` handler and verifies the live soul can enter plan mode afterwards.

## Root cause

The plan-mode tools (`ExitPlanMode`/`EnterPlanMode`/`WriteFile`/`StrReplaceFile`) are mutable instances stored on the shared agent toolset. Their `bind()` methods store closures over a specific `KimiSoul` via capturing `self` in `_bind_plan_mode_tools`. When two souls share the same agent, whichever soul calls `_bind_plan_mode_tools` last "wins" — the other soul loses its bindings.

## Verification

- Root cause confirmed by code-level trace: all three `KimiSoul` construction sites examined; only `/init` shares a live agent. The binding mechanism (closures capturing `self._plan_mode`) and the over-write-on-rebind behavior confirmed. The workaround mechanism (EnterPlanMode flips the stale soul's flag) also explained.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->