### PR TITLE
fix(acp): load global MCP config in kimi acp server

### DIFF
--- a/src/kimi_cli/acp/server.py
+++ b/src/kimi_cli/acp/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import time
 from datetime import datetime
@@ -8,7 +9,9 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 import acp
+from fastmcp.mcp_config import MCPConfig
 from kaos.path import KaosPath
+from pydantic import ValidationError
 
 from kimi_cli.acp.kaos import ACPKaos
 from kimi_cli.acp.mcp import acp_mcp_servers_to_mcp_config
@@ -25,6 +28,31 @@ from kimi_cli.session import Session
 from kimi_cli.soul.slash import registry as soul_slash_registry
 from kimi_cli.soul.toolset import KimiToolset
 from kimi_cli.utils.logging import logger
+
+
+def _load_global_mcp_config() -> MCPConfig | None:
+    """Load the globally-configured MCP servers shared with interactive mode.
+
+    These live in ``<share>/mcp.json`` (managed by ``kimi mcp add`` or edited by
+    hand) and are loaded by interactive ``kimi``, but were previously ignored by
+    the ``kimi acp`` server. Returns ``None`` when the file is absent or cannot
+    be parsed — a broken global config must not abort ACP session creation.
+    """
+    from kimi_cli.cli.mcp import get_global_mcp_config_file
+
+    mcp_file = get_global_mcp_config_file()
+    if not mcp_file.exists():
+        return None
+    try:
+        data = json.loads(mcp_file.read_text(encoding="utf-8"))
+        return MCPConfig.model_validate(data)
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        logger.warning(
+            "Ignoring unreadable global MCP config {file}: {error}",
+            file=mcp_file,
+            error=exc,
+        )
+        return None
 
 
 class ACPServer:
@@ -147,6 +175,21 @@ class ACPServer:
             logger.warning("Authentication required, {reason}", reason=reason)
             raise acp.RequestError.auth_required({"authMethods": auth_methods_data})
 
+    def _build_mcp_configs(self, mcp_servers: list[MCPServer] | None) -> list[MCPConfig]:
+        """Assemble the MCP configs for a session.
+
+        Merges the globally-configured MCP servers (shared with interactive
+        ``kimi``) with any servers the ACP client supplied in the request, so
+        ``kimi acp`` exposes the same MCP tools as interactive mode. Servers
+        provided by the client take precedence on name conflicts.
+        """
+        configs: list[MCPConfig] = []
+        global_config = _load_global_mcp_config()
+        if global_config is not None:
+            configs.append(global_config)
+        configs.append(acp_mcp_servers_to_mcp_config(mcp_servers or []))
+        return configs
+
     async def new_session(
         self, cwd: str, mcp_servers: list[MCPServer] | None = None, **kwargs: Any
     ) -> acp.NewSessionResponse:
@@ -159,10 +202,9 @@ class ACPServer:
 
         session = await Session.create(KaosPath.unsafe_from_local_path(Path(cwd)))
 
-        mcp_config = acp_mcp_servers_to_mcp_config(mcp_servers or [])
         cli_instance = await KimiCLI.create(
             session,
-            mcp_configs=[mcp_config],
+            mcp_configs=self._build_mcp_configs(mcp_servers),
             ui_mode="acp",
         )
         config = cli_instance.soul.runtime.config
@@ -229,10 +271,9 @@ class ACPServer:
             )
             raise acp.RequestError.invalid_params({"session_id": "Session not found"})
 
-        mcp_config = acp_mcp_servers_to_mcp_config(mcp_servers or [])
         cli_instance = await KimiCLI.create(
             session,
-            mcp_configs=[mcp_config],
+            mcp_configs=self._build_mcp_configs(mcp_servers),
             resumed=True,  # _setup_session loads existing sessions
             ui_mode="acp",
         )

--- a/tests/acp/test_server_mcp_config.py
+++ b/tests/acp/test_server_mcp_config.py
@@ -1,0 +1,52 @@
+"""Unit tests for ACPServer MCP config assembly.
+
+Regression coverage for the ``kimi acp`` server ignoring the globally-configured
+MCP servers (``<share>/mcp.json``) that interactive ``kimi`` loads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kimi_cli.acp.server import ACPServer, _load_global_mcp_config
+
+
+def _write_global_config(mcp_file: Path, servers: dict) -> None:
+    mcp_file.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+
+
+def test_load_global_mcp_config_missing_file(tmp_path: Path, monkeypatch) -> None:
+    missing = tmp_path / "mcp.json"
+    monkeypatch.setattr("kimi_cli.cli.mcp.get_global_mcp_config_file", lambda: missing)
+    assert _load_global_mcp_config() is None
+
+
+def test_load_global_mcp_config_malformed_is_ignored(tmp_path: Path, monkeypatch) -> None:
+    mcp_file = tmp_path / "mcp.json"
+    mcp_file.write_text("{ not valid json", encoding="utf-8")
+    monkeypatch.setattr("kimi_cli.cli.mcp.get_global_mcp_config_file", lambda: mcp_file)
+    # A broken global config must not raise; it is skipped.
+    assert _load_global_mcp_config() is None
+
+
+def test_build_mcp_configs_includes_global_servers(tmp_path: Path, monkeypatch) -> None:
+    mcp_file = tmp_path / "mcp.json"
+    _write_global_config(mcp_file, {"fs-test": {"command": "python", "args": ["-c", "pass"]}})
+    monkeypatch.setattr("kimi_cli.cli.mcp.get_global_mcp_config_file", lambda: mcp_file)
+
+    configs = ACPServer()._build_mcp_configs(None)
+
+    server_names = {name for config in configs for name in config.mcpServers}
+    assert "fs-test" in server_names
+
+
+def test_build_mcp_configs_without_global_config(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "kimi_cli.cli.mcp.get_global_mcp_config_file",
+        lambda: tmp_path / "does-not-exist.json",
+    )
+    # No global config on disk and no client-provided servers -> no MCP servers.
+    configs = ACPServer()._build_mcp_configs(None)
+    server_names = {name for config in configs for name in config.mcpServers}
+    assert server_names == set()


### PR DESCRIPTION
## Summary

`kimi acp` (the multi-session ACP server) never loads the user's globally-configured MCP servers, so ACP clients (Zed, JetBrains AI Assistant, orchestrators) only ever see the built-in tools — a parity gap with interactive `kimi`, which does load them. Fixes #2464.

## Root cause

Interactive `kimi` seeds its MCP configs from the global config file (`<share>/mcp.json`) when no `--mcp-config-file` is passed (`cli/__init__.py`):

```python
if not file_configs:
    default_mcp_file = get_global_mcp_config_file()
    if default_mcp_file.exists():
        file_configs.append(default_mcp_file)
```

The ACP server path (`ACPServer.new_session` / `_setup_session`) only ever built its config from the servers the ACP client passed in the request:

```python
mcp_config = acp_mcp_servers_to_mcp_config(mcp_servers or [])
cli_instance = await KimiCLI.create(session, mcp_configs=[mcp_config], ui_mode="acp")
```

When the client sends no `mcp_servers` (the common case), `acp_mcp_servers_to_mcp_config([])` returns an empty `MCPConfig`, so no MCP servers are ever connected. The globally-configured servers were never consulted, and the callback-level `--mcp-config-file` option is skipped once the `acp` subcommand is invoked.

## Fix

Introduce `_build_mcp_configs()`, which merges the global MCP config (via the same `get_global_mcp_config_file()` used by interactive mode) with any servers the ACP client supplied, and use it in both `new_session` and `_setup_session`. `KimiToolset.load_mcp_tools` already iterates over a list of configs, so passing multiple `MCPConfig`s merges their servers; client-provided servers take precedence on name conflicts (registered last).

A malformed/unreadable global config is logged and skipped (`_load_global_mcp_config` returns `None`) so a broken file cannot abort ACP session creation.

## Tests

Added `tests/acp/test_server_mcp_config.py` covering:
- missing global config file -> `None`
- malformed global config -> ignored, no raise
- global servers appear in the assembled configs
- no global config + no client servers -> no MCP servers

## Verification

Verified by reading the interactive vs. ACP code paths, `KimiCLI.create` / `load_agent` / `KimiToolset.load_mcp_tools` signatures and merge behavior, and `MCPConfig` usage across the codebase. Syntax-checked both files locally with `py_compile`. Not executed (no test run available in this environment).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->