### PR TITLE
feat(telemetry): align events with TS schema, add trace_id and missing events

### DIFF
--- a/packages/kosong/src/kosong/__init__.py
+++ b/packages/kosong/src/kosong/__init__.py
@@ -109,6 +109,7 @@ async def step(
     *,
     on_message_part: Callback[[StreamedMessagePart], None] | None = None,
     on_tool_result: Callable[[ToolResult], None] | None = None,
+    on_trace_id: Callback[[str | None], None] | None = None,
 ) -> "StepResult":
     """
     Run one agent "step". In one step, the function generates LLM response based on the given
@@ -162,6 +163,7 @@ async def step(
             history,
             on_message_part=on_message_part,
             on_tool_call=on_tool_call,
+            on_trace_id=on_trace_id,
         )
     except (ChatProviderError, asyncio.CancelledError):
         # cancel all the futures to avoid hanging tasks
@@ -177,6 +179,7 @@ async def step(
         result.usage,
         tool_calls,
         tool_result_futures,
+        trace_id=result.trace_id,
     )
 
 
@@ -196,6 +199,9 @@ class StepResult:
 
     _tool_result_futures: dict[str, ToolResultFuture]
     """@private The futures of the results of the spawned tool calls."""
+
+    trace_id: str | None = None
+    """The ``x-trace-id`` response header of the request, if the provider exposes it."""
 
     async def tool_results(self) -> list[ToolResult]:
         """All the tool results returned by corresponding tool calls."""

--- a/packages/kosong/src/kosong/_generate.py
+++ b/packages/kosong/src/kosong/_generate.py
@@ -22,6 +22,7 @@ async def generate(
     *,
     on_message_part: Callback[[StreamedMessagePart], None] | None = None,
     on_tool_call: Callback[[ToolCall], None] | None = None,
+    on_trace_id: Callback[[str | None], None] | None = None,
 ) -> "GenerateResult":
     """
     Generate one message based on the given context.
@@ -34,6 +35,8 @@ async def generate(
         history: The message history to use for generation.
         on_message_part: An optional callback to be called for each raw message part.
         on_tool_call: An optional callback to be called for each complete tool call.
+        on_trace_id: An optional callback fired with the request's ``x-trace-id``
+            response header as soon as it is available (before streaming starts).
 
     Returns:
         A tuple of the generated message and the token usage (if available).
@@ -51,6 +54,10 @@ async def generate(
 
     logger.trace("Generating with history: {history}", history=history)
     stream = await chat_provider.generate(system_prompt, tools, history)
+    if on_trace_id:
+        # getattr for robustness against third-party StreamedMessage
+        # implementations that predate the trace_id property.
+        await callback(on_trace_id, getattr(stream, "trace_id", None))
     async for part in stream:
         logger.trace("Received part: {part}", part=part)
         if on_message_part:
@@ -92,6 +99,7 @@ async def generate(
         id=stream.id,
         message=message,
         usage=stream.usage,
+        trace_id=getattr(stream, "trace_id", None),
     )
 
 
@@ -105,6 +113,8 @@ class GenerateResult:
     """The generated message."""
     usage: TokenUsage | None
     """The token usage of the generated message."""
+    trace_id: str | None = None
+    """The ``x-trace-id`` response header of the request, if the provider exposes it."""
 
 
 def _message_append(message: Message, part: StreamedMessagePart) -> None:

--- a/packages/kosong/src/kosong/chat_provider/__init__.py
+++ b/packages/kosong/src/kosong/chat_provider/__init__.py
@@ -95,6 +95,15 @@ class StreamedMessage(Protocol):
         """The token usage of the streamed message."""
         ...
 
+    @property
+    def trace_id(self) -> str | None:
+        """The ``x-trace-id`` response header of the underlying request, if exposed.
+
+        Only providers talking to the KFC inference service (e.g. Kimi) return a
+        value; all other providers return None.
+        """
+        ...
+
 
 class TokenUsage(BaseModel):
     """Token usage statistics."""
@@ -156,11 +165,20 @@ class APIStatusError(ChatProviderError):
 
     status_code: int
     request_id: str | None
+    trace_id: str | None
 
-    def __init__(self, status_code: int, message: str, *, request_id: str | None = None):
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        *,
+        request_id: str | None = None,
+        trace_id: str | None = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
         self.request_id = request_id
+        self.trace_id = trace_id
 
 
 class APIEmptyResponseError(ChatProviderError):
@@ -183,5 +201,8 @@ def convert_httpx_error(error: httpx.HTTPError) -> ChatProviderError:
         return APIConnectionError(str(error))
     if isinstance(error, httpx.HTTPStatusError):
         req_id = error.response.headers.get("x-request-id")
-        return APIStatusError(error.response.status_code, str(error), request_id=req_id)
+        trace_id = error.response.headers.get("x-trace-id")
+        return APIStatusError(
+            error.response.status_code, str(error), request_id=req_id, trace_id=trace_id
+        )
     return ChatProviderError(f"HTTP error: {error}")

--- a/packages/kosong/src/kosong/chat_provider/__init__.py
+++ b/packages/kosong/src/kosong/chat_provider/__init__.py
@@ -95,15 +95,6 @@ class StreamedMessage(Protocol):
         """The token usage of the streamed message."""
         ...
 
-    @property
-    def trace_id(self) -> str | None:
-        """The ``x-trace-id`` response header of the underlying request, if exposed.
-
-        Only providers talking to the KFC inference service (e.g. Kimi) return a
-        value; all other providers return None.
-        """
-        ...
-
 
 class TokenUsage(BaseModel):
     """Token usage statistics."""

--- a/packages/kosong/src/kosong/chat_provider/chaos.py
+++ b/packages/kosong/src/kosong/chat_provider/chaos.py
@@ -252,7 +252,7 @@ class ChaosStreamedMessage:
 
     @property
     def trace_id(self) -> str | None:
-        return self._wrapped.trace_id
+        return getattr(self._wrapped, "trace_id", None)
 
     def _should_corrupt_tool_call(self) -> bool:
         probability = self._config.corrupt_tool_call_probability

--- a/packages/kosong/src/kosong/chat_provider/chaos.py
+++ b/packages/kosong/src/kosong/chat_provider/chaos.py
@@ -250,6 +250,10 @@ class ChaosStreamedMessage:
     def usage(self) -> TokenUsage | None:
         return self._wrapped.usage
 
+    @property
+    def trace_id(self) -> str | None:
+        return self._wrapped.trace_id
+
     def _should_corrupt_tool_call(self) -> bool:
         probability = self._config.corrupt_tool_call_probability
         return probability > 0 and self._rng.random() < probability

--- a/packages/kosong/src/kosong/chat_provider/echo/echo.py
+++ b/packages/kosong/src/kosong/chat_provider/echo/echo.py
@@ -123,3 +123,7 @@ class EchoStreamedMessage(StreamedMessage):
     @property
     def usage(self) -> TokenUsage | None:
         return self._usage
+
+    @property
+    def trace_id(self) -> str | None:
+        return None

--- a/packages/kosong/src/kosong/chat_provider/echo/scripted_echo.py
+++ b/packages/kosong/src/kosong/chat_provider/echo/scripted_echo.py
@@ -101,3 +101,7 @@ class ScriptedEchoStreamedMessage(StreamedMessage):
     @property
     def usage(self) -> TokenUsage | None:
         return self._usage
+
+    @property
+    def trace_id(self) -> str | None:
+        return None

--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import mimetypes
 import os
 import uuid
@@ -179,7 +180,10 @@ class Kimi:
             # Note: LegacyAPIResponse.parse() is sync in openai SDK 2.x; it will
             # become a coroutine in the next major version.
             trace_id = raw_response.headers.get("x-trace-id")
-            return KimiStreamedMessage(raw_response.parse(), trace_id=trace_id)
+            parsed_response = raw_response.parse()
+            if inspect.isawaitable(parsed_response):
+                parsed_response = await parsed_response
+            return KimiStreamedMessage(parsed_response, trace_id=trace_id)
         except (OpenAIError, httpx.HTTPError) as e:
             raise convert_error(e) from e
 

--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -166,7 +166,7 @@ class Kimi:
             generation_kwargs.pop("max_completion_tokens", None)
 
         try:
-            response = await self.client.chat.completions.create(
+            raw_response = await self.client.chat.completions.with_raw_response.create(
                 model=self.model,
                 messages=messages,
                 tools=(_convert_tool(tool) for tool in tools),
@@ -174,7 +174,12 @@ class Kimi:
                 stream_options={"include_usage": True} if self.stream else omit,
                 **generation_kwargs,
             )
-            return KimiStreamedMessage(response)
+            # The promise resolves as soon as response headers arrive (before the
+            # stream body), so the trace id is available even mid-stream.
+            # Note: LegacyAPIResponse.parse() is sync in openai SDK 2.x; it will
+            # become a coroutine in the next major version.
+            trace_id = raw_response.headers.get("x-trace-id")
+            return KimiStreamedMessage(raw_response.parse(), trace_id=trace_id)
         except (OpenAIError, httpx.HTTPError) as e:
             raise convert_error(e) from e
 
@@ -372,13 +377,19 @@ def _convert_tool(tool: Tool) -> ChatCompletionToolParam:
 class KimiStreamedMessage:
     """The streamed message of the Kimi chat provider."""
 
-    def __init__(self, response: ChatCompletion | AsyncStream[ChatCompletionChunk]):
+    def __init__(
+        self,
+        response: ChatCompletion | AsyncStream[ChatCompletionChunk],
+        *,
+        trace_id: str | None = None,
+    ):
         if isinstance(response, ChatCompletion):
             self._iter = self._convert_non_stream_response(response)
         else:
             self._iter = self._convert_stream_response(response)
         self._id: str | None = None
         self._usage: CompletionUsage | None = None
+        self._trace_id = trace_id
 
     def __aiter__(self) -> AsyncIterator[StreamedMessagePart]:
         return self
@@ -389,6 +400,10 @@ class KimiStreamedMessage:
     @property
     def id(self) -> str | None:
         return self._id
+
+    @property
+    def trace_id(self) -> str | None:
+        return self._trace_id
 
     @property
     def usage(self) -> TokenUsage | None:

--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -167,22 +167,32 @@ class Kimi:
             generation_kwargs.pop("max_completion_tokens", None)
 
         try:
-            raw_response = await self.client.chat.completions.with_raw_response.create(
-                model=self.model,
-                messages=messages,
-                tools=(_convert_tool(tool) for tool in tools),
-                stream=self.stream,
-                stream_options={"include_usage": True} if self.stream else omit,
-                **generation_kwargs,
-            )
-            # The promise resolves as soon as response headers arrive (before the
-            # stream body), so the trace id is available even mid-stream.
-            # Note: LegacyAPIResponse.parse() is sync in openai SDK 2.x; it will
-            # become a coroutine in the next major version.
-            trace_id = raw_response.headers.get("x-trace-id")
-            parsed_response = raw_response.parse()
-            if inspect.isawaitable(parsed_response):
-                parsed_response = await parsed_response
+            if self.stream:
+                # ``with_raw_response`` eagerly reads the response body in the
+                # OpenAI SDK. Use the normal streaming path so callers receive
+                # the AsyncStream as soon as response headers arrive.
+                parsed_response = await cast(Any, self.client.chat.completions.create)(
+                    model=self.model,
+                    messages=messages,
+                    tools=(_convert_tool(tool) for tool in tools),
+                    stream=True,
+                    stream_options={"include_usage": True},
+                    **generation_kwargs,
+                )
+                trace_id = parsed_response.response.headers.get("x-trace-id")
+            else:
+                raw_response = await self.client.chat.completions.with_raw_response.create(
+                    model=self.model,
+                    messages=messages,
+                    tools=(_convert_tool(tool) for tool in tools),
+                    stream=False,
+                    stream_options=omit,
+                    **generation_kwargs,
+                )
+                trace_id = raw_response.headers.get("x-trace-id")
+                parsed_response = raw_response.parse()
+                if inspect.isawaitable(parsed_response):
+                    parsed_response = await parsed_response
             return KimiStreamedMessage(parsed_response, trace_id=trace_id)
         except (OpenAIError, httpx.HTTPError) as e:
             raise convert_error(e) from e

--- a/packages/kosong/src/kosong/chat_provider/mock.py
+++ b/packages/kosong/src/kosong/chat_provider/mock.py
@@ -78,3 +78,7 @@ class MockStreamedMessage(StreamedMessage):
     @property
     def usage(self) -> TokenUsage | None:
         return None
+
+    @property
+    def trace_id(self) -> str | None:
+        return None

--- a/packages/kosong/src/kosong/chat_provider/openai_common.py
+++ b/packages/kosong/src/kosong/chat_provider/openai_common.py
@@ -82,7 +82,10 @@ def convert_error(error: OpenAIError | httpx.HTTPError) -> ChatProviderError:
     match error:
         case openai.APIStatusError():
             req_id = error.response.headers.get("x-request-id")
-            return APIStatusError(error.status_code, error.message, request_id=req_id)
+            trace_id = error.response.headers.get("x-trace-id")
+            return APIStatusError(
+                error.status_code, error.message, request_id=req_id, trace_id=trace_id
+            )
         case openai.APITimeoutError():
             return APITimeoutError(error.message)
         case openai.APIConnectionError():

--- a/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/anthropic.py
@@ -526,6 +526,10 @@ class AnthropicStreamedMessage:
         return self._id
 
     @property
+    def trace_id(self) -> str | None:
+        return None
+
+    @property
     def usage(self) -> TokenUsage | None:
         # https://docs.claude.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
         return TokenUsage(

--- a/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/google_genai.py
@@ -250,6 +250,10 @@ class GoogleGenAIStreamedMessage:
         return self._id
 
     @property
+    def trace_id(self) -> str | None:
+        return None
+
+    @property
     def usage(self) -> TokenUsage | None:
         if self._usage is None:
             return None

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -243,6 +243,10 @@ class OpenAILegacyStreamedMessage:
         return self._id
 
     @property
+    def trace_id(self) -> str | None:
+        return None
+
+    @property
     def usage(self) -> TokenUsage | None:
         if self._usage:
             cached = 0

--- a/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
+++ b/packages/kosong/src/kosong/contrib/chat_provider/openai_responses.py
@@ -475,6 +475,10 @@ class OpenAIResponsesStreamedMessage:
         return self._id
 
     @property
+    def trace_id(self) -> str | None:
+        return None
+
+    @property
     def usage(self) -> TokenUsage | None:
         if self._usage:
             cached = 0

--- a/packages/kosong/tests/test_trace_id.py
+++ b/packages/kosong/tests/test_trace_id.py
@@ -11,12 +11,34 @@ import pytest
 import respx
 
 import kosong
-from kosong.chat_provider import APIStatusError
+from kosong.chat_provider import APIStatusError, StreamedMessage
 from kosong.chat_provider.kimi import Kimi
 from kosong.tooling.empty import EmptyToolset
 
 TRACE_ID = "trace-abc-123"
 URL = "https://api.moonshot.ai/v1/chat/completions"
+
+
+class _LegacyStreamedMessage:
+    """Third-party stream shape from before trace metadata was introduced."""
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    @property
+    def id(self) -> str | None:
+        return None
+
+    @property
+    def usage(self):
+        return None
+
+
+def test_trace_id_does_not_break_legacy_stream_protocol_compatibility():
+    assert isinstance(_LegacyStreamedMessage(), StreamedMessage)
 
 
 def _completion_payload() -> dict[str, object]:

--- a/packages/kosong/tests/test_trace_id.py
+++ b/packages/kosong/tests/test_trace_id.py
@@ -6,9 +6,12 @@ paths) and propagated through ``generate``/``step`` results and the
 ``on_trace_id`` early callback.
 """
 
+from typing import Any, cast
+
 import httpx
 import pytest
 import respx
+from openai.types.chat import ChatCompletion
 
 import kosong
 from kosong.chat_provider import APIStatusError, StreamedMessage
@@ -45,6 +48,7 @@ def _completion_payload() -> dict[str, object]:
     return {
         "id": "chatcmpl-test",
         "object": "chat.completion",
+        "created": 1,
         "model": "test-model",
         "choices": [
             {
@@ -106,6 +110,34 @@ async def test_kimi_streaming_captures_trace_id():
         assert stream.trace_id == TRACE_ID
         parts = [part async for part in stream]
         assert parts
+
+
+@pytest.mark.asyncio
+async def test_kimi_accepts_async_raw_response_parse():
+    class AsyncRawResponse:
+        headers = {"x-trace-id": TRACE_ID}
+
+        async def parse(self):
+            return ChatCompletion.model_validate(_completion_payload())
+
+    class Completions:
+        class WithRawResponse:
+            async def create(self, **kwargs: Any):
+                return AsyncRawResponse()
+
+        with_raw_response = WithRawResponse()
+
+    provider = Kimi(model="test-model", api_key="token", stream=False)
+    cast(Any, provider).client = type(
+        "FakeClient",
+        (),
+        {"chat": type("FakeChat", (), {"completions": Completions()})()},
+    )()
+
+    stream = await provider.generate("", [], [])
+    assert stream.trace_id == TRACE_ID
+    parts = [part async for part in stream]
+    assert parts
 
 
 @pytest.mark.asyncio

--- a/packages/kosong/tests/test_trace_id.py
+++ b/packages/kosong/tests/test_trace_id.py
@@ -1,0 +1,123 @@
+"""Verify ``x-trace-id`` response header capture and propagation.
+
+The KFC inference service returns a trace id in the ``x-trace-id`` response
+header. It must be captured by the Kimi provider (both success and error
+paths) and propagated through ``generate``/``step`` results and the
+``on_trace_id`` early callback.
+"""
+
+import httpx
+import pytest
+import respx
+
+import kosong
+from kosong.chat_provider import APIStatusError
+from kosong.chat_provider.kimi import Kimi
+from kosong.tooling.empty import EmptyToolset
+
+TRACE_ID = "trace-abc-123"
+URL = "https://api.moonshot.ai/v1/chat/completions"
+
+
+def _completion_payload() -> dict[str, object]:
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+@pytest.mark.asyncio
+async def test_kimi_captures_trace_id_header():
+    with respx.mock:
+        respx.post(URL).mock(
+            return_value=httpx.Response(
+                200, json=_completion_payload(), headers={"x-trace-id": TRACE_ID}
+            )
+        )
+        provider = Kimi(model="test-model", api_key="token", stream=False)
+        stream = await provider.generate("", [], [])
+        assert stream.trace_id == TRACE_ID
+        async for _ in stream:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_kimi_trace_id_none_without_header():
+    with respx.mock:
+        respx.post(URL).mock(return_value=httpx.Response(200, json=_completion_payload()))
+        provider = Kimi(model="test-model", api_key="token", stream=False)
+        stream = await provider.generate("", [], [])
+        assert stream.trace_id is None
+
+
+@pytest.mark.asyncio
+async def test_kimi_streaming_captures_trace_id():
+    """Streaming path: with_raw_response resolves at headers, parse() yields the stream."""
+    sse = (
+        'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
+        '"model":"test-model","choices":[{"index":0,'
+        '"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}\n\n'
+        'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
+        '"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],'
+        '"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n'
+        "data: [DONE]\n\n"
+    )
+    with respx.mock:
+        respx.post(URL).mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream", "x-trace-id": TRACE_ID},
+                content=sse,
+            )
+        )
+        provider = Kimi(model="test-model", api_key="token", stream=True)
+        stream = await provider.generate("", [], [])
+        assert stream.trace_id == TRACE_ID
+        parts = [part async for part in stream]
+        assert parts
+
+
+@pytest.mark.asyncio
+async def test_api_status_error_carries_trace_id():
+    with respx.mock:
+        respx.post(URL).mock(
+            return_value=httpx.Response(
+                500,
+                json={"error": {"message": "boom", "type": "server_error"}},
+                headers={"x-trace-id": TRACE_ID},
+            )
+        )
+        provider = Kimi(model="test-model", api_key="token", stream=False)
+        with pytest.raises(APIStatusError) as exc_info:
+            await provider.generate("", [], [])
+        assert exc_info.value.trace_id == TRACE_ID
+
+
+@pytest.mark.asyncio
+async def test_step_result_and_on_trace_id_callback():
+    seen: list[str | None] = []
+    with respx.mock:
+        respx.post(URL).mock(
+            return_value=httpx.Response(
+                200, json=_completion_payload(), headers={"x-trace-id": TRACE_ID}
+            )
+        )
+        provider = Kimi(model="test-model", api_key="token", stream=False)
+        result = await kosong.step(
+            chat_provider=provider,
+            system_prompt="",
+            toolset=EmptyToolset(),
+            history=[],
+            on_trace_id=seen.append,
+        )
+        assert result.trace_id == TRACE_ID
+        assert seen == [TRACE_ID]

--- a/packages/kosong/tests/test_trace_id.py
+++ b/packages/kosong/tests/test_trace_id.py
@@ -87,7 +87,7 @@ async def test_kimi_trace_id_none_without_header():
 
 @pytest.mark.asyncio
 async def test_kimi_streaming_captures_trace_id():
-    """Streaming path: with_raw_response resolves at headers, parse() yields the stream."""
+    """Streaming path returns before the response body is consumed."""
     sse = (
         'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
         '"model":"test-model","choices":[{"index":0,'
@@ -110,6 +110,33 @@ async def test_kimi_streaming_captures_trace_id():
         assert stream.trace_id == TRACE_ID
         parts = [part async for part in stream]
         assert parts
+
+
+@pytest.mark.asyncio
+async def test_kimi_streaming_uses_stream_response_headers():
+    class DelayedStream:
+        response = httpx.Response(200, headers={"x-trace-id": TRACE_ID})
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise AssertionError("the response body must not be consumed in generate")
+
+    class Completions:
+        async def create(self, **kwargs: Any):
+            assert kwargs["stream"] is True
+            return DelayedStream()
+
+    provider = Kimi(model="test-model", api_key="token", stream=True)
+    cast(Any, provider).client = type(
+        "FakeClient",
+        (),
+        {"chat": type("FakeChat", (), {"completions": Completions()})()},
+    )()
+
+    stream = await provider.generate("", [], [])
+    assert stream.trace_id == TRACE_ID
 
 
 @pytest.mark.asyncio

--- a/src/kimi_cli/approval_runtime/models.py
+++ b/src/kimi_cli/approval_runtime/models.py
@@ -34,6 +34,7 @@ class ApprovalRequestRecord:
     resolved_at: float | None = None
     response: ApprovalResponseKind | None = None
     feedback: str = ""
+    approved_via_session_cache: bool = False
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/src/kimi_cli/approval_runtime/runtime.py
+++ b/src/kimi_cli/approval_runtime/runtime.py
@@ -126,13 +126,21 @@ class ApprovalRuntime:
                 if request.status == "pending" and self._waiters.get(request_id) is waiter:
                     self._waiters.pop(request_id, None)
 
-    def resolve(self, request_id: str, response: ApprovalResponseKind, feedback: str = "") -> bool:
+    def resolve(
+        self,
+        request_id: str,
+        response: ApprovalResponseKind,
+        feedback: str = "",
+        *,
+        approved_via_session_cache: bool = False,
+    ) -> bool:
         request = self._requests.get(request_id)
         if request is None or request.status != "pending":
             return False
         request.status = "resolved"
         request.response = response
         request.feedback = feedback
+        request.approved_via_session_cache = approved_via_session_cache
         import time
 
         request.resolved_at = time.time()

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -17,6 +17,7 @@ from kosong.message import (
     VideoURLPart,
 )
 from kosong.tooling import Tool
+from kosong.utils.aio import Callback, callback
 from pydantic import SecretStr
 
 from kimi_cli.constant import USER_AGENT
@@ -112,6 +113,43 @@ class _KimiRequestChatProvider:
         )
 
 
+@dataclass(slots=True)
+class _TraceCallbackChatProvider:
+    _provider: ChatProvider
+    _on_trace_id: Callback[[str | None], None]
+    name: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.name = self._provider.name
+
+    @property
+    def model_name(self) -> str:
+        return self._provider.model_name
+
+    @property
+    def thinking_effort(self) -> ThinkingEffort | None:
+        return self._provider.thinking_effort
+
+    async def generate(
+        self,
+        system_prompt: str,
+        tools: Sequence[Tool],
+        history: Sequence[Message],
+    ) -> StreamedMessage:
+        await callback(self._on_trace_id, None)
+        try:
+            stream = await self._provider.generate(system_prompt, tools, history)
+        except BaseException as error:
+            if trace_id := getattr(error, "trace_id", None):
+                await callback(self._on_trace_id, trace_id)
+            raise
+        await callback(self._on_trace_id, getattr(stream, "trace_id", None))
+        return stream
+
+    def with_thinking(self, effort: ThinkingEffort) -> Self:
+        return type(self)(self._provider.with_thinking(effort), self._on_trace_id)
+
+
 def find_kimi_provider(chat_provider: ChatProvider) -> Kimi | None:
     """Return the Kimi provider backing a supported provider wrapper."""
     from kosong.chat_provider.chaos import ChaosChatProvider
@@ -131,6 +169,13 @@ def with_kimi_generation_overrides(
     if not generation_overrides or find_kimi_provider(chat_provider) is None:
         return chat_provider
     return _KimiRequestChatProvider(chat_provider, dict(generation_overrides))
+
+
+def with_trace_callback(
+    chat_provider: ChatProvider,
+    on_trace_id: Callback[[str | None], None],
+) -> ChatProvider:
+    return _TraceCallbackChatProvider(chat_provider, on_trace_id)
 
 
 def compute_max_completion_tokens(

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -11,7 +11,7 @@ from kimi_cli.approval_runtime import (
     ApprovalSource,
     get_current_approval_source_or_none,
 )
-from kimi_cli.soul.toolset import get_current_tool_call_or_none
+from kimi_cli.soul.toolset import get_current_step_no, get_current_tool_call_or_none
 from kimi_cli.tools.utils import ToolRejectedError
 from kimi_cli.utils.logging import logger
 from kimi_cli.wire.types import DisplayBlock
@@ -35,6 +35,7 @@ def _approval_surface(display: list[DisplayBlock]) -> str:
 
 def _track_permission_result(
     *,
+    step_no: int | None,
     tool_name: str,
     permission_mode: str,
     result: str,
@@ -59,6 +60,8 @@ def _track_permission_result(
         session_cache_written=session_cache_written,
         has_feedback=has_feedback,
     )
+    if step_no is not None:
+        kwargs["step_no"] = step_no
     if tid := get_current_trace_id():
         kwargs["trace_id"] = tid
     track("permission_approval_result", **kwargs)
@@ -224,6 +227,7 @@ class Approval:
         t0 = time.monotonic()
         surface = _approval_surface(display or [])
         _tool_name = tool_call.function.name
+        _step_no = get_current_step_no()
 
         def _elapsed_ms() -> int:
             return int((time.monotonic() - t0) * 1000)
@@ -244,6 +248,7 @@ class Approval:
                 approval_mode="afk" if self.is_afk() else "yolo",
             )
             _track_permission_result(
+                step_no=_step_no,
                 tool_name=_tool_name,
                 permission_mode="auto" if self.is_afk() else "yolo",
                 result="approved",
@@ -263,6 +268,7 @@ class Approval:
                 approval_mode="auto_session",
             )
             _track_permission_result(
+                step_no=_step_no,
                 tool_name=_tool_name,
                 permission_mode="auto",
                 result="approved",
@@ -300,6 +306,7 @@ class Approval:
             )
             record = self._runtime.get_request(request_id)
             _track_permission_result(
+                step_no=_step_no,
                 tool_name=_tool_name,
                 permission_mode="manual",
                 result="cancelled",
@@ -311,6 +318,7 @@ class Approval:
             return ApprovalResult(approved=False, feedback=record.feedback if record else "")
         except Exception:
             _track_permission_result(
+                step_no=_step_no,
                 tool_name=_tool_name,
                 permission_mode="manual",
                 result="error",
@@ -333,6 +341,7 @@ class Approval:
                     approval_mode="auto_session" if approved_via_session_cache else "manual",
                 )
                 _track_permission_result(
+                    step_no=_step_no,
                     tool_name=_tool_name,
                     permission_mode="auto" if approved_via_session_cache else "manual",
                     result="approved",
@@ -349,6 +358,7 @@ class Approval:
                     approval_mode="manual",
                 )
                 _track_permission_result(
+                    step_no=_step_no,
                     tool_name=_tool_name,
                     permission_mode="manual",
                     result="approved_for_session",
@@ -374,6 +384,7 @@ class Approval:
                     approval_mode="manual",
                 )
                 _track_permission_result(
+                    step_no=_step_no,
                     tool_name=_tool_name,
                     permission_mode="manual",
                     result="rejected",
@@ -390,6 +401,7 @@ class Approval:
                     approval_mode="manual",
                 )
                 _track_permission_result(
+                    step_no=_step_no,
                     tool_name=_tool_name,
                     permission_mode="manual",
                     result="rejected",

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import time
 import uuid
 from collections.abc import Callable
-from typing import Literal
+from typing import Any, Literal
 
 from kimi_cli.approval_runtime import (
     ApprovalCancelledError,
@@ -16,6 +17,51 @@ from kimi_cli.utils.logging import logger
 from kimi_cli.wire.types import DisplayBlock
 
 type Response = Literal["approve", "approve_for_session", "reject"]
+
+# Maps DisplayBlock.type to the TS approval_surface vocabulary.
+_SURFACE_BY_BLOCK_TYPE = {
+    "shell": "command",
+    "diff": "diff",
+    "todo": "todo_list",
+    "background_task": "task",
+}
+
+
+def _approval_surface(display: list[DisplayBlock]) -> str:
+    if not display:
+        return "generic"
+    return _SURFACE_BY_BLOCK_TYPE.get(display[0].type, "generic")
+
+
+def _track_permission_result(
+    *,
+    tool_name: str,
+    permission_mode: str,
+    result: str,
+    approval_surface: str,
+    duration_ms: int,
+    session_cache_written: bool,
+    has_feedback: bool,
+) -> None:
+    """Emit permission_approval_result (TS permissionGateService parity).
+
+    ``policy_name`` is always None — Python has no policy system.
+    """
+    from kimi_cli.telemetry import get_current_trace_id, track
+
+    kwargs: dict[str, Any] = dict(
+        policy_name=None,
+        tool_name=tool_name,
+        permission_mode=permission_mode,
+        result=result,
+        approval_surface=approval_surface,
+        duration_ms=duration_ms,
+        session_cache_written=session_cache_written,
+        has_feedback=has_feedback,
+    )
+    if tid := get_current_trace_id():
+        kwargs["trace_id"] = tid
+    track("permission_approval_result", **kwargs)
 
 
 class ApprovalResult:
@@ -175,6 +221,13 @@ class Approval:
         if tool_call is None:
             raise RuntimeError("Approval must be requested from a tool call.")
 
+        t0 = time.monotonic()
+        surface = _approval_surface(display or [])
+        _tool_name = tool_call.function.name
+
+        def _elapsed_ms() -> int:
+            return int((time.monotonic() - t0) * 1000)
+
         logger.debug(
             "{tool_name} ({tool_call_id}) requesting approval: {action} {description}",
             tool_name=tool_call.function.name,
@@ -190,6 +243,15 @@ class Approval:
                 tool_name=tool_call.function.name,
                 approval_mode="afk" if self.is_afk() else "yolo",
             )
+            _track_permission_result(
+                tool_name=_tool_name,
+                permission_mode="auto" if self.is_afk() else "yolo",
+                result="approved",
+                approval_surface=surface,
+                duration_ms=_elapsed_ms(),
+                session_cache_written=False,
+                has_feedback=False,
+            )
             return ApprovalResult(approved=True)
 
         if action in self._state.auto_approve_actions:
@@ -199,6 +261,15 @@ class Approval:
                 "tool_approved",
                 tool_name=tool_call.function.name,
                 approval_mode="auto_session",
+            )
+            _track_permission_result(
+                tool_name=_tool_name,
+                permission_mode="auto",
+                result="approved",
+                approval_surface=surface,
+                duration_ms=_elapsed_ms(),
+                session_cache_written=False,
+                has_feedback=False,
             )
             return ApprovalResult(approved=True)
 
@@ -228,7 +299,27 @@ class Approval:
                 approval_mode="cancelled",
             )
             record = self._runtime.get_request(request_id)
+            _track_permission_result(
+                tool_name=_tool_name,
+                permission_mode="manual",
+                result="cancelled",
+                approval_surface=surface,
+                duration_ms=_elapsed_ms(),
+                session_cache_written=False,
+                has_feedback=bool(record and record.feedback),
+            )
             return ApprovalResult(approved=False, feedback=record.feedback if record else "")
+        except Exception:
+            _track_permission_result(
+                tool_name=_tool_name,
+                permission_mode="manual",
+                result="error",
+                approval_surface=surface,
+                duration_ms=_elapsed_ms(),
+                session_cache_written=False,
+                has_feedback=False,
+            )
+            raise
         from kimi_cli.telemetry import track
 
         match response:
@@ -238,12 +329,30 @@ class Approval:
                     tool_name=tool_call.function.name,
                     approval_mode="manual",
                 )
+                _track_permission_result(
+                    tool_name=_tool_name,
+                    permission_mode="manual",
+                    result="approved",
+                    approval_surface=surface,
+                    duration_ms=_elapsed_ms(),
+                    session_cache_written=False,
+                    has_feedback=False,
+                )
                 return ApprovalResult(approved=True)
             case "approve_for_session":
                 track(
                     "tool_approved",
                     tool_name=tool_call.function.name,
                     approval_mode="manual",
+                )
+                _track_permission_result(
+                    tool_name=_tool_name,
+                    permission_mode="manual",
+                    result="approved_for_session",
+                    approval_surface=surface,
+                    duration_ms=_elapsed_ms(),
+                    session_cache_written=True,
+                    has_feedback=False,
                 )
                 self._state.auto_approve_actions.add(action)
                 self._state.notify_change()
@@ -257,11 +366,29 @@ class Approval:
                     tool_name=tool_call.function.name,
                     approval_mode="manual",
                 )
+                _track_permission_result(
+                    tool_name=_tool_name,
+                    permission_mode="manual",
+                    result="rejected",
+                    approval_surface=surface,
+                    duration_ms=_elapsed_ms(),
+                    session_cache_written=False,
+                    has_feedback=bool(feedback),
+                )
                 return ApprovalResult(approved=False, feedback=feedback)
             case _:
                 track(
                     "tool_rejected",
                     tool_name=tool_call.function.name,
                     approval_mode="manual",
+                )
+                _track_permission_result(
+                    tool_name=_tool_name,
+                    permission_mode="manual",
+                    result="rejected",
+                    approval_surface=surface,
+                    duration_ms=_elapsed_ms(),
+                    session_cache_written=False,
+                    has_feedback=False,
                 )
                 return ApprovalResult(approved=False)

--- a/src/kimi_cli/soul/approval.py
+++ b/src/kimi_cli/soul/approval.py
@@ -322,16 +322,19 @@ class Approval:
             raise
         from kimi_cli.telemetry import track
 
+        record = self._runtime.get_request(request_id)
+        approved_via_session_cache = bool(record and record.approved_via_session_cache)
+
         match response:
             case "approve":
                 track(
                     "tool_approved",
                     tool_name=tool_call.function.name,
-                    approval_mode="manual",
+                    approval_mode="auto_session" if approved_via_session_cache else "manual",
                 )
                 _track_permission_result(
                     tool_name=_tool_name,
-                    permission_mode="manual",
+                    permission_mode="auto" if approved_via_session_cache else "manual",
                     result="approved",
                     approval_surface=surface,
                     duration_ms=_elapsed_ms(),
@@ -358,7 +361,11 @@ class Approval:
                 self._state.notify_change()
                 for pending in self._runtime.list_pending():
                     if pending.action == action:
-                        self._runtime.resolve(pending.id, "approve")
+                        self._runtime.resolve(
+                            pending.id,
+                            "approve",
+                            approved_via_session_cache=True,
+                        )
                 return ApprovalResult(approved=True)
             case "reject":
                 track(

--- a/src/kimi_cli/soul/compaction.py
+++ b/src/kimi_cli/soul/compaction.py
@@ -21,6 +21,7 @@ COMPACTION_OUTPUT_PREFIX = "Previous context has been compacted. Here is the com
 class CompactionResult(NamedTuple):
     messages: Sequence[Message]
     usage: TokenUsage | None
+    trace_id: str | None = None
 
     @property
     def estimated_token_count(self) -> int:
@@ -142,7 +143,9 @@ class SimpleCompaction:
         content.extend(part for part in compacted_msg.content if not isinstance(part, ThinkPart))
         compacted_messages: list[Message] = [Message(role="user", content=content)]
         compacted_messages.extend(to_preserve)
-        return CompactionResult(messages=compacted_messages, usage=result.usage)
+        return CompactionResult(
+            messages=compacted_messages, usage=result.usage, trace_id=result.trace_id
+        )
 
     class PrepareResult(NamedTuple):
         compact_message: Message | None

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -260,7 +260,6 @@ class KimiSoul:
         self._last_tool_calls: list[tuple[str, str]] = []
         self._plan_mode: bool = self._runtime.session.state.plan_mode
         self._plan_session_id: str | None = self._runtime.session.state.plan_session_id
-        self._current_turn_id: str = ""
         self._root_trace_id: str | None = None
         # Pre-warm slug cache so the persisted slug survives process restarts
         if self._plan_session_id is not None and self._runtime.session.state.plan_slug is not None:
@@ -669,9 +668,6 @@ class KimiSoul:
         turn_finished = False
         interrupt_reason: str | None = None
         turn_t0 = time.monotonic()
-        # Reset per-turn state so slash-only / hook-blocked runs (which never
-        # reach _turn()) don't carry the previous turn's id into turn_ended.
-        self._current_turn_id = ""
         self._set_trace_id(None)
         if get_current_approval_source_or_none() is None:
             created_approval_source = ApprovalSource(kind="foreground_turn", id=uuid.uuid4().hex)
@@ -829,8 +825,6 @@ class KimiSoul:
                     duration_ms=int((time.monotonic() - turn_t0) * 1000),
                     mode="plan" if self._plan_mode else "agent",
                 )
-                if self._current_turn_id:
-                    _ended_kwargs["turn_id"] = self._current_turn_id
                 _ended_kwargs.update(_provider_telemetry_kwargs(self._runtime.llm))
                 if _tid := get_current_trace_id():
                     _ended_kwargs["trace_id"] = _tid
@@ -851,7 +845,6 @@ class KimiSoul:
         if missing_caps := check_message(user_message, self._runtime.llm.capabilities):
             raise LLMNotSupported(self._runtime.llm, list(missing_caps))
 
-        self._current_turn_id = uuid.uuid4().hex
         self._last_tool_calls = []
         await self._checkpoint()  # this creates the checkpoint 0 on first run
         await self._context.append_message(user_message)

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -34,11 +34,13 @@ from kimi_cli.background import build_active_task_snapshot
 from kimi_cli.hooks.engine import HookEngine
 from kimi_cli.llm import (
     DEFAULT_COMPLETION_TOKEN_SAFETY_MARGIN,
+    LLM,
     ModelCapability,
     compute_max_completion_tokens,
     estimate_request_tokens,
     find_kimi_provider,
     with_kimi_generation_overrides,
+    with_trace_callback,
 )
 from kimi_cli.notifications import (
     NotificationView,
@@ -168,6 +170,40 @@ def is_retryable_api_error(e: Exception) -> bool:
     if isinstance(e, APIStatusError):
         return e.status_code in _RETRYABLE_STATUS_CODES
     return isinstance(e, ChatProviderError)
+
+
+def _provider_telemetry_kwargs(llm: LLM | None) -> dict[str, str]:
+    if llm is None or llm.provider_config is None:
+        return {}
+    provider_type = llm.provider_config.type
+    return {"provider_type": provider_type, "protocol": provider_type}
+
+
+def _track_api_error(
+    error: ChatProviderError,
+    *,
+    llm: LLM,
+    duration_ms: int,
+    input_tokens: int | None = None,
+) -> None:
+    from kimi_cli.telemetry import get_current_trace_id, track
+
+    error_type, status_code = classify_api_error(error)
+    properties: dict[str, Any] = {
+        "error_type": error_type,
+        "model": llm.model_name,
+        "retryable": is_retryable_api_error(error),
+        "duration_ms": duration_ms,
+        **_provider_telemetry_kwargs(llm),
+    }
+    if status_code is not None:
+        properties["status_code"] = status_code
+    if input_tokens is not None and input_tokens > 0:
+        properties["input_tokens"] = input_tokens
+    trace_id = getattr(error, "trace_id", None) or get_current_trace_id()
+    if trace_id:
+        properties["trace_id"] = trace_id
+    track("api_error", **properties)
 
 
 type StepStopReason = Literal["no_tool_calls", "tool_rejected", "tool_call_repeat"]
@@ -623,6 +659,9 @@ class KimiSoul:
         # Reset per-turn state so slash-only / hook-blocked runs (which never
         # reach _turn()) don't carry the previous turn's id into turn_ended.
         self._current_turn_id = ""
+        from kimi_cli.telemetry import set_current_trace_id
+
+        set_current_trace_id(None, root=self.is_root)
         if get_current_approval_source_or_none() is None:
             created_approval_source = ApprovalSource(kind="foreground_turn", id=uuid.uuid4().hex)
             approval_source_token = set_current_approval_source(created_approval_source)
@@ -668,7 +707,11 @@ class KimiSoul:
             turn_started = True
             from kimi_cli.telemetry import track as _track_telemetry
 
-            _track_telemetry("turn_started", mode="plan" if self._plan_mode else "agent")
+            _track_telemetry(
+                "turn_started",
+                mode="plan" if self._plan_mode else "agent",
+                **_provider_telemetry_kwargs(self._runtime.llm),
+            )
             user_message = Message(role="user", content=user_input)
             text_input = user_message.extract_text(" ").strip()
 
@@ -755,6 +798,7 @@ class KimiSoul:
                     mode="plan" if self._plan_mode else "agent",
                     at_step=getattr(self, "_current_step_no", 0),
                     interrupt_reason=interrupt_reason or "error",
+                    **_provider_telemetry_kwargs(self._runtime.llm),
                 )
                 if _tid := get_current_trace_id():
                     _interrupt_kwargs["trace_id"] = _tid
@@ -776,9 +820,7 @@ class KimiSoul:
                 )
                 if self._current_turn_id:
                     _ended_kwargs["turn_id"] = self._current_turn_id
-                if self._runtime.llm is not None and self._runtime.llm.provider_config is not None:
-                    _ended_kwargs["provider_type"] = self._runtime.llm.provider_config.type
-                    _ended_kwargs["protocol"] = self._runtime.llm.provider_config.type
+                _ended_kwargs.update(_provider_telemetry_kwargs(self._runtime.llm))
                 if _tid := get_current_trace_id():
                     _ended_kwargs["trace_id"] = _tid
                 _track_ended("turn_ended", **_ended_kwargs)
@@ -789,6 +831,7 @@ class KimiSoul:
                 )
             if approval_source_token is not None:
                 reset_current_approval_source(approval_source_token)
+            set_current_trace_id(None, root=self.is_root)
 
     async def _turn(self, user_message: Message) -> TurnOutcome:
         if self._runtime.llm is None:
@@ -1009,31 +1052,6 @@ class KimiSoul:
                 )
                 wire_send(StepInterrupted())
 
-                # Track API/step errors
-                from kimi_cli.telemetry import track
-
-                error_type, status_code = classify_api_error(e)
-                track_kwargs: dict[str, Any] = {
-                    "error_type": error_type,
-                    "retryable": is_retryable_api_error(e),
-                }
-                if status_code is not None:
-                    track_kwargs["status_code"] = status_code
-                # Enrich with context attached by _step() (model, duration, input_tokens)
-                _kimi_ctx = getattr(e, "_kimi_api_error_context", None)
-                if _kimi_ctx is not None:
-                    for key in (
-                        "model",
-                        "duration_ms",
-                        "input_tokens",
-                        "provider_type",
-                        "protocol",
-                        "trace_id",
-                    ):
-                        if key in _kimi_ctx:
-                            track_kwargs[key] = _kimi_ctx[key]
-                track("api_error", **track_kwargs)
-
                 # --- StopFailure hook ---
                 from kimi_cli.hooks import events as _hook_events
 
@@ -1166,6 +1184,12 @@ class KimiSoul:
             input_tokens_floor=self._context.token_count_with_pending,
         )
         request_chat_provider = with_kimi_generation_overrides(chat_provider, generation_overrides)
+        from kimi_cli.telemetry import set_current_trace_id
+
+        request_chat_provider = with_trace_callback(
+            request_chat_provider,
+            lambda trace_id: set_current_trace_id(trace_id, root=self.is_root),
+        )
 
         # ═══════════════════════════════════════════════════════════════════════
         # 2e.4. LLM CALL WITH RETRY
@@ -1174,11 +1198,12 @@ class KimiSoul:
             """Single LLM invocation (wrapped by retry + connection recovery)."""
             # ── 2e.4.1. Toolset begin_step ────────────────────────────────────
             if isinstance(self._agent.toolset, KimiToolset):
-                self._agent.toolset.begin_step(self._last_tool_calls)
+                self._agent.toolset.begin_step(
+                    self._last_tool_calls,
+                    step_no=self._current_step_no,
+                )
             # ── 2e.4.2. kosong.step ───────────────────────────────────────────
             # run an LLM step (may be interrupted)
-            from kimi_cli.telemetry import set_current_trace_id
-
             return await kosong.step(
                 request_chat_provider,
                 self._agent.system_prompt,
@@ -1186,9 +1211,6 @@ class KimiSoul:
                 effective_history,
                 on_message_part=wire_send,
                 on_tool_result=wire_send,
-                # Fired as soon as response headers arrive, before streaming —
-                # tool tasks spawned mid-stream therefore see the trace id.
-                on_trace_id=lambda tid: set_current_trace_id(tid, root=self.is_root),
             )
 
         max_attempts = self._loop_control.max_retries_per_step
@@ -1215,21 +1237,13 @@ class KimiSoul:
         try:
             result = await _kosong_step_with_retry()
         except Exception as _step_exc:
-            # Attach known context so the outer loop can enrich api_error telemetry
-            _ctx: dict[str, Any] = {
-                "model": self._runtime.llm.model_name,
-                "duration_ms": int((time.monotonic() - t0) * 1000),
-            }
-            if self._runtime.llm.provider_config is not None:
-                _ctx["provider_type"] = self._runtime.llm.provider_config.type
-                _ctx["protocol"] = self._runtime.llm.provider_config.type
-            if self._context.token_count > 0:
-                _ctx["input_tokens"] = self._context.token_count
-            # Trace id of the failed request (absent for network-layer errors,
-            # which never received response headers).
-            if isinstance(_step_exc, APIStatusError) and _step_exc.trace_id:
-                _ctx["trace_id"] = _step_exc.trace_id
-            _step_exc._kimi_api_error_context = _ctx  # type: ignore[attr-defined]
+            if isinstance(_step_exc, ChatProviderError):
+                _track_api_error(
+                    _step_exc,
+                    llm=self._runtime.llm,
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                    input_tokens=self._context.token_count,
+                )
             raise
 
         # ═══════════════════════════════════════════════════════════════════════
@@ -1462,12 +1476,19 @@ class KimiSoul:
         async def _run_compaction_once() -> CompactionResult:
             if self._runtime.llm is None:
                 raise LLMNotSet()
+            request_provider = with_kimi_generation_overrides(
+                self._runtime.llm.chat_provider,
+                compaction_overrides,
+            )
+            from kimi_cli.telemetry import set_current_trace_id
+
+            request_provider = with_trace_callback(
+                request_provider,
+                lambda trace_id: set_current_trace_id(trace_id, root=self.is_root),
+            )
             compaction_llm = replace(
                 self._runtime.llm,
-                chat_provider=with_kimi_generation_overrides(
-                    self._runtime.llm.chat_provider,
-                    compaction_overrides,
-                ),
+                chat_provider=request_provider,
             )
             return await self._compaction.compact(
                 self._context.history,
@@ -1521,7 +1542,15 @@ class KimiSoul:
         try:
             compaction_result = await _compact_with_retry()
         except Exception as _compact_exc:
-            from kimi_cli.telemetry import track
+            from kimi_cli.telemetry import get_current_trace_id, track
+
+            if isinstance(_compact_exc, ChatProviderError) and self._runtime.llm is not None:
+                _track_api_error(
+                    _compact_exc,
+                    llm=self._runtime.llm,
+                    duration_ms=int((time.monotonic() - start_time) * 1000),
+                    input_tokens=before_tokens,
+                )
 
             failed_kwargs: dict[str, Any] = dict(
                 source="auto" if trigger_reason == "auto" else "manual",
@@ -1537,7 +1566,7 @@ class KimiSoul:
                 error_type=type(_compact_exc).__name__,
             )
             # Trace id of the failed compaction request (absent for network errors)
-            if _exc_trace_id := getattr(_compact_exc, "trace_id", None):
+            if _exc_trace_id := (getattr(_compact_exc, "trace_id", None) or get_current_trace_id()):
                 failed_kwargs["trace_id"] = _exc_trace_id
             track("compaction_failed", **failed_kwargs)
             raise

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -17,6 +17,7 @@ from kosong.chat_provider import (
     APIStatusError,
     APITimeoutError,
     ChatProvider,
+    ChatProviderError,
     RetryableChatProvider,
 )
 from kosong.message import Message
@@ -125,6 +126,8 @@ def classify_api_error(e: Exception) -> tuple[str, int | None]:
             return "rate_limit", status_code
         if status in (401, 403):
             return "auth", status_code
+        if status == 529:
+            return "overloaded", status_code
         if status >= 500:
             return "5xx_server", status_code
         if 400 <= status < 500:
@@ -138,7 +141,7 @@ def classify_api_error(e: Exception) -> tuple[str, int | None]:
             ):
                 return "context_overflow", status_code
             return "4xx_client", status_code
-        return "api", status_code
+        return "other", status_code
     if isinstance(e, APIConnectionError):
         return "network", None
     if isinstance(e, (APITimeoutError, TimeoutError)):
@@ -146,6 +149,25 @@ def classify_api_error(e: Exception) -> tuple[str, int | None]:
     if isinstance(e, APIEmptyResponseError):
         return "empty_response", None
     return "other", None
+
+
+_RETRYABLE_STATUS_CODES = frozenset({408, 409, 429, 500, 502, 503, 504, 529})
+
+
+def is_retryable_api_error(e: Exception) -> bool:
+    """Classify retryability for the ``api_error`` telemetry event.
+
+    Aligned with the TS ``isRetryableGenerateError``: the listed status codes
+    (including 529 overloaded) count as retryable, and any ChatProviderError
+    (network/timeout/empty-response) counts as retryable by the fallback rule.
+
+    Deliberately separate from ``KimiSoul._is_retryable_error``, which drives
+    the tenacity retry loop — the Python retry loop does not currently retry
+    408/409/529, but telemetry must report the TS-comparable value.
+    """
+    if isinstance(e, APIStatusError):
+        return e.status_code in _RETRYABLE_STATUS_CODES
+    return isinstance(e, ChatProviderError)
 
 
 type StepStopReason = Literal["no_tool_calls", "tool_rejected", "tool_call_repeat"]
@@ -596,6 +618,11 @@ class KimiSoul:
         created_approval_source: ApprovalSource | None = None
         turn_started = False
         turn_finished = False
+        interrupt_reason: str | None = None
+        turn_t0 = time.monotonic()
+        # Reset per-turn state so slash-only / hook-blocked runs (which never
+        # reach _turn()) don't carry the previous turn's id into turn_ended.
+        self._current_turn_id = ""
         if get_current_approval_source_or_none() is None:
             created_approval_source = ApprovalSource(kind="foreground_turn", id=uuid.uuid4().hex)
             approval_source_token = set_current_approval_source(created_approval_source)
@@ -708,16 +735,53 @@ class KimiSoul:
                             fresh.custom_title = title
                             save_session_state(fresh, session.dir)
                         session.state.custom_title = fresh.custom_title
+        except MaxStepsReached:
+            interrupt_reason = "max_steps"
+            raise
+        except asyncio.CancelledError:
+            interrupt_reason = "user_cancelled"
+            raise
+        except Exception:
+            interrupt_reason = "error"
+            raise
         finally:
+            from kimi_cli.telemetry import get_current_trace_id
+
             if turn_started and not turn_finished:
                 wire_send(TurnEnd())
                 from kimi_cli.telemetry import track as _track_telemetry
 
-                _track_telemetry(
-                    "turn_interrupted",
+                _interrupt_kwargs: dict[str, Any] = dict(
                     mode="plan" if self._plan_mode else "agent",
                     at_step=getattr(self, "_current_step_no", 0),
+                    interrupt_reason=interrupt_reason or "error",
                 )
+                if _tid := get_current_trace_id():
+                    _interrupt_kwargs["trace_id"] = _tid
+                _track_telemetry("turn_interrupted", **_interrupt_kwargs)
+            if turn_started:
+                # turn_ended fires unconditionally once a turn began (TS parity).
+                from kimi_cli.telemetry import track as _track_ended
+
+                _ended_kwargs: dict[str, Any] = dict(
+                    reason=(
+                        "completed"
+                        if turn_finished
+                        else "cancelled"
+                        if interrupt_reason == "user_cancelled"
+                        else "failed"
+                    ),
+                    duration_ms=int((time.monotonic() - turn_t0) * 1000),
+                    mode="plan" if self._plan_mode else "agent",
+                )
+                if self._current_turn_id:
+                    _ended_kwargs["turn_id"] = self._current_turn_id
+                if self._runtime.llm is not None and self._runtime.llm.provider_config is not None:
+                    _ended_kwargs["provider_type"] = self._runtime.llm.provider_config.type
+                    _ended_kwargs["protocol"] = self._runtime.llm.provider_config.type
+                if _tid := get_current_trace_id():
+                    _ended_kwargs["trace_id"] = _tid
+                _track_ended("turn_ended", **_ended_kwargs)
             if created_approval_source is not None and self._runtime.approval_runtime is not None:
                 self._runtime.approval_runtime.cancel_by_source(
                     created_approval_source.kind,
@@ -949,13 +1013,23 @@ class KimiSoul:
                 from kimi_cli.telemetry import track
 
                 error_type, status_code = classify_api_error(e)
-                track_kwargs: dict[str, Any] = {"error_type": error_type}
+                track_kwargs: dict[str, Any] = {
+                    "error_type": error_type,
+                    "retryable": is_retryable_api_error(e),
+                }
                 if status_code is not None:
                     track_kwargs["status_code"] = status_code
                 # Enrich with context attached by _step() (model, duration, input_tokens)
                 _kimi_ctx = getattr(e, "_kimi_api_error_context", None)
                 if _kimi_ctx is not None:
-                    for key in ("model", "duration_ms", "input_tokens"):
+                    for key in (
+                        "model",
+                        "duration_ms",
+                        "input_tokens",
+                        "provider_type",
+                        "protocol",
+                        "trace_id",
+                    ):
                         if key in _kimi_ctx:
                             track_kwargs[key] = _kimi_ctx[key]
                 track("api_error", **track_kwargs)
@@ -1003,6 +1077,8 @@ class KimiSoul:
             if back_to_the_future is not None:
                 # Revert context to the checkpoint and inject D-Mail message.
                 await self._context.revert_to(back_to_the_future.checkpoint_id)
+                # KimiToolset.begin_step resets dedup/repeat state when the
+                # previous-call list is empty, so the next step starts clean.
                 self._last_tool_calls = []
                 await self._checkpoint()
                 await self._context.append_message(back_to_the_future.messages)
@@ -1101,6 +1177,8 @@ class KimiSoul:
                 self._agent.toolset.begin_step(self._last_tool_calls)
             # ── 2e.4.2. kosong.step ───────────────────────────────────────────
             # run an LLM step (may be interrupted)
+            from kimi_cli.telemetry import set_current_trace_id
+
             return await kosong.step(
                 request_chat_provider,
                 self._agent.system_prompt,
@@ -1108,6 +1186,9 @@ class KimiSoul:
                 effective_history,
                 on_message_part=wire_send,
                 on_tool_result=wire_send,
+                # Fired as soon as response headers arrive, before streaming —
+                # tool tasks spawned mid-stream therefore see the trace id.
+                on_trace_id=lambda tid: set_current_trace_id(tid, root=self.is_root),
             )
 
         max_attempts = self._loop_control.max_retries_per_step
@@ -1139,8 +1220,15 @@ class KimiSoul:
                 "model": self._runtime.llm.model_name,
                 "duration_ms": int((time.monotonic() - t0) * 1000),
             }
+            if self._runtime.llm.provider_config is not None:
+                _ctx["provider_type"] = self._runtime.llm.provider_config.type
+                _ctx["protocol"] = self._runtime.llm.provider_config.type
             if self._context.token_count > 0:
                 _ctx["input_tokens"] = self._context.token_count
+            # Trace id of the failed request (absent for network-layer errors,
+            # which never received response headers).
+            if isinstance(_step_exc, APIStatusError) and _step_exc.trace_id:
+                _ctx["trace_id"] = _step_exc.trace_id
             _step_exc._kimi_api_error_context = _ctx  # type: ignore[attr-defined]
             raise
 
@@ -1435,15 +1523,28 @@ class KimiSoul:
         except Exception as _compact_exc:
             from kimi_cli.telemetry import track
 
-            track(
-                "compaction_failed",
-                trigger_type=trigger_reason,
-                before_tokens=before_tokens,
+            failed_kwargs: dict[str, Any] = dict(
+                source="auto" if trigger_reason == "auto" else "manual",
+                tokens_before=before_tokens,
                 duration_ms=int((time.monotonic() - start_time) * 1000),
+                round=1,
                 retry_count=retry_count,
+                thinking_effort=(
+                    self._runtime.llm.chat_provider.thinking_effort or "unknown"
+                    if self._runtime.llm is not None
+                    else "unknown"
+                ),
                 error_type=type(_compact_exc).__name__,
             )
+            # Trace id of the failed compaction request (absent for network errors)
+            if _exc_trace_id := getattr(_compact_exc, "trace_id", None):
+                failed_kwargs["trace_id"] = _exc_trace_id
+            track("compaction_failed", **failed_kwargs)
             raise
+        from kimi_cli.telemetry import set_current_trace_id
+
+        set_current_trace_id(compaction_result.trace_id, root=self.is_root)
+        history_count_before = len(self._context.history)
         await self._context.clear()
         await self._context.write_system_prompt(self._agent.system_prompt)
         await self._checkpoint()
@@ -1481,15 +1582,24 @@ class KimiSoul:
 
         duration_ms = int((time.monotonic() - start_time) * 1000)
         track_kwargs = dict(
-            trigger_type=trigger_reason,
-            before_tokens=before_tokens,
-            after_tokens=estimated_token_count,
+            source="auto" if trigger_reason == "auto" else "manual",
+            tokens_before=before_tokens,
+            tokens_after=estimated_token_count,
             duration_ms=duration_ms,
+            compacted_count=max(0, history_count_before - (len(compaction_result.messages) - 1)),
+            round=1,
             retry_count=retry_count,
+            thinking_effort=(
+                self._runtime.llm.chat_provider.thinking_effort or "unknown"
+                if self._runtime.llm is not None
+                else "unknown"
+            ),
         )
         if compaction_result.usage is not None:
-            track_kwargs["llm_input_tokens"] = compaction_result.usage.input
-            track_kwargs["llm_output_tokens"] = compaction_result.usage.output
+            track_kwargs["input_tokens"] = compaction_result.usage.input
+            track_kwargs["output_tokens"] = compaction_result.usage.output
+        if compaction_result.trace_id is not None:
+            track_kwargs["trace_id"] = compaction_result.trace_id
         track("compaction_finished", **track_kwargs)
 
         _hook_task = asyncio.create_task(

--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -261,6 +261,7 @@ class KimiSoul:
         self._plan_mode: bool = self._runtime.session.state.plan_mode
         self._plan_session_id: str | None = self._runtime.session.state.plan_session_id
         self._current_turn_id: str = ""
+        self._root_trace_id: str | None = None
         # Pre-warm slug cache so the persisted slug survives process restarts
         if self._plan_session_id is not None and self._runtime.session.state.plan_slug is not None:
             from kimi_cli.tools.plan.heroes import seed_slug_cache
@@ -331,6 +332,18 @@ class KimiSoul:
     def is_subagent(self) -> bool:
         """Whether this soul is running as a subagent rather than the root session."""
         return self._runtime.role == "subagent"
+
+    @property
+    def root_trace_id(self) -> str | None:
+        """The latest LLM trace id for this root session, for UI events."""
+        return self._root_trace_id if self.is_root else None
+
+    def _set_trace_id(self, trace_id: str | None) -> None:
+        from kimi_cli.telemetry import set_current_trace_id
+
+        set_current_trace_id(trace_id)
+        if self.is_root:
+            self._root_trace_id = trace_id
 
     @property
     def plan_mode(self) -> bool:
@@ -659,9 +672,7 @@ class KimiSoul:
         # Reset per-turn state so slash-only / hook-blocked runs (which never
         # reach _turn()) don't carry the previous turn's id into turn_ended.
         self._current_turn_id = ""
-        from kimi_cli.telemetry import set_current_trace_id
-
-        set_current_trace_id(None, root=self.is_root)
+        self._set_trace_id(None)
         if get_current_approval_source_or_none() is None:
             created_approval_source = ApprovalSource(kind="foreground_turn", id=uuid.uuid4().hex)
             approval_source_token = set_current_approval_source(created_approval_source)
@@ -831,7 +842,7 @@ class KimiSoul:
                 )
             if approval_source_token is not None:
                 reset_current_approval_source(approval_source_token)
-            set_current_trace_id(None, root=self.is_root)
+            self._set_trace_id(None)
 
     async def _turn(self, user_message: Message) -> TurnOutcome:
         if self._runtime.llm is None:
@@ -1184,11 +1195,9 @@ class KimiSoul:
             input_tokens_floor=self._context.token_count_with_pending,
         )
         request_chat_provider = with_kimi_generation_overrides(chat_provider, generation_overrides)
-        from kimi_cli.telemetry import set_current_trace_id
-
         request_chat_provider = with_trace_callback(
             request_chat_provider,
-            lambda trace_id: set_current_trace_id(trace_id, root=self.is_root),
+            self._set_trace_id,
         )
 
         # ═══════════════════════════════════════════════════════════════════════
@@ -1480,11 +1489,9 @@ class KimiSoul:
                 self._runtime.llm.chat_provider,
                 compaction_overrides,
             )
-            from kimi_cli.telemetry import set_current_trace_id
-
             request_provider = with_trace_callback(
                 request_provider,
-                lambda trace_id: set_current_trace_id(trace_id, root=self.is_root),
+                self._set_trace_id,
             )
             compaction_llm = replace(
                 self._runtime.llm,
@@ -1570,9 +1577,7 @@ class KimiSoul:
                 failed_kwargs["trace_id"] = _exc_trace_id
             track("compaction_failed", **failed_kwargs)
             raise
-        from kimi_cli.telemetry import set_current_trace_id
-
-        set_current_trace_id(compaction_result.trace_id, root=self.is_root)
+        self._set_trace_id(compaction_result.trace_id)
         history_count_before = len(self._context.history)
         await self._context.clear()
         await self._context.write_system_prompt(self._agent.system_prompt)

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -239,6 +239,7 @@ class KimiToolset:
         self._step_closed: bool = False
         self._dedup_triggered: bool = False
         self._force_stop_turn: bool = False
+        self._current_step_no: int = 0
 
     def set_hook_engine(self, engine: HookEngine) -> None:
         self._hook_engine = engine
@@ -276,8 +277,9 @@ class KimiToolset:
             tool.base for tool in self._tool_dict.values() if tool.name not in self._hidden_tools
         ]
 
-    def begin_step(self, previous_calls: list[tuple[str, str]]) -> None:
+    def begin_step(self, previous_calls: list[tuple[str, str]], *, step_no: int = 0) -> None:
         """Called before each step to set up deduplication state."""
+        self._current_step_no = step_no
         self._previous_step_calls = [
             _normalize_call_key(tool_name, arguments) for tool_name, arguments in previous_calls
         ]
@@ -366,6 +368,7 @@ class KimiToolset:
                     "tool_call_dedup_detected",
                     tool_call_id=tool_call.id,
                     tool_name=tool_name,
+                    step_no=self._current_step_no,
                     dup_type="same_step",
                     args_hash=_args_hash(canonical_args),
                     **_trace_id_kwargs(),
@@ -432,6 +435,7 @@ class KimiToolset:
                     "tool_call_dedup_detected",
                     tool_call_id=tool_call.id,
                     tool_name=tool_name,
+                    step_no=self._current_step_no,
                     dup_type="cross_step",
                     args_hash=_args_hash(canonical_args),
                     **_trace_id_kwargs(),

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from kimi_cli.soul.agent import Runtime
 
 current_tool_call = ContextVar[ToolCall | None]("current_tool_call", default=None)
+_current_step_no: ContextVar[int | None] = ContextVar("current_step_no", default=None)
 
 _current_session_id: ContextVar[str] = ContextVar("_current_session_id", default="")
 
@@ -95,6 +96,11 @@ def get_current_tool_call_or_none() -> ToolCall | None:
     Expect to be not None when called from a `__call__` method of a tool.
     """
     return current_tool_call.get()
+
+
+def get_current_step_no() -> int | None:
+    """Return the step number associated with the current tool task."""
+    return _current_step_no.get()
 
 
 type ToolType = CallableTool | CallableTool2[Any]
@@ -280,6 +286,7 @@ class KimiToolset:
     def begin_step(self, previous_calls: list[tuple[str, str]], *, step_no: int = 0) -> None:
         """Called before each step to set up deduplication state."""
         self._current_step_no = step_no
+        _current_step_no.set(step_no)
         self._previous_step_calls = [
             _normalize_call_key(tool_name, arguments) for tool_name, arguments in previous_calls
         ]

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -73,6 +73,22 @@ def _get_session_id() -> str:
     return _current_session_id.get()
 
 
+def _trace_id_kwargs() -> dict[str, str]:
+    """``trace_id`` telemetry kwargs for the current request, empty when unavailable."""
+    from kimi_cli.telemetry import get_current_trace_id
+
+    if tid := get_current_trace_id():
+        return {"trace_id": tid}
+    return {}
+
+
+def _args_hash(canonical_args: str) -> str:
+    """Stable 8-char hash of canonical tool-call arguments (TS args_hash parity)."""
+    import hashlib
+
+    return hashlib.sha256(canonical_args.encode()).hexdigest()[:8]
+
+
 def get_current_tool_call_or_none() -> ToolCall | None:
     """
     Get the current tool call or None.
@@ -344,10 +360,51 @@ class KimiToolset:
 
             # Same-step dedup: wait for the original task and copy its result.
             if call_key in self._current_step_tasks:
+                from kimi_cli.telemetry import track
+
+                track(
+                    "tool_call_dedup_detected",
+                    tool_call_id=tool_call.id,
+                    tool_name=tool_name,
+                    dup_type="same_step",
+                    args_hash=_args_hash(canonical_args),
+                    **_trace_id_kwargs(),
+                )
                 original_task = self._current_step_tasks[call_key]
 
                 async def _await_dup() -> ToolResult:
-                    original_result = await original_task
+                    t0 = time.monotonic()
+                    try:
+                        original_result = await original_task
+                    except asyncio.CancelledError:
+                        track(
+                            "tool_call",
+                            tool_call_id=tool_call.id,
+                            tool_name=tool_name,
+                            outcome="cancelled",
+                            duration_ms=int((time.monotonic() - t0) * 1000),
+                            dup_type="same_step",
+                            error_type="cancelled",
+                            **_trace_id_kwargs(),
+                        )
+                        raise
+                    dup_error = (
+                        original_result.return_value
+                        if isinstance(original_result.return_value, ToolError)
+                        else None
+                    )
+                    dup_kwargs = {
+                        "tool_call_id": tool_call.id,
+                        "tool_name": tool_name,
+                        "outcome": "error" if dup_error is not None else "success",
+                        "duration_ms": int((time.monotonic() - t0) * 1000),
+                        "dup_type": "same_step",
+                        **_trace_id_kwargs(),
+                    }
+                    if dup_error is not None:
+                        dup_kwargs["error_type"] = "error"
+                        dup_kwargs["error_class"] = type(dup_error).__name__
+                    track("tool_call", **dup_kwargs)
                     return ToolResult(
                         tool_call_id=tool_call.id,
                         return_value=original_result.return_value,
@@ -369,6 +426,15 @@ class KimiToolset:
                     tool_name=tool_name,
                     repeat_count=repeat_count,
                     action=action,
+                    **_trace_id_kwargs(),
+                )
+                track(
+                    "tool_call_dedup_detected",
+                    tool_call_id=tool_call.id,
+                    tool_name=tool_name,
+                    dup_type="cross_step",
+                    args_hash=_args_hash(canonical_args),
+                    **_trace_id_kwargs(),
                 )
                 self._dedup_triggered = True
                 if action == "stop":
@@ -407,6 +473,20 @@ class KimiToolset:
                 t0 = time.monotonic()
                 try:
                     ret = await tool.call(arguments)
+                except asyncio.CancelledError:
+                    from kimi_cli.telemetry import track
+
+                    track(
+                        "tool_call",
+                        tool_call_id=tool_call.id,
+                        tool_name=tool_name,
+                        outcome="cancelled",
+                        duration_ms=int((time.monotonic() - t0) * 1000),
+                        dup_type="cross_step" if is_cross_step_dup else "normal",
+                        error_type="cancelled",
+                        **_trace_id_kwargs(),
+                    )
+                    raise
                 except Exception as e:
                     tool_elapsed = time.monotonic() - t0
                     logger.exception(
@@ -434,13 +514,16 @@ class KimiToolset:
                     )
                     from kimi_cli.telemetry import track
 
-                    _error_type = type(e).__name__
                     track(
                         "tool_call",
+                        tool_call_id=tool_call.id,
                         tool_name=tool_name,
                         outcome="error",
                         duration_ms=int(tool_elapsed * 1000),
-                        error_type=_error_type,
+                        error_type="error",
+                        error_class=type(e).__name__,
+                        dup_type="cross_step" if is_cross_step_dup else "normal",
+                        **_trace_id_kwargs(),
                     )
                     return ToolResult(
                         tool_call_id=tool_call.id,
@@ -459,19 +542,24 @@ class KimiToolset:
                 if isinstance(ret, ToolError):
                     _track_tool_call(
                         "tool_call",
+                        tool_call_id=tool_call.id,
                         tool_name=tool_name,
                         outcome="error",
                         duration_ms=int(tool_elapsed * 1000),
-                        error_type=type(ret).__name__,
+                        error_type="error",
+                        error_class=type(ret).__name__,
                         dup_type="cross_step" if is_cross_step_dup else "normal",
+                        **_trace_id_kwargs(),
                     )
                 else:
                     _track_tool_call(
                         "tool_call",
+                        tool_call_id=tool_call.id,
                         tool_name=tool_name,
                         outcome="success",
                         duration_ms=int(tool_elapsed * 1000),
                         dup_type="cross_step" if is_cross_step_dup else "normal",
+                        **_trace_id_kwargs(),
                     )
 
                 # --- PostToolUse (fire-and-forget) ---

--- a/src/kimi_cli/telemetry/__init__.py
+++ b/src/kimi_cli/telemetry/__init__.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from collections import deque
 from contextlib import suppress
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -47,6 +48,42 @@ _session_started_sessions: set[str] = set()
 """Session ids that already emitted the session_started event in this process."""
 _sink: EventSink | None = None
 _disabled: bool = False
+
+# ---------------------------------------------------------------------------
+# Current request trace id (x-trace-id response header)
+# ---------------------------------------------------------------------------
+#
+# Two-level holder mirroring the TS agent telemetry context:
+# - ``_trace_id_var`` is a ContextVar, so each turn task (foreground turn,
+#   subagent, background task) sees the trace id of its own latest LLM
+#   request, and tool tasks created after the request inherits it.
+# - ``_root_trace_id`` mirrors the root (foreground) agent's value so that UI
+#   code running outside the turn task (e.g. the shell live view handling
+#   ESC / question panels) can read it.
+_trace_id_var: ContextVar[str | None] = ContextVar("kimi_telemetry_trace_id", default=None)
+_root_trace_id: str | None = None
+
+
+def set_current_trace_id(trace_id: str | None, *, root: bool = False) -> None:
+    """Record the trace id of the latest LLM request in the current context.
+
+    Pass ``root=True`` only from the root agent so UI code can read the value
+    via ``get_root_trace_id`` outside the turn task's context.
+    """
+    global _root_trace_id
+    _trace_id_var.set(trace_id)
+    if root:
+        _root_trace_id = trace_id
+
+
+def get_current_trace_id() -> str | None:
+    """The trace id of the latest LLM request in the current task context."""
+    return _trace_id_var.get()
+
+
+def get_root_trace_id() -> str | None:
+    """The trace id of the root agent's latest LLM request (for UI emit points)."""
+    return _root_trace_id
 
 
 def set_context(*, device_id: str, session_id: str) -> None:

--- a/src/kimi_cli/telemetry/__init__.py
+++ b/src/kimi_cli/telemetry/__init__.py
@@ -53,37 +53,22 @@ _disabled: bool = False
 # Current request trace id (x-trace-id response header)
 # ---------------------------------------------------------------------------
 #
-# Two-level holder mirroring the TS agent telemetry context:
-# - ``_trace_id_var`` is a ContextVar, so each turn task (foreground turn,
-#   subagent, background task) sees the trace id of its own latest LLM
-#   request, and tool tasks created after the request inherits it.
-# - ``_root_trace_id`` mirrors the root (foreground) agent's value so that UI
-#   code running outside the turn task (e.g. the shell live view handling
-#   ESC / question panels) can read it.
+# The ContextVar is intentionally the only process-global state here. Each
+# turn task (foreground turn, subagent, background task) sees the trace id of
+# its own latest LLM request, and tool tasks created after the request inherit
+# it. Root-session UI state is owned by KimiSoul and passed to the UI through
+# an explicit session-bound getter.
 _trace_id_var: ContextVar[str | None] = ContextVar("kimi_telemetry_trace_id", default=None)
-_root_trace_id: str | None = None
 
 
-def set_current_trace_id(trace_id: str | None, *, root: bool = False) -> None:
-    """Record the trace id of the latest LLM request in the current context.
-
-    Pass ``root=True`` only from the root agent so UI code can read the value
-    via ``get_root_trace_id`` outside the turn task's context.
-    """
-    global _root_trace_id
+def set_current_trace_id(trace_id: str | None) -> None:
+    """Record the trace id of the latest LLM request in the current context."""
     _trace_id_var.set(trace_id)
-    if root:
-        _root_trace_id = trace_id
 
 
 def get_current_trace_id() -> str | None:
     """The trace id of the latest LLM request in the current task context."""
     return _trace_id_var.get()
-
-
-def get_root_trace_id() -> str | None:
-    """The trace id of the root agent's latest LLM request (for UI emit points)."""
-    return _root_trace_id
 
 
 def set_context(*, device_id: str, session_id: str) -> None:

--- a/src/kimi_cli/ui/shell/__init__.py
+++ b/src/kimi_cli/ui/shell/__init__.py
@@ -842,6 +842,14 @@ class Shell:
 
         captured_view: _PromptLiveView | None = None
         pending: list[UserInput] = []  # queued messages being drained
+        get_trace_id: Callable[[], str | None] | None = None
+        if isinstance(self.soul, KimiSoul):
+            root_soul = self.soul
+
+            def get_root_trace_id() -> str | None:
+                return root_soul.root_trace_id
+
+            get_trace_id = get_root_trace_id
 
         try:
             snap = self.soul.status
@@ -871,6 +879,7 @@ class Shell:
                     cancel_event=cancel_event,
                     prompt_session=self._prompt_session,
                     steer=self.soul.steer if isinstance(self.soul, KimiSoul) else None,
+                    get_trace_id=get_trace_id,
                     btw_runner=self._make_btw_runner(),
                     bind_running_input=self._bind_running_input,
                     unbind_running_input=self._unbind_running_input,
@@ -924,6 +933,7 @@ class Shell:
                         cancel_event=cancel_event,
                         prompt_session=self._prompt_session,
                         steer=self.soul.steer if isinstance(self.soul, KimiSoul) else None,
+                        get_trace_id=get_trace_id,
                         btw_runner=self._make_btw_runner(),
                         bind_running_input=self._bind_running_input,
                         unbind_running_input=self._unbind_running_input,

--- a/src/kimi_cli/ui/shell/visualize/__init__.py
+++ b/src/kimi_cli/ui/shell/visualize/__init__.py
@@ -119,6 +119,7 @@ async def visualize(
     prompt_session: CustomPromptSession | None = None,
     steer: Callable[[str | list[ContentPart]], None] | None = None,
     btw_runner: BtwRunner | None = None,
+    get_trace_id: Callable[[], str | None] | None = None,
     bind_running_input: Callable[[Callable[[UserInput], None], Callable[[], None]], None]
     | None = None,
     unbind_running_input: Callable[[], None] | None = None,
@@ -139,6 +140,7 @@ async def visualize(
             steer=steer,
             btw_runner=btw_runner,
             cancel_event=cancel_event,
+            get_trace_id=get_trace_id,
             show_thinking_stream=show_thinking_stream,
         )
         prompt_session.attach_running_prompt(view)
@@ -150,7 +152,12 @@ async def visualize(
         if bind_running_input is not None:
             bind_running_input(view.handle_local_input, _cancel_running_input)
     else:
-        view = _LiveView(initial_status, cancel_event, show_thinking_stream=show_thinking_stream)
+        view = _LiveView(
+            initial_status,
+            cancel_event,
+            get_trace_id=get_trace_id,
+            show_thinking_stream=show_thinking_stream,
+        )
     if on_view_ready is not None:
         on_view_ready(view)
     try:

--- a/src/kimi_cli/ui/shell/visualize/_interactive.py
+++ b/src/kimi_cli/ui/shell/visualize/_interactive.py
@@ -72,9 +72,15 @@ class _PromptLiveView(_LiveView):
         steer: Callable[[str | list[ContentPart]], None],
         btw_runner: BtwRunner | None = None,
         cancel_event: asyncio.Event | None = None,
+        get_trace_id: Callable[[], str | None] | None = None,
         show_thinking_stream: bool = False,
     ) -> None:
-        super().__init__(initial_status, cancel_event, show_thinking_stream=show_thinking_stream)
+        super().__init__(
+            initial_status,
+            cancel_event,
+            get_trace_id=get_trace_id,
+            show_thinking_stream=show_thinking_stream,
+        )
         self._prompt_session = prompt_session
         self._steer = steer
         self._btw_runner = btw_runner

--- a/src/kimi_cli/ui/shell/visualize/_live_view.py
+++ b/src/kimi_cli/ui/shell/visualize/_live_view.py
@@ -551,9 +551,14 @@ class _LiveView:
             return
         all_done = panel.submit()
         if all_done:
-            from kimi_cli.telemetry import track
+            from kimi_cli.telemetry import get_root_trace_id, track
 
-            track("question_answered", method=method)
+            track(
+                "question_answered",
+                method=method,
+                answered=len(panel.get_answers()),
+                **({"trace_id": tid} if (tid := get_root_trace_id()) else {}),
+            )
             panel.request.resolve(panel.get_answers())
             self.show_next_question_request()
 
@@ -578,9 +583,12 @@ class _LiveView:
                     # "Other" is handled in keyboard_handler (async context)
                     self._try_submit_question(method="enter")
                 case KeyEvent.ESCAPE:
-                    from kimi_cli.telemetry import track
+                    from kimi_cli.telemetry import get_root_trace_id, track
 
-                    track("question_dismissed")
+                    track(
+                        "question_dismissed",
+                        **({"trace_id": tid} if (tid := get_root_trace_id()) else {}),
+                    )
                     self._current_question_panel.request.resolve({})
                     self.show_next_question_request()
                 case (
@@ -615,9 +623,15 @@ class _LiveView:
 
         # handle ESC key to cancel the run
         if event == KeyEvent.ESCAPE and self._cancel_event is not None:
-            from kimi_cli.telemetry import track
+            from kimi_cli.telemetry import get_root_trace_id, track
 
-            track("cancel")
+            track(
+                "cancel",
+                **{
+                    "from": "compacting" if self._compacting_spinner is not None else "streaming",
+                    **({"trace_id": tid} if (tid := get_root_trace_id()) else {}),
+                },
+            )
             self._cancel_event.set()
             return
 

--- a/src/kimi_cli/ui/shell/visualize/_live_view.py
+++ b/src/kimi_cli/ui/shell/visualize/_live_view.py
@@ -130,9 +130,11 @@ class _LiveView:
         initial_status: StatusUpdate,
         cancel_event: asyncio.Event | None = None,
         *,
+        get_trace_id: Callable[[], str | None] | None = None,
         show_thinking_stream: bool = False,
     ):
         self._cancel_event = cancel_event
+        self._get_trace_id = get_trace_id
         self._show_thinking_stream = show_thinking_stream
 
         self._mooning_spinner = Spinner("moon", "")
@@ -160,6 +162,9 @@ class _LiveView:
 
         self._need_recompose = False
         self._external_messages: Queue[WireMessage] = Queue()
+
+    def _current_trace_id(self) -> str | None:
+        return self._get_trace_id() if self._get_trace_id is not None else None
 
     def _reset_live_shape(self, live: Live) -> None:
         # Rich doesn't expose a public API to clear Live's cached render height.
@@ -551,13 +556,13 @@ class _LiveView:
             return
         all_done = panel.submit()
         if all_done:
-            from kimi_cli.telemetry import get_root_trace_id, track
+            from kimi_cli.telemetry import track
 
             track(
                 "question_answered",
                 method=method,
                 answered=len(panel.get_answers()),
-                **({"trace_id": tid} if (tid := get_root_trace_id()) else {}),
+                **({"trace_id": tid} if (tid := self._current_trace_id()) else {}),
             )
             panel.request.resolve(panel.get_answers())
             self.show_next_question_request()
@@ -583,11 +588,11 @@ class _LiveView:
                     # "Other" is handled in keyboard_handler (async context)
                     self._try_submit_question(method="enter")
                 case KeyEvent.ESCAPE:
-                    from kimi_cli.telemetry import get_root_trace_id, track
+                    from kimi_cli.telemetry import track
 
                     track(
                         "question_dismissed",
-                        **({"trace_id": tid} if (tid := get_root_trace_id()) else {}),
+                        **({"trace_id": tid} if (tid := self._current_trace_id()) else {}),
                     )
                     self._current_question_panel.request.resolve({})
                     self.show_next_question_request()
@@ -623,13 +628,13 @@ class _LiveView:
 
         # handle ESC key to cancel the run
         if event == KeyEvent.ESCAPE and self._cancel_event is not None:
-            from kimi_cli.telemetry import get_root_trace_id, track
+            from kimi_cli.telemetry import track
 
             track(
                 "cancel",
                 **{
                     "from": "compacting" if self._compacting_spinner is not None else "streaming",
-                    **({"trace_id": tid} if (tid := get_root_trace_id()) else {}),
+                    **({"trace_id": tid} if (tid := self._current_trace_id()) else {}),
                 },
             )
             self._cancel_event.set()

--- a/tests/core/test_approval_telemetry.py
+++ b/tests/core/test_approval_telemetry.py
@@ -10,8 +10,8 @@ from kimi_cli.soul.approval import Approval
 from kimi_cli.soul.toolset import current_tool_call
 
 
-def _tool_call(name: str = "Bash") -> ToolCall:
-    return ToolCall(id="tc-1", function=ToolCall.FunctionBody(name=name, arguments="{}"))
+def _tool_call(name: str = "Bash", *, call_id: str = "tc-1") -> ToolCall:
+    return ToolCall(id=call_id, function=ToolCall.FunctionBody(name=name, arguments="{}"))
 
 
 def _permission_events(mock_track) -> list:
@@ -161,3 +161,40 @@ async def test_session_cached_action_emits_auto_mode():
     assert kwargs["result"] == "approved"
     assert kwargs["permission_mode"] == "auto"
     assert kwargs["session_cache_written"] is False
+
+
+@pytest.mark.asyncio
+async def test_session_approval_marks_other_pending_requests_as_cache_approved():
+    approval = Approval()
+
+    async def request(call_id: str):
+        token = current_tool_call.set(_tool_call(call_id=call_id))
+        try:
+            return await approval.request("Bash", "bash:ls", "list files")
+        finally:
+            current_tool_call.reset(token)
+
+    with patch("kimi_cli.telemetry.track") as mock_track:
+        first = asyncio.create_task(request("tc-1"))
+        second = asyncio.create_task(request("tc-2"))
+        await asyncio.sleep(0)
+        pending = approval._runtime.list_pending()
+        assert len(pending) == 2
+        approval._runtime.resolve(pending[0].id, "approve_for_session")
+        await asyncio.gather(first, second)
+
+    calls = _permission_events(mock_track)
+    assert len(calls) == 2
+    event_props = [call[1] for call in calls]
+    assert any(
+        props["result"] == "approved_for_session"
+        and props["permission_mode"] == "manual"
+        and props["session_cache_written"] is True
+        for props in event_props
+    )
+    assert any(
+        props["result"] == "approved"
+        and props["permission_mode"] == "auto"
+        and props["session_cache_written"] is False
+        for props in event_props
+    )

--- a/tests/core/test_approval_telemetry.py
+++ b/tests/core/test_approval_telemetry.py
@@ -1,0 +1,163 @@
+"""Telemetry parity tests for the permission_approval_result event (TS alignment)."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from kosong.message import ToolCall
+
+from kimi_cli.soul.approval import Approval
+from kimi_cli.soul.toolset import current_tool_call
+
+
+def _tool_call(name: str = "Bash") -> ToolCall:
+    return ToolCall(id="tc-1", function=ToolCall.FunctionBody(name=name, arguments="{}"))
+
+
+def _permission_events(mock_track) -> list:
+    return [c for c in mock_track.call_args_list if c[0][0] == "permission_approval_result"]
+
+
+@pytest.mark.asyncio
+async def test_yolo_auto_approve_emits_permission_result():
+    approval = Approval(yolo=True)
+    token = current_tool_call.set(_tool_call())
+    try:
+        with patch("kimi_cli.telemetry.track") as mock_track:
+            result = await approval.request("Bash", "bash:ls", "list files")
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is True
+    calls = _permission_events(mock_track)
+    assert len(calls) == 1
+    kwargs = calls[0][1]
+    assert kwargs["result"] == "approved"
+    assert kwargs["permission_mode"] == "yolo"
+    assert kwargs["tool_name"] == "Bash"
+    assert kwargs["approval_surface"] == "generic"
+    assert kwargs["session_cache_written"] is False
+    assert kwargs["has_feedback"] is False
+    assert kwargs["policy_name"] is None
+    assert kwargs["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_afk_auto_approve_maps_to_auto_mode():
+    from kimi_cli.soul.approval import ApprovalState
+
+    approval = Approval(state=ApprovalState(afk=True))
+    token = current_tool_call.set(_tool_call())
+    try:
+        with patch("kimi_cli.telemetry.track") as mock_track:
+            result = await approval.request("Bash", "bash:ls", "list files")
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is True
+    calls = _permission_events(mock_track)
+    assert len(calls) == 1
+    assert calls[0][1]["permission_mode"] == "auto"
+    assert calls[0][1]["result"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_manual_approve_emits_permission_result():
+    approval = Approval()
+    token = current_tool_call.set(_tool_call())
+    try:
+        with patch("kimi_cli.telemetry.track") as mock_track:
+
+            async def resolve_later():
+                await asyncio.sleep(0.02)
+                for pending in approval._runtime.list_pending():
+                    approval._runtime.resolve(pending.id, "approve")
+
+            resolver = asyncio.create_task(resolve_later())
+            result = await approval.request("Bash", "bash:ls", "list files")
+            await resolver
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is True
+    calls = _permission_events(mock_track)
+    assert len(calls) == 1
+    kwargs = calls[0][1]
+    assert kwargs["result"] == "approved"
+    assert kwargs["permission_mode"] == "manual"
+    assert kwargs["session_cache_written"] is False
+
+
+@pytest.mark.asyncio
+async def test_manual_approve_for_session_writes_cache():
+    approval = Approval()
+    token = current_tool_call.set(_tool_call())
+    try:
+        with patch("kimi_cli.telemetry.track") as mock_track:
+
+            async def resolve_later():
+                await asyncio.sleep(0.02)
+                for pending in approval._runtime.list_pending():
+                    approval._runtime.resolve(pending.id, "approve_for_session")
+
+            resolver = asyncio.create_task(resolve_later())
+            result = await approval.request("Bash", "bash:ls", "list files")
+            await resolver
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is True
+    assert "bash:ls" in approval._state.auto_approve_actions
+    calls = _permission_events(mock_track)
+    assert len(calls) == 1
+    kwargs = calls[0][1]
+    assert kwargs["result"] == "approved_for_session"
+    assert kwargs["session_cache_written"] is True
+
+
+@pytest.mark.asyncio
+async def test_manual_reject_with_feedback():
+    approval = Approval()
+    token = current_tool_call.set(_tool_call())
+    try:
+        with patch("kimi_cli.telemetry.track") as mock_track:
+
+            async def resolve_later():
+                await asyncio.sleep(0.02)
+                for pending in approval._runtime.list_pending():
+                    approval._runtime.resolve(pending.id, "reject", feedback="do not")
+
+            resolver = asyncio.create_task(resolve_later())
+            result = await approval.request("Bash", "bash:rm", "remove files")
+            await resolver
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is False
+    assert result.feedback == "do not"
+    calls = _permission_events(mock_track)
+    assert len(calls) == 1
+    kwargs = calls[0][1]
+    assert kwargs["result"] == "rejected"
+    assert kwargs["has_feedback"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_cached_action_emits_auto_mode():
+    from kimi_cli.soul.approval import ApprovalState
+
+    approval = Approval(state=ApprovalState(auto_approve_actions={"bash:ls"}))
+    token = current_tool_call.set(_tool_call())
+    try:
+        with patch("kimi_cli.telemetry.track") as mock_track:
+            result = await approval.request("Bash", "bash:ls", "list files")
+    finally:
+        current_tool_call.reset(token)
+
+    assert result.approved is True
+    calls = _permission_events(mock_track)
+    assert len(calls) == 1
+    kwargs = calls[0][1]
+    assert kwargs["result"] == "approved"
+    assert kwargs["permission_mode"] == "auto"
+    assert kwargs["session_cache_written"] is False

--- a/tests/core/test_approval_telemetry.py
+++ b/tests/core/test_approval_telemetry.py
@@ -7,7 +7,7 @@ import pytest
 from kosong.message import ToolCall
 
 from kimi_cli.soul.approval import Approval
-from kimi_cli.soul.toolset import current_tool_call
+from kimi_cli.soul.toolset import KimiToolset, current_tool_call
 
 
 def _tool_call(name: str = "Bash", *, call_id: str = "tc-1") -> ToolCall:
@@ -21,6 +21,7 @@ def _permission_events(mock_track) -> list:
 @pytest.mark.asyncio
 async def test_yolo_auto_approve_emits_permission_result():
     approval = Approval(yolo=True)
+    KimiToolset().begin_step([], step_no=3)
     token = current_tool_call.set(_tool_call())
     try:
         with patch("kimi_cli.telemetry.track") as mock_track:
@@ -35,6 +36,7 @@ async def test_yolo_auto_approve_emits_permission_result():
     assert kwargs["result"] == "approved"
     assert kwargs["permission_mode"] == "yolo"
     assert kwargs["tool_name"] == "Bash"
+    assert kwargs["step_no"] == 3
     assert kwargs["approval_surface"] == "generic"
     assert kwargs["session_cache_written"] is False
     assert kwargs["has_feedback"] is False

--- a/tests/core/test_auth_error_handling.py
+++ b/tests/core/test_auth_error_handling.py
@@ -74,6 +74,10 @@ class StaticStreamedMessage:
     def usage(self) -> TokenUsage | None:
         return None
 
+    @property
+    def trace_id(self) -> str | None:
+        return None
+
 
 class Auth401Provider:
     """A provider that always returns 401 Unauthorized."""

--- a/tests/core/test_kimisoul_ralph_loop.py
+++ b/tests/core/test_kimisoul_ralph_loop.py
@@ -68,6 +68,10 @@ class SequenceStreamedMessage:
     def usage(self) -> TokenUsage | None:
         return None
 
+    @property
+    def trace_id(self) -> str | None:
+        return None
+
 
 class SequenceChatProvider:
     name = "sequence"

--- a/tests/core/test_kimisoul_repeat.py
+++ b/tests/core/test_kimisoul_repeat.py
@@ -55,6 +55,10 @@ class _RepeatStream:
     def usage(self) -> TokenUsage | None:
         return None
 
+    @property
+    def trace_id(self) -> str | None:
+        return None
+
 
 class _RepeatChatProvider:
     name = "repeat"

--- a/tests/core/test_kimisoul_retry_recovery.py
+++ b/tests/core/test_kimisoul_retry_recovery.py
@@ -54,6 +54,10 @@ class StaticStreamedMessage:
     def usage(self) -> TokenUsage | None:
         return None
 
+    @property
+    def trace_id(self) -> str | None:
+        return None
+
 
 class RecoveringSequenceProvider:
     name = "recovering-sequence"
@@ -212,6 +216,10 @@ class PartialThenErrorStreamedMessage:
 
     @property
     def usage(self) -> TokenUsage | None:
+        return None
+
+    @property
+    def trace_id(self) -> str | None:
         return None
 
 

--- a/tests/core/test_kimisoul_steer.py
+++ b/tests/core/test_kimisoul_steer.py
@@ -384,6 +384,10 @@ class _SequenceStreamedMessage:
     def usage(self):
         return None
 
+    @property
+    def trace_id(self) -> str | None:
+        return None
+
 
 class _SequenceChatProvider:
     name = "sequence"

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -45,6 +45,10 @@ class _SequenceStream:
     def usage(self) -> TokenUsage | None:
         return None
 
+    @property
+    def trace_id(self) -> str | None:
+        return None
+
 
 class _SequenceProvider:
     name = "notification-sequence"

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -647,7 +647,7 @@ async def test_tool_call_dedup_detected_telemetry(monkeypatch: pytest.MonkeyPatc
     ts = _make_toolset()
     args = '{"value":"x"}'
 
-    ts.begin_step([])
+    ts.begin_step([], step_no=4)
     r1 = ts.handle(
         ToolCall(id="tc-1", function=ToolCall.FunctionBody(name="ToolA", arguments=args))
     )
@@ -658,7 +658,7 @@ async def test_tool_call_dedup_detected_telemetry(monkeypatch: pytest.MonkeyPatc
     await asyncio.gather(r1, r2)
     previous = ts.end_step()
 
-    ts.begin_step(previous)
+    ts.begin_step(previous, step_no=5)
     r3 = ts.handle(
         ToolCall(id="tc-3", function=ToolCall.FunctionBody(name="ToolA", arguments=args))
     )
@@ -667,6 +667,7 @@ async def test_tool_call_dedup_detected_telemetry(monkeypatch: pytest.MonkeyPatc
 
     dedup_events = [(e, p) for e, p in events if e == "tool_call_dedup_detected"]
     assert [p["dup_type"] for _, p in dedup_events] == ["same_step", "cross_step"]
+    assert [p["step_no"] for _, p in dedup_events] == [4, 5]
     assert all(p["tool_name"] == "ToolA" for _, p in dedup_events)
     assert all("args_hash" in p and "tool_call_id" in p for _, p in dedup_events)
 

--- a/tests/core/test_toolset.py
+++ b/tests/core/test_toolset.py
@@ -633,3 +633,111 @@ async def test_tool_call_repeat_telemetry_matches_kimi_code(
     assert [p["action"] for _, p in repeat_events] == ["none", "r1", "r1", "r2"]
     assert all(p["tool_name"] == "ToolA" for _, p in repeat_events)
     assert all(set(p) == {"tool_name", "repeat_count", "action"} for _, p in repeat_events)
+
+
+async def test_tool_call_dedup_detected_telemetry(monkeypatch: pytest.MonkeyPatch):
+    """tool_call_dedup_detected fires for same-step and cross-step duplicates."""
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def fake_track(event: str, **props: object) -> None:
+        events.append((event, props))
+
+    monkeypatch.setattr("kimi_cli.telemetry.track", fake_track)
+
+    ts = _make_toolset()
+    args = '{"value":"x"}'
+
+    ts.begin_step([])
+    r1 = ts.handle(
+        ToolCall(id="tc-1", function=ToolCall.FunctionBody(name="ToolA", arguments=args))
+    )
+    r2 = ts.handle(
+        ToolCall(id="tc-2", function=ToolCall.FunctionBody(name="ToolA", arguments=args))
+    )
+    assert isinstance(r1, asyncio.Task) and isinstance(r2, asyncio.Task)
+    await asyncio.gather(r1, r2)
+    previous = ts.end_step()
+
+    ts.begin_step(previous)
+    r3 = ts.handle(
+        ToolCall(id="tc-3", function=ToolCall.FunctionBody(name="ToolA", arguments=args))
+    )
+    assert isinstance(r3, asyncio.Task)
+    await r3
+
+    dedup_events = [(e, p) for e, p in events if e == "tool_call_dedup_detected"]
+    assert [p["dup_type"] for _, p in dedup_events] == ["same_step", "cross_step"]
+    assert all(p["tool_name"] == "ToolA" for _, p in dedup_events)
+    assert all("args_hash" in p and "tool_call_id" in p for _, p in dedup_events)
+
+
+async def test_tool_call_error_uses_enum_and_error_class(monkeypatch: pytest.MonkeyPatch):
+    """tool_call error events use the TS error_type enum; class name goes to error_class."""
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def fake_track(event: str, **props: object) -> None:
+        events.append((event, props))
+
+    monkeypatch.setattr("kimi_cli.telemetry.track", fake_track)
+
+    class FailingTool(CallableTool2[DummyParams]):
+        name: str = "FailingTool"
+        description: str = "always fails"
+        params: type[DummyParams] = DummyParams
+
+        async def __call__(self, params: DummyParams) -> ToolReturnValue:
+            raise ValueError("boom")
+
+    ts = _make_toolset()
+    ts.add(FailingTool())
+    ts.begin_step([])
+    result = ts.handle(
+        ToolCall(id="tc-f", function=ToolCall.FunctionBody(name="FailingTool", arguments="{}"))
+    )
+    assert isinstance(result, asyncio.Task)
+    await result
+
+    tool_call_events = [(e, p) for e, p in events if e == "tool_call"]
+    assert len(tool_call_events) == 1
+    props = tool_call_events[0][1]
+    assert props["outcome"] == "error"
+    assert props["error_type"] == "error"
+    assert props["error_class"] == "ValueError"
+
+
+async def test_tool_call_cancelled_outcome(monkeypatch: pytest.MonkeyPatch):
+    """Cancelling a running tool emits outcome=cancelled + error_type=cancelled."""
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def fake_track(event: str, **props: object) -> None:
+        events.append((event, props))
+
+    monkeypatch.setattr("kimi_cli.telemetry.track", fake_track)
+
+    class SlowTool(CallableTool2[DummyParams]):
+        name: str = "SlowTool"
+        description: str = "never finishes"
+        params: type[DummyParams] = DummyParams
+
+        async def __call__(self, params: DummyParams) -> ToolReturnValue:
+            await asyncio.sleep(60)
+            return ToolOk(output="done")
+
+    ts = _make_toolset()
+    ts.add(SlowTool())
+    ts.begin_step([])
+    result = ts.handle(
+        ToolCall(id="tc-s", function=ToolCall.FunctionBody(name="SlowTool", arguments="{}"))
+    )
+    assert isinstance(result, asyncio.Task)
+    await asyncio.sleep(0)
+    result.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await result
+
+    tool_call_events = [(e, p) for e, p in events if e == "tool_call"]
+    assert len(tool_call_events) == 1
+    props = tool_call_events[0][1]
+    assert props["outcome"] == "cancelled"
+    assert props["error_type"] == "cancelled"
+    assert "error_class" not in props

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -224,6 +224,13 @@ class TestAPIErrorClassification:
         et, _ = classify_api_error(self._mk_status_error(502))
         assert et == "5xx_server"
 
+    def test_529_maps_to_overloaded(self):
+        from kimi_cli.soul.kimisoul import classify_api_error
+
+        et, sc = classify_api_error(self._mk_status_error(529))
+        assert et == "overloaded"
+        assert sc == 529
+
     def test_400_maps_to_4xx_client(self):
         from kimi_cli.soul.kimisoul import classify_api_error
 
@@ -315,6 +322,43 @@ class TestAPIErrorClassification:
         event = _collect_events()[-1]
         assert event["properties"]["status_code"] == 503
         assert isinstance(event["properties"]["status_code"], int)
+
+
+class TestRetryableClassification:
+    """api_error.retryable follows the TS isRetryableGenerateError table."""
+
+    def _status(self, status: int):
+        from kosong.chat_provider import APIStatusError
+
+        return APIStatusError(status, "err")
+
+    def test_529_overloaded_is_retryable(self):
+        from kimi_cli.soul.kimisoul import is_retryable_api_error
+
+        assert is_retryable_api_error(self._status(529)) is True
+
+    def test_408_409_are_retryable(self):
+        from kimi_cli.soul.kimisoul import is_retryable_api_error
+
+        assert is_retryable_api_error(self._status(408)) is True
+        assert is_retryable_api_error(self._status(409)) is True
+
+    def test_400_is_not_retryable(self):
+        from kimi_cli.soul.kimisoul import is_retryable_api_error
+
+        assert is_retryable_api_error(self._status(400)) is False
+
+    def test_network_error_is_retryable(self):
+        from kosong.chat_provider import APIConnectionError
+
+        from kimi_cli.soul.kimisoul import is_retryable_api_error
+
+        assert is_retryable_api_error(APIConnectionError("lost")) is True
+
+    def test_non_provider_error_is_not_retryable(self):
+        from kimi_cli.soul.kimisoul import is_retryable_api_error
+
+        assert is_retryable_api_error(RuntimeError("x")) is False
 
 
 # ---------------------------------------------------------------------------
@@ -936,7 +980,7 @@ class TestCompactionTracking:
 
     @pytest.mark.asyncio
     async def test_auto_compaction_success_emits_event(self):
-        """Auto-triggered success: track has trigger_type=auto + after_tokens."""
+        """Auto-triggered success: track has source=auto + tokens_after."""
         soul = self._make_soul(before_tokens=12000, estimated_after=3000)
 
         with (
@@ -951,17 +995,20 @@ class TestCompactionTracking:
         assert len(calls) == 1
         args, kwargs = calls[0]
         assert args[0] == "compaction_finished"
-        assert kwargs["trigger_type"] == "auto"
-        assert kwargs["before_tokens"] == 12000
-        assert kwargs["after_tokens"] == 3000
+        assert kwargs["source"] == "auto"
+        assert kwargs["tokens_before"] == 12000
+        assert kwargs["tokens_after"] == 3000
         assert kwargs["duration_ms"] >= 0
         assert kwargs["retry_count"] == 0
-        assert "llm_input_tokens" not in kwargs
-        assert "llm_output_tokens" not in kwargs
+        assert kwargs["round"] == 1
+        assert "thinking_effort" in kwargs
+        assert "compacted_count" in kwargs
+        assert "input_tokens" not in kwargs
+        assert "output_tokens" not in kwargs
 
     @pytest.mark.asyncio
     async def test_manual_compaction_without_prompt_emits_event(self):
-        """/compact without instruction yields trigger_type=manual."""
+        """/compact without instruction yields source=manual."""
         soul = self._make_soul(before_tokens=8000, estimated_after=2000)
 
         with (
@@ -972,13 +1019,13 @@ class TestCompactionTracking:
 
         calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
-        assert calls[0][1]["trigger_type"] == "manual"
+        assert calls[0][1]["source"] == "manual"
         assert calls[0][1]["duration_ms"] >= 0
         assert calls[0][1]["retry_count"] == 0
 
     @pytest.mark.asyncio
     async def test_manual_compaction_with_prompt_emits_event(self):
-        """/compact with instruction yields trigger_type=manual-with-prompt."""
+        """/compact with instruction still yields source=manual (TS-aligned enum)."""
         soul = self._make_soul(before_tokens=8000, estimated_after=2000)
 
         with (
@@ -989,13 +1036,13 @@ class TestCompactionTracking:
 
         calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_finished"]
         assert len(calls) == 1
-        assert calls[0][1]["trigger_type"] == "manual-with-prompt"
+        assert calls[0][1]["source"] == "manual"
         assert calls[0][1]["duration_ms"] >= 0
         assert calls[0][1]["retry_count"] == 0
 
     @pytest.mark.asyncio
     async def test_compaction_failure_emits_event_then_reraises(self):
-        """On compaction failure: track compaction_failed (no after_tokens), then re-raise."""
+        """On compaction failure: track compaction_failed (no tokens_after), then re-raise."""
         soul = self._make_soul(before_tokens=50000, estimated_after=0)
         # Force the compaction to fail with a non-retryable error
         soul._run_with_connection_recovery = AsyncMock(side_effect=RuntimeError("compaction boom"))
@@ -1010,11 +1057,12 @@ class TestCompactionTracking:
         calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_failed"]
         assert len(calls) == 1
         kwargs = calls[0][1]
-        assert kwargs["trigger_type"] == "auto"
-        assert kwargs["before_tokens"] == 50000
-        assert "after_tokens" not in kwargs
+        assert kwargs["source"] == "auto"
+        assert kwargs["tokens_before"] == 50000
+        assert "tokens_after" not in kwargs
         assert kwargs["duration_ms"] >= 0
         assert kwargs["retry_count"] == 0
+        assert kwargs["round"] == 1
         assert kwargs["error_type"] == "RuntimeError"
 
 
@@ -1111,3 +1159,77 @@ class TestPlanLifecycleEvents:
         track("plan_enter_resolved", outcome="auto_approved")
         event = _collect_events()[-1]
         assert event["properties"]["outcome"] == "auto_approved"
+
+
+# ---------------------------------------------------------------------------
+# 9. Trace id holder (x-trace-id propagation)
+# ---------------------------------------------------------------------------
+
+
+class TestTraceIdHolder:
+    """Verify the two-level trace id holder used by trace_id event properties."""
+
+    def teardown_method(self):
+        from kimi_cli.telemetry import set_current_trace_id
+
+        set_current_trace_id(None, root=True)
+
+    def test_set_get_current_trace_id(self):
+        from kimi_cli.telemetry import get_current_trace_id, set_current_trace_id
+
+        set_current_trace_id("t-1")
+        assert get_current_trace_id() == "t-1"
+        set_current_trace_id(None)
+        assert get_current_trace_id() is None
+
+    def test_root_mirror_only_set_when_root(self):
+        from kimi_cli.telemetry import get_root_trace_id, set_current_trace_id
+
+        set_current_trace_id(None, root=True)
+        set_current_trace_id("t-sub", root=False)
+        assert get_root_trace_id() is None
+        set_current_trace_id("t-root", root=True)
+        assert get_root_trace_id() == "t-root"
+
+    @pytest.mark.asyncio
+    async def test_contextvar_propagates_to_child_tasks(self):
+        """Tool tasks created after the request see the request's trace id."""
+        import asyncio
+
+        from kimi_cli.telemetry import get_current_trace_id, set_current_trace_id
+
+        set_current_trace_id("t-parent")
+
+        async def child_read():
+            return get_current_trace_id()
+
+        assert await asyncio.create_task(child_read()) == "t-parent"
+
+    @pytest.mark.asyncio
+    async def test_contextvar_isolated_from_sibling_tasks(self):
+        """A subagent turn setting its own trace id must not affect the parent."""
+        import asyncio
+
+        from kimi_cli.telemetry import get_current_trace_id, set_current_trace_id
+
+        set_current_trace_id("t-parent")
+
+        async def child_set():
+            set_current_trace_id("t-child")
+            return get_current_trace_id()
+
+        assert await asyncio.create_task(child_set()) == "t-child"
+        assert get_current_trace_id() == "t-parent"
+
+
+class TestTurnEndedEvent:
+    """turn_ended fires with the TS-aligned property shape."""
+
+    def test_turn_ended_reason_enum(self):
+        for reason in ("completed", "cancelled", "failed"):
+            telemetry_mod._event_queue.clear()
+            track("turn_ended", reason=reason, duration_ms=1, mode="agent")
+            event = _collect_events()[-1]
+            assert event["event"] == "turn_ended"
+            assert event["properties"]["reason"] == reason
+            assert isinstance(event["properties"]["duration_ms"], int)

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -37,6 +37,7 @@ def _reset_telemetry_state():
     telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
+    telemetry_mod.set_current_trace_id(None, root=True)
     yield
     telemetry_mod._event_queue.clear()
     telemetry_mod._device_id = None
@@ -45,6 +46,7 @@ def _reset_telemetry_state():
     telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
+    telemetry_mod.set_current_trace_id(None, root=True)
 
 
 def _collect_events() -> list[dict[str, Any]]:
@@ -1065,6 +1067,40 @@ class TestCompactionTracking:
         assert kwargs["round"] == 1
         assert kwargs["error_type"] == "RuntimeError"
 
+    @pytest.mark.asyncio
+    async def test_compaction_api_failure_emits_complete_api_error(self):
+        from kosong.chat_provider import APIConnectionError
+
+        from kimi_cli.telemetry import set_current_trace_id
+
+        soul = self._make_soul(before_tokens=50000, estimated_after=0)
+        soul._runtime.llm.model_name = "test-model"
+        soul._runtime.llm.provider_config.type = "kimi"
+        soul._run_with_connection_recovery = AsyncMock(
+            side_effect=APIConnectionError("stream disconnected")
+        )
+        set_current_trace_id("trace-compaction")
+
+        with (
+            patch("kimi_cli.soul.kimisoul.wire_send"),
+            patch("kimi_cli.telemetry.track") as mock_track,
+            pytest.raises(APIConnectionError, match="stream disconnected"),
+        ):
+            await soul.compact_context()
+
+        api_calls = [c for c in mock_track.call_args_list if c[0][0] == "api_error"]
+        assert len(api_calls) == 1
+        api_kwargs = api_calls[0][1]
+        assert api_kwargs["model"] == "test-model"
+        assert api_kwargs["provider_type"] == "kimi"
+        assert api_kwargs["protocol"] == "kimi"
+        assert api_kwargs["duration_ms"] >= 0
+        assert api_kwargs["input_tokens"] == 50000
+        assert api_kwargs["trace_id"] == "trace-compaction"
+
+        compaction_calls = [c for c in mock_track.call_args_list if c[0][0] == "compaction_failed"]
+        assert compaction_calls[0][1]["trace_id"] == "trace-compaction"
+
 
 # ---------------------------------------------------------------------------
 # 8. Plan lifecycle events
@@ -1220,6 +1256,109 @@ class TestTraceIdHolder:
 
         assert await asyncio.create_task(child_set()) == "t-child"
         assert get_current_trace_id() == "t-parent"
+
+    @pytest.mark.asyncio
+    async def test_request_wrapper_clears_stale_trace_before_headers(self):
+        from collections.abc import Sequence
+        from typing import Self
+
+        from kosong.chat_provider import APIConnectionError, ThinkingEffort
+        from kosong.message import Message
+        from kosong.tooling import Tool
+
+        from kimi_cli.llm import with_trace_callback
+        from kimi_cli.telemetry import get_current_trace_id, set_current_trace_id
+
+        class FailingProvider:
+            name = "failing"
+
+            @property
+            def model_name(self) -> str:
+                return "failing"
+
+            @property
+            def thinking_effort(self) -> ThinkingEffort | None:
+                return None
+
+            async def generate(
+                self,
+                system_prompt: str,
+                tools: Sequence[Tool],
+                history: Sequence[Message],
+            ):
+                raise APIConnectionError("before headers")
+
+            def with_thinking(self, effort: ThinkingEffort) -> Self:
+                return self
+
+        set_current_trace_id("stale")
+        provider = with_trace_callback(FailingProvider(), set_current_trace_id)
+
+        with pytest.raises(APIConnectionError, match="before headers"):
+            await provider.generate("", [], [])
+
+        assert get_current_trace_id() is None
+
+    @pytest.mark.asyncio
+    async def test_request_wrapper_keeps_header_trace_for_stream_failure(self):
+        from collections.abc import AsyncIterator, Sequence
+        from typing import Self
+
+        from kosong.chat_provider import APIConnectionError, StreamedMessagePart, ThinkingEffort
+        from kosong.message import Message
+        from kosong.tooling import Tool
+
+        from kimi_cli.llm import with_trace_callback
+        from kimi_cli.telemetry import get_current_trace_id, set_current_trace_id
+
+        class FailingStream:
+            def __aiter__(self) -> AsyncIterator[StreamedMessagePart]:
+                return self
+
+            async def __anext__(self) -> StreamedMessagePart:
+                raise APIConnectionError("after headers")
+
+            @property
+            def id(self) -> str | None:
+                return None
+
+            @property
+            def usage(self):
+                return None
+
+            @property
+            def trace_id(self) -> str | None:
+                return "trace-current"
+
+        class StreamingProvider:
+            name = "streaming"
+
+            @property
+            def model_name(self) -> str:
+                return "streaming"
+
+            @property
+            def thinking_effort(self) -> ThinkingEffort | None:
+                return None
+
+            async def generate(
+                self,
+                system_prompt: str,
+                tools: Sequence[Tool],
+                history: Sequence[Message],
+            ) -> FailingStream:
+                return FailingStream()
+
+            def with_thinking(self, effort: ThinkingEffort) -> Self:
+                return self
+
+        provider = with_trace_callback(StreamingProvider(), set_current_trace_id)
+        stream = await provider.generate("", [], [])
+
+        with pytest.raises(APIConnectionError, match="after headers"):
+            await anext(stream.__aiter__())
+
+        assert get_current_trace_id() == "trace-current"
 
 
 class TestTurnEndedEvent:

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -37,7 +37,7 @@ def _reset_telemetry_state():
     telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
-    telemetry_mod.set_current_trace_id(None, root=True)
+    telemetry_mod.set_current_trace_id(None)
     yield
     telemetry_mod._event_queue.clear()
     telemetry_mod._device_id = None
@@ -46,7 +46,7 @@ def _reset_telemetry_state():
     telemetry_mod._session_started_sessions.clear()
     telemetry_mod._sink = None
     telemetry_mod._disabled = False
-    telemetry_mod.set_current_trace_id(None, root=True)
+    telemetry_mod.set_current_trace_id(None)
 
 
 def _collect_events() -> list[dict[str, Any]]:
@@ -1208,7 +1208,7 @@ class TestTraceIdHolder:
     def teardown_method(self):
         from kimi_cli.telemetry import set_current_trace_id
 
-        set_current_trace_id(None, root=True)
+        set_current_trace_id(None)
 
     def test_set_get_current_trace_id(self):
         from kimi_cli.telemetry import get_current_trace_id, set_current_trace_id
@@ -1218,14 +1218,21 @@ class TestTraceIdHolder:
         set_current_trace_id(None)
         assert get_current_trace_id() is None
 
-    def test_root_mirror_only_set_when_root(self):
-        from kimi_cli.telemetry import get_root_trace_id, set_current_trace_id
+    def test_ui_trace_getters_are_session_bound(self):
+        from kimi_cli.ui.shell.visualize._live_view import _LiveView
 
-        set_current_trace_id(None, root=True)
-        set_current_trace_id("t-sub", root=False)
-        assert get_root_trace_id() is None
-        set_current_trace_id("t-root", root=True)
-        assert get_root_trace_id() == "t-root"
+        trace_ids = {"a": "t-a", "b": "t-b"}
+        view_a = object.__new__(_LiveView)
+        view_a._get_trace_id = lambda: trace_ids["a"]
+        view_b = object.__new__(_LiveView)
+        view_b._get_trace_id = lambda: trace_ids["b"]
+
+        assert view_a._current_trace_id() == "t-a"
+        assert view_b._current_trace_id() == "t-b"
+
+        trace_ids["a"] = "t-a-next"
+        assert view_a._current_trace_id() == "t-a-next"
+        assert view_b._current_trace_id() == "t-b"
 
     @pytest.mark.asyncio
     async def test_contextvar_propagates_to_child_tasks(self):

--- a/tests/ui_and_conv/test_visualize_running_prompt.py
+++ b/tests/ui_and_conv/test_visualize_running_prompt.py
@@ -43,6 +43,7 @@ async def test_visualize_uses_prompt_live_view_when_prompt_session_and_steer_are
             steer,
             btw_runner=None,
             cancel_event,
+            get_trace_id=None,
             show_thinking_stream=False,
         ):
             called.append(("init", initial_status, cancel_event))


### PR DESCRIPTION
## Related Issue

N/A — no tracking issue. This aligns the Python telemetry surface with the
TS rewrite's event registry (`agent-core-v2` `events.ts`).

## Description

**kosong**

- Kimi provider captures the `x-trace-id` response header via
  `with_raw_response` (stream + non-stream); `trace_id` is carried on
  `APIStatusError` (openai + httpx conversion paths)
- `StreamedMessage` / `GenerateResult` / `StepResult` thread `trace_id` through
- New `on_trace_id` callback fired as soon as response headers arrive
  (before streaming), so events emitted mid-stream see the current request

**kimi-cli**

- Two-level current-trace holder (ContextVar per turn task + root mirror for
  UI) feeding `trace_id` into `api_error`, `compaction_*`, `turn_interrupted`,
  `turn_ended`, `cancel`, `tool_call`, `tool_call_dedup_detected`,
  `tool_call_repeat`, `permission_approval_result`, `question_answered/dismissed`
- `compaction_finished/failed` renamed to TS property names
  (`source`/`tokens_before`/`tokens_after`/`input_tokens`/`output_tokens`),
  gain `round`/`thinking_effort`/`compacted_count`
- `api_error` gains `retryable` (TS `isRetryableGenerateError` table, incl.
  408/409/529), `provider_type`/`protocol`, and `overloaded` (529); the non-TS
  `api` error_type folds into `other`
- `tool_call` gains `tool_call_id`, `cancelled` outcome, `trace_id`;
  `error_type` becomes the TS enum (`'error'|'cancelled'`) with the exception
  class moved to `error_class`
- `tool_call_dedup_detected` re-added at same-step/cross-step detection
  (`args_hash` over canonical args)
- `turn_interrupted` gains `interrupt_reason`; `cancel` gains `from`
  (`streaming`/`compacting`); `question_answered` gains `answered`
- New events: `turn_ended` (unconditional at turn end) and
  `permission_approval_result` (all approval decision points; existing
  `tool_approved`/`tool_rejected` kept for compatibility)

Open questions for reviewers:

- `turn_id` is intentionally NOT added: Python currently has uuid-hex turn
  ids while TS uses a per-session monotonic integer — needs a data-side
  decision before unifying the property.
- Auto-approve paths (yolo/afk/session-cache hit) also emit
  `permission_approval_result` (TS only emits when an approval prompt
  resolves); flagged for data-team sign-off.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog.
- [ ] I have run `make gen-docs` to update the user documentation.
