### PR TITLE
fix(acp): signal QuestionNotSupported instead of resolving empty answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- ACP: `AskUserQuestion` now signals `QuestionNotSupported` instead of resolving an empty answer, so the model falls back to asking in plain text rather than seeing a phantom user dismissal
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/acp/session.py
+++ b/src/kimi_cli/acp/session.py
@@ -30,6 +30,7 @@ from kimi_cli.wire.types import (
     MCPLoadingEnd,
     Notification,
     PlanDisplay,
+    QuestionNotSupported,
     QuestionRequest,
     StatusUpdate,
     SteerInput,
@@ -209,10 +210,13 @@ class ACPSession:
                     case ToolCallRequest():
                         logger.warning("Unexpected ToolCallRequest in ACP session: {msg}", msg=msg)
                     case QuestionRequest():
+                        # Signal the tool that the client cannot render questions,
+                        # so it can tell the LLM to ask in plain text instead.
                         logger.warning(
-                            "QuestionRequest is unsupported in ACP session; resolving empty answer."
+                            "QuestionRequest is unsupported in ACP session; "
+                            "signaling QuestionNotSupported."
                         )
-                        msg.resolve({})
+                        msg.set_exception(QuestionNotSupported())
                     case _:
                         pass
         except LLMNotSet as e:

--- a/tests/acp/test_session_questions.py
+++ b/tests/acp/test_session_questions.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+import acp
+import pytest
+
+from kimi_cli.acp.session import ACPSession
+from kimi_cli.wire.types import (
+    QuestionItem,
+    QuestionNotSupported,
+    QuestionOption,
+    QuestionRequest,
+    TextPart,
+    TurnBegin,
+    TurnEnd,
+)
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, Any]] = []
+
+    async def session_update(self, session_id: str, update: object) -> None:
+        self.updates.append((session_id, update))
+
+
+def _make_question_request() -> QuestionRequest:
+    return QuestionRequest(
+        id="q1",
+        tool_call_id="tc1",
+        questions=[
+            QuestionItem(
+                question="Which option?",
+                header="Choice",
+                options=[QuestionOption(label="A"), QuestionOption(label="B")],
+                multi_select=False,
+            )
+        ],
+    )
+
+
+class _QuestionCLI:
+    def __init__(self, request: QuestionRequest) -> None:
+        self._request = request
+
+    async def run(self, _user_input, _cancel_event):
+        yield TurnBegin(user_input=[TextPart(text="hello")])
+        yield self._request
+        yield TurnEnd()
+
+
+@pytest.mark.asyncio
+async def test_acp_session_signals_question_not_supported() -> None:
+    request = _make_question_request()
+    session = ACPSession("session-1", _QuestionCLI(request), _FakeConn())  # type: ignore[arg-type]
+
+    response = await session.prompt([acp.text_block("hello")])
+
+    assert response.stop_reason == "end_turn"
+    assert request.resolved
+    with pytest.raises(QuestionNotSupported):
+        await request.wait()


### PR DESCRIPTION
## Related Issue

Resolve #2495

## Description

In ACP server mode every `QuestionRequest` gets resolved with an empty dict (`src/kimi_cli/acp/session.py` line 211), which is indistinguishable from the user actually dismissing the question. The model receives "User dismissed the question without answering" even though the ACP client never rendered anything, so it can retry the tool or just give up on getting an answer.

This applies the short term fix from the issue: signal `QuestionNotSupported` instead. It's the same thing the Wire server already does for clients without the `supports_question` capability (`src/kimi_cli/wire/server.py` line 1055), and it routes into the existing fallback in the ask_user tool which tells the model to ask the question in plain text instead. So over ACP (Zed, JetBrains, etc) the question actually reaches the user now, just as regular text.

One side effect worth calling out: `EnterPlanMode`/`ExitPlanMode` also send `QuestionRequest`, so over ACP they now return their "client does not support plan mode" ToolError instead of a phantom dismissal. That matches how Wire clients without question support already behave, so I think it's the right call, but flagging it in case you see it differently.

Follow up ideas from the issue (out of scope here): hide the AskUserQuestion tool in ACP mode like `_sync_ask_user_tool_visibility` does for Wire, or map questions onto `session/request_permission`. Happy to take a stab at either if there's interest.

Test: added `tests/acp/test_session_questions.py` which runs a prompt turn through `ACPSession` with a fake CLI yielding a `QuestionRequest` and asserts the request resolves with `QuestionNotSupported`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog. (i updated CHANGELOG.md by hand in the same style, the gen-changelog skill needs a Kimi API setup i don't have)
- [x] I have run `make gen-docs` to update the user documentation. (checked docs/, nothing describes ACP question behavior so there was nothing to regenerate)

---

small disclosure: i'm a freshman in college and i talked the logic through with claude code before writing this. the diff is tiny but if i misread how any of this works i would honestly love to know, still learning :)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->