### PR TITLE
Fix: record started_at for background agent tasks so duration is reported

### DIFF
--- a/src/kimi_cli/background/manager.py
+++ b/src/kimi_cli/background/manager.py
@@ -616,6 +616,13 @@ class BackgroundTaskManager:
             return
         runtime.status = "running"
         runtime.updated_at = time.time()
+        # Record the first transition into "running" as the task's start time so
+        # that completion duration can be computed. Agent tasks reach the
+        # "running" state here (bash tasks set started_at in the worker); guard
+        # against overwriting it because this method is also called again after
+        # each approval is resolved, which would otherwise reset the duration.
+        if runtime.started_at is None:
+            runtime.started_at = runtime.updated_at
         runtime.heartbeat_at = runtime.updated_at
         runtime.failure_reason = None
         self._store.write_runtime(task_id, runtime)

--- a/tests/background/test_manager.py
+++ b/tests/background/test_manager.py
@@ -826,6 +826,47 @@ def test_mark_task_running_and_completed_clear_approval_reason(runtime):
     assert completed.runtime.failure_reason is None
 
 
+def test_mark_task_running_sets_started_at_once(runtime):
+    manager = runtime.background_tasks
+    store = manager.store
+    spec = TaskSpec(
+        id="a4444444",
+        kind="agent",
+        session_id=runtime.session.id,
+        description="started_at task",
+        tool_call_id="tool-started-at",
+        owner_role="root",
+        kind_payload={"agent_id": "aagent", "subagent_type": "coder"},
+    )
+    store.create_task(spec)
+
+    # Freshly created agent tasks have no start time yet.
+    assert store.read_runtime(spec.id).started_at is None
+
+    # The first "running" transition records the start time.
+    manager._mark_task_running(spec.id)
+    first_started_at = store.read_runtime(spec.id).started_at
+    assert first_started_at is not None
+
+    # A later re-mark (e.g. after an approval is resolved) must not reset it,
+    # otherwise the completion duration would only span the last approval gap.
+    store.write_runtime(
+        spec.id,
+        store.read_runtime(spec.id).model_copy(
+            update={"status": "awaiting_approval", "failure_reason": "Need approval"}
+        ),
+    )
+    manager._mark_task_running(spec.id)
+    assert store.read_runtime(spec.id).started_at == first_started_at
+
+    # With started_at set, completion can compute a duration (finished - started).
+    manager._mark_task_completed(spec.id)
+    done = store.read_runtime(spec.id)
+    assert done.started_at == first_started_at
+    assert done.finished_at is not None
+    assert done.finished_at >= done.started_at
+
+
 def test_publish_terminal_notifications_creates_notification(runtime):
     manager = runtime.background_tasks
     store = manager.store


### PR DESCRIPTION
### Problem

Background **agent** tasks never have `runtime.started_at` set, so their run
duration is silently lost. Background **bash** tasks set it correctly.

The only place `started_at` is ever assigned is the bash worker startup
(`background/worker.py`):

```python
runtime.status = "starting"
runtime.worker_pid = os.getpid()
runtime.started_at = time.time()
```

Agent tasks reach the running state through `BackgroundTaskManager._mark_task_running`
(called from `background/agent_runner.py`), which set every startup field
**except** `started_at`:

```python
runtime.status = "running"
runtime.updated_at = time.time()
runtime.heartbeat_at = runtime.updated_at
runtime.failure_reason = None
```

Since `TaskRuntime.started_at` defaults to `None` (`background/models.py`), agent
tasks keep `started_at is None` for their whole lifetime.

### Impact

Downstream consumers guard on `started_at`, so for agent tasks they silently
degrade:

- `publish_terminal_notifications` computes `duration_s = None`, so the completion
  notification omits the `Duration: …` line that bash tasks show.
- `_mark_task_completed` / `_mark_task_failed` / `_mark_task_timed_out` /
  `_mark_task_killed` all gate telemetry on
  `if runtime.started_at and runtime.finished_at:`, which is never true for agent
  tasks — so the `background_task_completed` event (with `duration_s`) is never
  emitted for them.

### Fix

Record the first transition into `running` as the start time in
`_mark_task_running`, mirroring what the bash worker does. The assignment is
guarded by `started_at is None` because `_mark_task_running` is also invoked
again after each approval is resolved; overwriting would otherwise shrink the
measured duration to the last approval gap.

```python
runtime.status = "running"
runtime.updated_at = time.time()
if runtime.started_at is None:
    runtime.started_at = runtime.updated_at
runtime.heartbeat_at = runtime.updated_at
```

This has no effect on bash tasks (they don't go through `_mark_task_running`) and
is a no-op for tasks that already reached a terminal state (the early return
guarding terminal status is untouched).

### Test

Adds `test_mark_task_running_sets_started_at_once`, asserting that the first
`_mark_task_running` sets `started_at`, a subsequent re-mark (e.g. after an
approval) preserves it, and completion then yields `finished_at >= started_at`.

### Verification

- `python -m py_compile` on both changed files: passes.
- New/existing tests verified by reading; not executed in my environment
  (runtime deps such as `kosong`/`kaos` were not installable here).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->