### PR TITLE
fix(kosong): preserve empty-string reasoning_content as ThinkPart

### DIFF
--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Kimi: Preserve empty-string `reasoning_content` as `ThinkPart(think="")` in both streaming and non-streaming responses — previously the truthy check dropped empty deltas, conflating "reasoned but empty" with "no reasoning at all"; the stored (empty) ThinkPart is what makes `_convert_message` emit `reasoning_content` on the next request, so preserved-thinking backends that require the field on every assistant message no longer 400 after a reason-free turn
+
 ## 0.53.0 (2026-04-28)
 
 - Kimi: Fix stale API key after OAuth token refresh — `on_retryable_error` now reads the current `api_key` from the live client instead of the cached `_api_key`, so that OAuth token refreshes applied via `client.api_key` are preserved when the client is rebuilt after a retryable error

--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -437,7 +437,8 @@ class KimiStreamedMessage:
         self._id = response.id
         self._usage = response.usage
         message = response.choices[0].message
-        if reasoning_content := getattr(message, "reasoning_content", None):
+        reasoning_content = getattr(message, "reasoning_content", None)
+        if reasoning_content is not None:
             assert isinstance(reasoning_content, str)
             yield ThinkPart(think=reasoning_content)
         if message.content:
@@ -469,8 +470,12 @@ class KimiStreamedMessage:
 
                 delta = chunk.choices[0].delta
 
-                # convert thinking content
-                if reasoning_content := getattr(delta, "reasoning_content", None):
+                # convert thinking content — an empty string means "reasoned
+                # but empty", not "no reasoning": keep it as a ThinkPart so
+                # the distinction round-trips to the server (preserved-thinking
+                # backends require reasoning_content on every assistant turn)
+                reasoning_content = getattr(delta, "reasoning_content", None)
+                if reasoning_content is not None:
                     assert isinstance(reasoning_content, str)
                     yield ThinkPart(think=reasoning_content)
 

--- a/packages/kosong/tests/api_snapshot_tests/test_kimi.py
+++ b/packages/kosong/tests/api_snapshot_tests/test_kimi.py
@@ -1,13 +1,16 @@
 """Snapshot tests for Kimi chat provider."""
 
 import json
+from collections.abc import AsyncIterator
+from typing import Any
 
 import respx
 from common import COMMON_CASES, Case, make_chat_completion_response, run_test_cases
 from httpx import Response
 from inline_snapshot import snapshot
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
-from kosong.chat_provider.kimi import Kimi
+from kosong.chat_provider.kimi import Kimi, KimiStreamedMessage
 from kosong.message import Message, TextPart, ThinkPart, ToolCall
 from kosong.tooling import Tool
 
@@ -596,3 +599,94 @@ async def test_kimi_with_extra_body_non_thinking_key_shallow_merge():
             pass
         body = json.loads(mock.calls.last.request.content.decode())
         assert body["custom"] == snapshot({"b": 2})
+
+
+def _make_chunk(delta: dict[str, Any], finish_reason: str | None = None) -> ChatCompletionChunk:
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "kimi-k2-thinking",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+    )
+
+
+async def test_kimi_stream_preserves_empty_reasoning_delta():
+    """An empty-string ``reasoning_content`` delta means "reasoned but
+    empty", not "no reasoning" — it must surface as a ThinkPart so the
+    distinction round-trips to the server: preserved-thinking backends
+    require reasoning_content on every assistant message, and the stored
+    ThinkPart (even empty) is what makes _convert_message emit the field."""
+    chunks = [
+        _make_chunk({"reasoning_content": ""}),
+        _make_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "Shell_2",
+                        "type": "function",
+                        "function": {"name": "Shell", "arguments": "{}"},
+                    }
+                ]
+            },
+            finish_reason="stop",
+        ),
+    ]
+
+    async def _aiter() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    stream = KimiStreamedMessage(_aiter())  # type: ignore[arg-type]
+    parts = [part async for part in stream]
+    assert parts[0] == ThinkPart(think="")
+    assert isinstance(parts[1], ToolCall)
+
+
+async def test_kimi_non_stream_preserves_empty_reasoning_content():
+    """Same distinction for the non-streaming path: ``reasoning_content: \"\"``
+    on the response message must yield an (empty) ThinkPart."""
+    response = ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "kimi-k2-thinking",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Done.",
+                        "reasoning_content": "",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    )
+    stream = KimiStreamedMessage(response)
+    parts = [part async for part in stream]
+    assert parts[0] == ThinkPart(think="")
+    assert parts[1] == TextPart(text="Done.")
+
+
+async def test_kimi_absent_reasoning_field_still_yields_no_thinkpart():
+    """A delta WITHOUT the reasoning_content field is the genuinely
+    reason-free case and must NOT fabricate a ThinkPart — the empty vs
+    absent distinction is exactly what preserved thinking relies on."""
+    chunks = [
+        _make_chunk({"content": "Done."}, finish_reason="stop"),
+    ]
+
+    async def _aiter() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    stream = KimiStreamedMessage(_aiter())  # type: ignore[arg-type]
+    parts = [part async for part in stream]
+    assert parts == [TextPart(text="Done.")]


### PR DESCRIPTION
## Related Issue

N/A — caught in a live session via request dump: `coding-model-okapi-0711-vibe` returned 400 `preserved thinking (thinking.keep=all) requires reasoning_content on every assistant message, but assistant message at index 6 is missing reasoning_content`.

## Description

Empty-string `reasoning_content` means "reasoned but empty", not "no reasoning". The truthy checks in the Kimi stream/non-stream converters dropped empty deltas, so a turn whose stream carried `reasoning_content: ""` produced an assistant message with no `ThinkPart` at all. On the next request `_convert_message` then omitted `reasoning_content` for that turn, and preserved-thinking backends (some always-thinking models enforce `thinking.keep=all` by default) reject the request with 400.

Wire-log evidence from the incident session: the failing turn's stream contained only the ToolCall (output = 109 tokens ≈ the tool-call JSON), with no ContentPart at all — the model emitted empty reasoning for that turn.

Changes:

- `kimi.py`: use `is not None` instead of truthy checks in both `_convert_stream_response` and `_convert_non_stream_response`, so empty-string `reasoning_content` yields `ThinkPart(think="")`, which `_convert_message` round-trips as `reasoning_content: ""` via the existing `has_reasoning` path.
- A delta/response with the field genuinely absent still yields no ThinkPart — the empty-vs-absent distinction is preserved.
- Tests: streaming empty delta, non-streaming empty field, and absent field (must not fabricate a ThinkPart).

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->