### PR TITLE
fix: shorten_middle output exceeds target width by ellipsis length

### DIFF
--- a/src/kimi_cli/utils/string.py
+++ b/src/kimi_cli/utils/string.py
@@ -32,7 +32,11 @@ def shorten_middle(text: str, width: int, remove_newline: bool = True) -> str:
         return text
     if remove_newline:
         text = _NEWLINE_RE.sub(" ", text)
-    return text[: width // 2] + "..." + text[-width // 2 :]
+    # Account for the 3-character "..." ellipsis.
+    available = max(0, width - 3)
+    left = available // 2
+    right = available - left
+    return text[:left] + "..." + text[-right:] if right > 0 else text[:width]
 
 
 def random_string(length: int = 8) -> str:


### PR DESCRIPTION
## Problem

The `shorten_middle` function in `src/kimi_cli/utils/string.py` does not account for the
3-character `"..."` ellipsis when computing the left and right slice widths.
This causes the output to always be longer than the requested `width` by up to
3 characters.

### Reproducer

```python
>>> from kimi_cli.utils.string import shorten_middle
>>> shorten_middle("abcdefghij", 1)
'...j'       # length 4, expected at most 1
>>> shorten_middle("abcdefghij", 5)
'ab...hij'   # length 8, expected at most 5
>>> shorten_middle("abcdefghij", 8)
'abcd...hij' # length 11, expected at most 8
```

### Root cause

Line 35: `text[: width // 2] + "..." + text[-width // 2 :]`

- The 3-character `"..."` is not subtracted from `width`, so the output is always
  `width + 3` characters long (for `width >= 3`).
- For small widths where `width < 3`, Python's floor division of negative numbers
  (`-width // 2`) gives unexpected slice indices (e.g. `-1 // 2 == -1`, `-2 // 2 == -1`),
  producing even more misleading results.

### Fix

Subtract 3 from the available width before computing half-widths, and handle the
edge case where `width < 3` by falling back to a plain prefix slice:

```python
available = max(0, width - 3)
left = available // 2
right = available - left
return text[:left] + "..." + text[-right:] if right > 0 else text[:width]
```

### Call site impact

The known caller (`src/kimi_cli/tools/__init__.py:97`) uses `width=50`, where the
current code would produce 53-character output instead of 50.

### Verification

Tested locally with the same Python file:

```python
>>> def fixed_shorten_middle(text, width, remove_newline=True):
...     if len(text) <= width:
...         return text
...     import re
...     if remove_newline:
...         text = re.sub(r"[\r\n]+", " ", text)
...     available = max(0, width - 3)
...     left = available // 2
...     right = available - left
...     return text[:left] + "..." + text[-right:] if right > 0 else text[:width]
...
>>> fixed_shorten_middle("abcdefghij", 5)
'a...j'       # length 5, within width ✅
>>> fixed_shorten_middle("abcdefghij", 1)
'a'           # length 1, within width ✅
>>> fixed_shorten_middle("abcdefghij", 8)
'ab...hij'    # length 8, within width ✅
>>> fixed_shorten_middle("abcdefghij", 50)
'abcdefghij'  # already short enough, returned as-is ✅
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->