### PR TITLE
fix(kosong): raise a clear error on circular $ref in deref_json_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Kosong: Fix `deref_json_schema` overflowing the stack on a circular `$ref`. A recursive tool parameter model (for example a Pydantic model that references itself) made schema dereferencing recurse until a `RecursionError`; it now raises a clear `ValueError` naming the circular reference
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/packages/kosong/src/kosong/utils/jsonschema.py
+++ b/packages/kosong/src/kosong/utils/jsonschema.py
@@ -43,17 +43,26 @@ def deref_json_schema(schema: JsonDict) -> JsonDict:
         except (KeyError, TypeError, ValueError):
             raise ValueError(f"Unable to resolve reference path: {pointer}") from None
 
-    def traverse(node: JsonType, root: JsonDict) -> JsonType:
-        """Recursively traverse every node to inline local references."""
+    def traverse(node: JsonType, root: JsonDict, seen: frozenset[str] = frozenset()) -> JsonType:
+        """Recursively traverse every node to inline local references.
+
+        ``seen`` holds the ``$ref`` targets currently being inlined along the
+        active chain. A self-referential schema (for example a ``$defs`` entry
+        that Pydantic emits for a recursive model) cannot be fully inlined, so
+        we raise a clear error instead of recursing until the stack overflows.
+        """
         if isinstance(node, dict):
             # Replace local ``$ref`` entries with their referenced payload.
             if "$ref" in node and isinstance(node["$ref"], str):
                 ref_path = node["$ref"]
                 if ref_path.startswith("#"):
+                    if ref_path in seen:
+                        msg = f"Circular $ref detected: {ref_path!r} cannot be inlined"
+                        raise ValueError(msg)
                     # Resolve the local reference target.
                     target = resolve_pointer(root, ref_path)
                     # Recursively inline the target in case it contains more refs.
-                    ref = traverse(target, root)
+                    ref = traverse(target, root, seen | {ref_path})
                     if not isinstance(ref, dict):
                         msg = "Local $ref must resolve to a JSON object"
                         raise TypeError(msg)
@@ -65,11 +74,11 @@ def deref_json_schema(schema: JsonDict) -> JsonDict:
                     return node
 
             # Traverse the remaining mapping entries.
-            return {k: traverse(v, root) for k, v in node.items()}
+            return {k: traverse(v, root, seen) for k, v in node.items()}
 
         elif isinstance(node, list):
             # Traverse list members (e.g. allOf, oneOf, items).
-            return [traverse(item, root) for item in node]
+            return [traverse(item, root, seen) for item in node]
 
         else:
             return node

--- a/packages/kosong/tests/test_json_schema_deref.py
+++ b/packages/kosong/tests/test_json_schema_deref.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel, Field
 
@@ -416,3 +417,16 @@ def test_nested_ref():
             "type": "object",
         }
     )
+
+
+def test_deref_circular_ref_raises():
+    """A self-referential schema cannot be fully inlined. Pydantic emits a
+    circular `$ref` for a recursive model, so `deref_json_schema` must raise a
+    clear error rather than recurse until the stack overflows."""
+
+    class Node(BaseModel):
+        value: str = Field(description="The node value.")
+        children: list[Node] = Field(default_factory=list)
+
+    with pytest.raises(ValueError, match=r"Circular \$ref"):
+        deref_json_schema(Node.model_json_schema())


### PR DESCRIPTION
## Related Issue

None. This is a small self-contained bug fix, well under the 100-line guideline in CONTRIBUTING. Happy to open an issue first if you prefer that flow.

## Description

`kosong.utils.jsonschema.deref_json_schema` inlines every local `$ref` and recursively traverses the target, but it has no cycle detection. A self-referential schema, which Pydantic emits for a recursive model, therefore recursed until a `RecursionError`, despite the docstring promising expansion "without infinite recursion". A tool whose parameter model is recursive crashes tool conversion with a stack overflow:

    from pydantic import BaseModel
    from kosong.utils.jsonschema import deref_json_schema

    class Node(BaseModel):
        value: str
        children: list["Node"] = []

    deref_json_schema(Node.model_json_schema())  # RecursionError

This change tracks the `$ref` targets currently being inlined along the active chain and raises a clear `ValueError` naming the circular reference when a `$ref` points back into that chain. Schemas that reference the same definition several times in different branches are unaffected, since the tracking is scoped to the active chain.

Adds a regression test (`test_deref_circular_ref_raises`); it fails with `RecursionError` on the current code. All 13 tests in `test_json_schema_deref.py` and the kimi tool-conversion tests pass, and ruff is clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any. (No existing issue; explained above.)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog. (Entry added to the Unreleased section by hand in the existing style; `make gen-changelog` drives Kimi CLI itself, which I could not run locally.)
- [ ] I have run `make gen-docs` to update the user documentation. (N/A: no user-facing docs change.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->