### PR TITLE
feat(kimi): configurable thinking effort and /effort command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Shell: Add `/effort` slash command to view or change the thinking effort level (`off`/`low`/`medium`/`high`/`xhigh`/`max`) — interactive picker when run without arguments, direct set via `/effort <level>`, and `/effort default` to clear the override; the level is saved per model (falling back to the global default), picking an explicit level also switches thinking on/off to match, and the change is applied on reload
+- Core: Add configurable thinking effort — `default_thinking_effort` config, per-model `thinking_effort`, and a `--thinking-effort` CLI flag. The CLI flag implies the thinking switch (`off` disables thinking) while config-file levels apply only when thinking is on; on Kimi providers an explicit level is forwarded via the legacy `reasoning_effort` passthrough while the default path sends nothing, so the model's own default (its maximum thinking) always applies unless you opt into a level
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -4,6 +4,9 @@ This page documents the changes in each Kimi Code CLI release.
 
 ## Unreleased
 
+- Shell: Add `/effort` slash command to view or change the thinking effort level (`off`/`low`/`medium`/`high`/`xhigh`/`max`) — interactive picker when run without arguments, direct set via `/effort <level>`, and `/effort default` to clear the override; the level is saved per model (falling back to the global default), picking an explicit level also switches thinking on/off to match, and the change is applied on reload
+- Core: Add configurable thinking effort — `default_thinking_effort` config, per-model `thinking_effort`, and a `--thinking-effort` CLI flag. The CLI flag implies the thinking switch (`off` disables thinking) while config-file levels apply only when thinking is on; on Kimi providers an explicit level is forwarded via the legacy `reasoning_effort` passthrough while the default path sends nothing, so the model's own default (its maximum thinking) always applies unless you opt into a level
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -4,6 +4,9 @@
 
 ## 未发布
 
+- Shell：新增 `/effort` 斜杠命令查看或切换思考档位（`off`/`low`/`medium`/`high`/`xhigh`/`max`）——无参数时弹出交互选择器，`/effort <档位>` 直接设置，`/effort default` 清除覆盖；档位按模型保存（无法匹配模型时回落到全局默认），选择具体档位会同步思考开关，保存后自动重载生效
+- Core：思考档位可配置——新增 `default_thinking_effort` 全局配置、`models.<name>.thinking_effort` 单模型配置与 `--thinking-effort` CLI 参数。CLI 参数会联动思考开关（`off` 即关闭思考），配置文件中的档位仅在思考开启时生效；Kimi 供应商下显式档位经旧版 `reasoning_effort` 透传，默认路径不发送任何 effort 参数，因此除非主动选择档位，否则始终应用模型自身默认（最大思考）
+
 ## 1.49.0 (2026-07-16)
 
 **亮点**：Kimi 供应商的补全 token 预算现在会根据模型剩余上下文窗口动态调整，减少长轮次中的上下文超限错误

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import kaos
 from kaos.path import KaosPath
+from kosong.chat_provider import ThinkingEffort
 from pydantic import SecretStr
 
 from kimi_cli.agentspec import DEFAULT_AGENT_FILE
@@ -126,6 +127,7 @@ class KimiCLI:
         config: Config | Path | None = None,
         model_name: str | None = None,
         thinking: bool | None = None,
+        thinking_effort: ThinkingEffort | None = None,
         # Run mode
         yolo: bool = False,
         afk: bool = False,
@@ -230,8 +232,18 @@ class KimiCLI:
         assert model is not None
         env_overrides = augment_provider_with_env_vars(provider, model)
 
+        # An explicit --thinking-effort implies the thinking switch (a level above
+        # "off" enables thinking, "off" disables it) unless --thinking was given.
+        # Config-file levels never flip the switch — they apply when thinking is on.
+        if thinking is None and thinking_effort is not None:
+            thinking = thinking_effort != "off"
+
         # determine thinking mode
         thinking = config.default_thinking if thinking is None else thinking
+
+        # determine thinking effort: CLI > per-model config > global config
+        if thinking_effort is None:
+            thinking_effort = model.thinking_effort or config.default_thinking_effort
 
         # determine yolo mode
         yolo = yolo if yolo else config.default_yolo
@@ -244,6 +256,7 @@ class KimiCLI:
             provider,
             model,
             thinking=thinking,
+            thinking_effort=thinking_effort,
             session_id=session.id,
             oauth=oauth,
         )

--- a/src/kimi_cli/cli/__init__.py
+++ b/src/kimi_cli/cli/__init__.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, get_args
 
 import typer
+from kosong.chat_provider import ThinkingEffort
 
 if TYPE_CHECKING:
     from kimi_cli.session import Session
 
 from ._lazy_group import LazySubcommandGroup
+
+# typer cannot resolve kosong's PEP 695 `type ThinkingEffort = Literal[...]` alias
+# in option annotations (RuntimeError: Type not yet supported), so the levels are
+# spelled out inline at --thinking-effort below. The two definitions must not
+# drift — this assert fails at import time if kosong ever changes the set.
+assert set(get_args(ThinkingEffort.__value__)) == {
+    "off",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+}
 
 
 class Reload(Exception):
@@ -183,6 +197,18 @@ def kimi(
         typer.Option(
             "--thinking/--no-thinking",
             help="Enable thinking mode. Default: default thinking mode set in config file.",
+        ),
+    ] = None,
+    # NOTE: inline Literal mirrors kosong's ThinkingEffort (guarded above) —
+    # typer cannot resolve the PEP 695 alias in option annotations.
+    thinking_effort: Annotated[
+        Literal["off", "low", "medium", "high", "xhigh", "max"] | None,
+        typer.Option(
+            "--thinking-effort",
+            help=(
+                "Thinking effort level (off/low/medium/high/xhigh/max). "
+                "Implies --thinking unless 'off'. Default: high when thinking is on."
+            ),
         ),
     ] = None,
     # Run mode
@@ -621,6 +647,7 @@ def kimi(
                 config=config,
                 model_name=model_name,
                 thinking=thinking,
+                thinking_effort=thinking_effort,
                 yolo=yolo,
                 afk=afk,
                 runtime_afk=ui == "print",

--- a/src/kimi_cli/config.py
+++ b/src/kimi_cli/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Literal, Self
 
 import tomlkit
+from kosong.chat_provider import ThinkingEffort
 from pydantic import (
     AliasChoices,
     BaseModel,
@@ -70,6 +71,14 @@ class LLMModel(BaseModel):
     """Model capabilities"""
     display_name: str | None = None
     """Human-readable model name (sourced from the provider's models API when available)"""
+    thinking_effort: ThinkingEffort | None = None
+    """Default thinking effort level for this model (off/low/medium/high/xhigh/max).
+    Overrides the global ``default_thinking_effort``. Applies when thinking mode is
+    enabled — a config-file level never flips the thinking switch on its own (the
+    ``/effort`` command and the ``--thinking-effort`` flag do). For Kimi models an
+    explicit level is forwarded as the legacy ``reasoning_effort`` passthrough
+    (low/medium/high reduce reasoning; unknown values such as "max" are ignored by
+    the server, which then applies the model default — its maximum thinking)."""
 
 
 class LoopControl(BaseModel):
@@ -198,6 +207,16 @@ class Config(BaseModel):
     )
     default_model: str = Field(default="", description="Default model to use")
     default_thinking: bool = Field(default=False, description="Default thinking mode")
+    default_thinking_effort: ThinkingEffort | None = Field(
+        default=None,
+        description=(
+            "Default thinking effort level (off/low/medium/high/xhigh/max) applied when "
+            "thinking mode is enabled; never flips the thinking switch on its own. "
+            "Overridden per model by models.<name>.thinking_effort and per run by "
+            "--thinking-effort (which does imply the switch). When unset, no effort "
+            "parameter is sent and the model's own default applies."
+        ),
+    )
     default_yolo: bool = Field(default=False, description="Default yolo (auto-approve) mode")
     skip_afk_prompt_injection: bool = Field(
         default=False,

--- a/src/kimi_cli/llm.py
+++ b/src/kimi_cli/llm.py
@@ -328,6 +328,7 @@ def create_llm(
     model: LLMModel,
     *,
     thinking: bool | None = None,
+    thinking_effort: ThinkingEffort | None = None,
     session_id: str | None = None,
     oauth: OAuthManager | None = None,
 ) -> LLM | None:
@@ -471,12 +472,31 @@ def create_llm(
 
     capabilities = derive_model_capabilities(model)
 
+    # An explicit effort implies the thinking switch when none was given: any level
+    # above "off" enables thinking, "off" disables it.
+    if thinking is None and thinking_effort is not None:
+        thinking = thinking_effort != "off"
+
     # Apply thinking if specified or if model always requires thinking
     thinking_on = "always_thinking" in capabilities or (
         thinking is True and "thinking" in capabilities
     )
     if thinking_on:
-        chat_provider = chat_provider.with_thinking("high")
+        effort: ThinkingEffort = (
+            thinking_effort if thinking_effort and thinking_effort != "off" else "high"
+        )
+        chat_provider = chat_provider.with_thinking(effort)
+        # Kimi serializes only ``thinking.type`` (upstream kosong behavior). Honor an
+        # *explicitly requested* effort via the legacy ``reasoning_effort`` passthrough
+        # so it actually reaches the server: the coding API honors low/medium/high
+        # (reduces reasoning) and silently ignores unknown values such as "max",
+        # falling back to the model default — which is its maximum thinking. The
+        # default path deliberately sends nothing so that default always applies.
+        if thinking_effort and provider.type == "kimi":
+            from kosong.chat_provider.kimi import Kimi
+
+            if isinstance(chat_provider, Kimi):
+                chat_provider = chat_provider.with_generation_kwargs(reasoning_effort=effort)
     elif thinking is False:
         chat_provider = chat_provider.with_thinking("off")
     # If thinking is None and model doesn't always think, leave as-is (default behavior)

--- a/src/kimi_cli/ui/shell/slash.py
+++ b/src/kimi_cli/ui/shell/slash.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, cast
 
+from kosong.chat_provider import ThinkingEffort
 from prompt_toolkit.shortcuts.choice_input import ChoiceInput
 
 from kimi_cli import logger
@@ -307,6 +308,139 @@ async def model(app: Shell, args: str):
         f"[green]Switched to {selected_display} "
         f"with thinking {'on' if new_thinking else 'off'}. "
         "Reloading...[/green]"
+    )
+    raise Reload(session_id=soul.runtime.session.id)
+
+
+_THINKING_EFFORT_LEVELS: tuple[str, ...] = ("off", "low", "medium", "high", "xhigh", "max")
+
+
+@registry.command
+async def effort(app: Shell, args: str):
+    """View or change the thinking effort level (off/low/medium/high/xhigh/max)"""
+    soul = ensure_kimi_soul(app)
+    if soul is None:
+        return
+    config = soul.runtime.config
+
+    if not config.is_from_default_location:
+        console.print(
+            "[yellow]Changing thinking effort requires the default config file; "
+            "restart without --config/--config-file.[/yellow]"
+        )
+        return
+
+    # Current effective effort (runtime) and the configured override (if any)
+    curr_effort = soul.runtime.llm.chat_provider.thinking_effort if soul.runtime.llm else None
+    curr_model_cfg = soul.runtime.llm.model_config if soul.runtime.llm else None
+    curr_model_name: str | None = None
+    if curr_model_cfg is not None:
+        for name, model_cfg in config.models.items():
+            if model_cfg == curr_model_cfg:
+                curr_model_name = name
+                break
+    configured_effort = (
+        curr_model_cfg.thinking_effort if curr_model_cfg is not None else None
+    ) or config.default_thinking_effort
+
+    from kimi_cli.llm import derive_model_capabilities
+
+    always_thinking = curr_model_cfg is not None and (
+        "always_thinking" in derive_model_capabilities(curr_model_cfg)
+    )
+
+    selected_effort: ThinkingEffort | None
+    arg = args.strip().lower()
+    if arg:
+        if arg in ("default", "unset", "clear"):
+            selected_effort = None
+        elif arg in _THINKING_EFFORT_LEVELS:
+            selected_effort = cast(ThinkingEffort, arg)
+        else:
+            console.print(
+                f"[red]Invalid effort level: {arg}[/red] "
+                f"(expected one of: {', '.join(_THINKING_EFFORT_LEVELS)}, default)"
+            )
+            return
+    else:
+        choices: list[tuple[str, str]] = [
+            (level, level + (" (current)" if level == curr_effort else ""))
+            for level in _THINKING_EFFORT_LEVELS
+        ]
+        choices.append(
+            (
+                "default",
+                "default (no explicit effort)"
+                + (" (current)" if configured_effort is None else ""),
+            )
+        )
+        try:
+            selection = await ChoiceInput(
+                message=(
+                    f"Thinking effort (current: {curr_effort or 'default'}; "
+                    "↑↓ navigate, Enter select, Ctrl+C cancel):"
+                ),
+                options=choices,
+                default=curr_effort or "default",
+            ).prompt_async()
+        except (EOFError, KeyboardInterrupt):
+            return
+        if not selection:
+            return
+        selected_effort = None if selection == "default" else cast(ThinkingEffort, selection)
+
+    if selected_effort == configured_effort:
+        console.print(
+            f"[yellow]Thinking effort is already {selected_effort or 'default'}.[/yellow]"
+        )
+        return
+
+    if selected_effort == "off" and always_thinking:
+        console.print("[yellow]This model always thinks; effort 'off' cannot disable it.[/yellow]")
+        return
+
+    # Save: prefer the per-model override when the current model is known, so the
+    # level stays attached to the model it was tuned for; otherwise set the global
+    # default. An explicitly chosen level also implies the thinking switch: keep
+    # default_thinking coherent so the level actually takes effect after reload.
+    switch_note = ""
+    try:
+        config_for_save = load_config()
+        if curr_model_name is not None and curr_model_name in config_for_save.models:
+            config_for_save.models[curr_model_name].thinking_effort = selected_effort
+            target = f"model {curr_model_name}"
+        else:
+            config_for_save.default_thinking_effort = selected_effort
+            target = "global default"
+        if selected_effort is not None and not always_thinking:
+            new_thinking = selected_effort != "off"
+            if config_for_save.default_thinking != new_thinking:
+                config_for_save.default_thinking = new_thinking
+                switch_note = f" Thinking switched {'on' if new_thinking else 'off'} to match."
+        save_config(config_for_save)
+    except (ConfigError, OSError) as exc:
+        console.print(f"[red]Failed to save config: {exc}[/red]")
+        return
+
+    # Keep the in-memory config in sync for this process
+    if curr_model_name is not None and curr_model_name in config.models:
+        config.models[curr_model_name].thinking_effort = selected_effort
+    else:
+        config.default_thinking_effort = selected_effort
+    if selected_effort is not None and not always_thinking:
+        config.default_thinking = selected_effort != "off"
+
+    note = ""
+    if selected_effort in ("xhigh", "max"):
+        note = (
+            "\n[dim]note: levels above high take effect only on providers that accept "
+            "them (e.g. Anthropic). Kimi forwards the level verbatim and the server "
+            "decides — unknown levels fall back to the model default, which is its "
+            "maximum thinking.[/dim]"
+        )
+    console.print(
+        f"[green]Thinking effort set to {selected_effort or 'default'} for {target}."
+        f"{switch_note} Reloading...[/green]{note}"
     )
     raise Reload(session_id=soul.runtime.session.id)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -23,6 +23,7 @@ def test_default_config_dump():
         {
             "default_model": "",
             "default_thinking": False,
+            "default_thinking_effort": None,
             "default_yolo": False,
             "default_plan_mode": False,
             "default_editor": "",
@@ -97,6 +98,31 @@ def test_load_config_text_invalid():
 def test_load_config_invalid_ralph_iterations():
     with pytest.raises(ConfigError, match="max_ralph_iterations"):
         load_config_from_string('{"loop_control": {"max_ralph_iterations": -2}}')
+
+
+def test_load_config_default_thinking_effort():
+    config = load_config_from_string('default_thinking_effort = "max"\n')
+    assert config.default_thinking_effort == "max"
+
+
+def test_load_config_model_thinking_effort():
+    config = load_config_from_string(
+        '[providers."test-provider"]\n'
+        'type = "kimi"\n'
+        'base_url = "https://api.test/v1"\n'
+        'api_key = ""\n'
+        '[models."test/model"]\n'
+        'provider = "test-provider"\n'
+        'model = "test-model"\n'
+        "max_context_size = 100000\n"
+        'thinking_effort = "max"\n'
+    )
+    assert config.models["test/model"].thinking_effort == "max"
+
+
+def test_load_config_thinking_effort_invalid():
+    with pytest.raises(ConfigError, match="thinking_effort"):
+        load_config_from_string('default_thinking_effort = "ultra"\n')
 
 
 def test_load_config_reserved_context_size():

--- a/tests/core/test_create_llm.py
+++ b/tests/core/test_create_llm.py
@@ -598,6 +598,115 @@ def test_create_llm_kimi_thinking_keep_skipped_when_thinking_off(monkeypatch):
     assert "reasoning_effort" not in llm.chat_provider.model_parameters
 
 
+def _make_kimi_switchable_thinking_model() -> tuple[LLMProvider, LLMModel]:
+    """Helper: kimi provider + model with an explicit (switchable) thinking capability."""
+    provider = LLMProvider(
+        type="kimi",
+        base_url="https://api.test/v1",
+        api_key=SecretStr("test-key"),
+    )
+    model = LLMModel(
+        provider="kimi",
+        # no "thinking"/"reason" marker in the name, so derive_model_capabilities
+        # keeps exactly the explicit set below (switchable, not always-thinking)
+        model="kimi-switchable-toggle",
+        max_context_size=4096,
+        capabilities={"thinking"},
+    )
+    return provider, model
+
+
+def test_create_llm_thinking_effort_replaces_hardcoded_high():
+    """An explicit thinking_effort is applied to the provider instead of the
+    hardcoded default "high". For Kimi the wire still only carries thinking.type;
+    the level is kept as provider state."""
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model, thinking_effort="max")
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "max"
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    assert extra_body.get("thinking", {}).get("type") == "enabled"
+
+
+def test_create_llm_thinking_effort_implies_thinking_on():
+    """A non-off effort implies thinking on when thinking itself is not set."""
+    provider, model = _make_kimi_switchable_thinking_model()
+
+    llm = create_llm(provider, model, thinking_effort="low")
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "low"
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    assert extra_body.get("thinking", {}).get("type") == "enabled"
+
+
+def test_create_llm_thinking_effort_off_disables_thinking():
+    """thinking_effort="off" implies thinking disabled when thinking is not set."""
+    provider, model = _make_kimi_switchable_thinking_model()
+
+    llm = create_llm(provider, model, thinking_effort="off")
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "off"
+    extra_body = llm.chat_provider.model_parameters.get("extra_body") or {}
+    assert extra_body.get("thinking", {}).get("type") == "disabled"
+
+
+def test_create_llm_explicit_thinking_false_wins_over_effort():
+    """An explicit thinking=False beats a non-off effort (switch over level)."""
+    provider, model = _make_kimi_switchable_thinking_model()
+
+    llm = create_llm(provider, model, thinking=False, thinking_effort="max")
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "off"
+
+
+def test_create_llm_kimi_explicit_effort_passes_through_as_reasoning_effort():
+    """An explicitly requested effort on a Kimi provider is forwarded via the
+    legacy ``reasoning_effort`` passthrough so the server can actually honor it."""
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model, thinking_effort="low")
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "low"
+    assert llm.chat_provider.model_parameters.get("reasoning_effort") == "low"
+
+
+def test_create_llm_kimi_max_effort_passes_through_verbatim():
+    """ "max" is forwarded unchanged — the server is the source of truth (it
+    ignores unknown values and applies the model default = maximum thinking)."""
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model, thinking_effort="max")
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "max"
+    assert llm.chat_provider.model_parameters.get("reasoning_effort") == "max"
+
+
+def test_create_llm_kimi_default_path_sends_no_reasoning_effort():
+    """With no explicit effort configured, no reasoning_effort is sent, so the
+    model's own default (its maximum thinking) applies."""
+    provider, model = _make_kimi_thinking_model()
+
+    llm = create_llm(provider, model, thinking=True)
+    assert llm is not None
+    assert isinstance(llm.chat_provider, Kimi)
+
+    assert llm.chat_provider.thinking_effort == "high"
+    assert "reasoning_effort" not in llm.chat_provider.model_parameters
+
+
 def test_create_llm_kimi_thinking_keep_skipped_when_no_thinking_branch(monkeypatch):
     """When the model has no thinking capability and thinking is None, neither
     with_thinking branch runs — keep must also NOT be injected."""

--- a/tests/core/test_thinking_effort_flag.py
+++ b/tests/core/test_thinking_effort_flag.py
@@ -1,0 +1,183 @@
+"""Tests for thinking / thinking-effort resolution in KimiCLI.create().
+
+Precedence rules under test:
+- An explicit --thinking-effort flag implies the thinking switch (a level above
+  "off" enables thinking, "off" disables it).
+- An explicit --thinking flag beats --thinking-effort.
+- Config-file effort levels (per-model > global) apply only when thinking is
+  already on — they never flip the thinking switch by themselves.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import SecretStr
+
+import kimi_cli.app as app_module
+from kimi_cli.app import KimiCLI
+from kimi_cli.config import Config, LLMModel, LLMProvider
+
+_PROVIDER = "test-provider"
+_MODEL = "test/model"
+
+
+def _make_config(
+    *,
+    default_thinking: bool = False,
+    default_effort: str | None = None,
+    model_effort: str | None = None,
+) -> Config:
+    return Config(
+        default_model=_MODEL,
+        default_thinking=default_thinking,
+        default_thinking_effort=default_effort,  # type: ignore[arg-type]
+        providers={
+            _PROVIDER: LLMProvider(
+                type="kimi",
+                base_url="https://api.test/v1",
+                api_key=SecretStr("test-key"),
+            )
+        },
+        models={
+            _MODEL: LLMModel(
+                provider=_PROVIDER,
+                model="test-model",
+                max_context_size=100_000,
+                capabilities={"thinking"},
+                thinking_effort=model_effort,  # type: ignore[arg-type]
+            )
+        },
+    )
+
+
+@pytest.fixture
+def create_llm_calls(monkeypatch) -> list[dict]:
+    """Patch heavy KimiCLI.create() dependencies and capture create_llm kwargs."""
+    calls: list[dict] = []
+
+    def fake_create_llm(*args, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    fake_context = SimpleNamespace(system_prompt=None)
+    fake_context.restore = AsyncMock()
+    fake_context.write_system_prompt = AsyncMock()
+
+    async def fake_runtime_create(config, _oauth, _llm, session, yolo, **kwargs):
+        return SimpleNamespace(
+            session=session,
+            config=config,
+            llm=None,
+            approval=SimpleNamespace(
+                is_yolo=lambda: yolo,
+                is_afk=lambda: kwargs.get("afk", False) or kwargs.get("runtime_afk", False),
+            ),
+            notifications=SimpleNamespace(recover=lambda: None),
+            background_tasks=SimpleNamespace(reconcile=lambda: None),
+        )
+
+    class FakeSoul:
+        def __init__(self, agent, context):
+            pass
+
+        def set_hook_engine(self, engine):
+            pass
+
+    monkeypatch.setattr(app_module, "load_config", lambda conf: conf)
+    monkeypatch.setattr(app_module, "augment_provider_with_env_vars", lambda p, m: {})
+    monkeypatch.setattr(app_module, "create_llm", fake_create_llm)
+    monkeypatch.setattr(app_module.Runtime, "create", fake_runtime_create)
+    monkeypatch.setattr(
+        app_module,
+        "load_agent",
+        AsyncMock(return_value=SimpleNamespace(name="test", system_prompt="sp")),
+    )
+    monkeypatch.setattr(app_module, "Context", lambda _path: fake_context)
+    monkeypatch.setattr(app_module, "KimiSoul", FakeSoul)
+    return calls
+
+
+class TestEffortFlagImpliesThinking:
+    async def test_flag_level_enables_thinking_when_config_off(self, session, create_llm_calls):
+        """--thinking-effort low with default_thinking=false still runs with thinking."""
+        config = _make_config(default_thinking=False)
+
+        await KimiCLI.create(session, config=config, thinking_effort="low", resumed=False)
+
+        assert create_llm_calls[0]["thinking"] is True
+        assert create_llm_calls[0]["thinking_effort"] == "low"
+
+    async def test_flag_off_disables_thinking_when_config_on(self, session, create_llm_calls):
+        """--thinking-effort off with default_thinking=true runs with thinking off."""
+        config = _make_config(default_thinking=True)
+
+        await KimiCLI.create(session, config=config, thinking_effort="off", resumed=False)
+
+        assert create_llm_calls[0]["thinking"] is False
+        assert create_llm_calls[0]["thinking_effort"] == "off"
+
+    async def test_explicit_thinking_flag_beats_effort_flag(self, session, create_llm_calls):
+        """--thinking wins over --thinking-effort off (explicit switch over level)."""
+        config = _make_config(default_thinking=False)
+
+        await KimiCLI.create(
+            session, config=config, thinking=True, thinking_effort="off", resumed=False
+        )
+
+        assert create_llm_calls[0]["thinking"] is True
+        assert create_llm_calls[0]["thinking_effort"] == "off"
+
+
+class TestConfigEffortNeverFlipsSwitch:
+    async def test_model_effort_does_not_enable_thinking(self, session, create_llm_calls):
+        """Per-model config effort applies the level but leaves the switch as configured."""
+        config = _make_config(default_thinking=False, model_effort="max")
+
+        await KimiCLI.create(session, config=config, resumed=False)
+
+        assert create_llm_calls[0]["thinking"] is False
+        assert create_llm_calls[0]["thinking_effort"] == "max"
+
+    async def test_global_effort_does_not_enable_thinking(self, session, create_llm_calls):
+        """Global config effort applies the level but leaves the switch as configured."""
+        config = _make_config(default_thinking=False, default_effort="low")
+
+        await KimiCLI.create(session, config=config, resumed=False)
+
+        assert create_llm_calls[0]["thinking"] is False
+        assert create_llm_calls[0]["thinking_effort"] == "low"
+
+    async def test_model_effort_applies_when_thinking_on(self, session, create_llm_calls):
+        config = _make_config(default_thinking=True, model_effort="max")
+
+        await KimiCLI.create(session, config=config, resumed=False)
+
+        assert create_llm_calls[0]["thinking"] is True
+        assert create_llm_calls[0]["thinking_effort"] == "max"
+
+
+class TestEffortPrecedence:
+    async def test_flag_beats_model_config(self, session, create_llm_calls):
+        config = _make_config(default_thinking=True, model_effort="max")
+
+        await KimiCLI.create(session, config=config, thinking_effort="low", resumed=False)
+
+        assert create_llm_calls[0]["thinking_effort"] == "low"
+
+    async def test_model_config_beats_global_config(self, session, create_llm_calls):
+        config = _make_config(default_thinking=True, default_effort="low", model_effort="max")
+
+        await KimiCLI.create(session, config=config, resumed=False)
+
+        assert create_llm_calls[0]["thinking_effort"] == "max"
+
+    async def test_no_effort_anywhere_passes_none(self, session, create_llm_calls):
+        config = _make_config(default_thinking=True)
+
+        await KimiCLI.create(session, config=config, resumed=False)
+
+        assert create_llm_calls[0]["thinking"] is True
+        assert create_llm_calls[0]["thinking_effort"] is None

--- a/tests/ui_and_conv/test_shell_effort_slash.py
+++ b/tests/ui_and_conv/test_shell_effort_slash.py
@@ -1,0 +1,198 @@
+"""Tests for the /effort slash command.
+
+Verifies registration, the direct-args path (/effort <level>), per-model vs
+global config persistence, invalid input handling, and the Reload flow.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from pydantic import SecretStr
+
+from kimi_cli.cli import Reload
+from kimi_cli.config import Config, LLMModel, LLMProvider
+from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.ui.shell import slash as slash_module
+from kimi_cli.ui.shell.slash import ShellSlashCmdFunc, shell_mode_registry
+from kimi_cli.ui.shell.slash import registry as shell_slash_registry
+from kimi_cli.utils.slashcmd import SlashCommand
+
+_MODEL_NAME = "test/model"
+
+
+def _make_config() -> Config:
+    config = Config(
+        default_model=_MODEL_NAME,
+        default_thinking=True,
+        providers={
+            "test-provider": LLMProvider(
+                type="kimi",
+                base_url="https://api.test/v1",
+                api_key=SecretStr("test-key"),
+            )
+        },
+        models={
+            _MODEL_NAME: LLMModel(
+                provider="test-provider",
+                model="test-model",
+                max_context_size=100_000,
+            )
+        },
+    )
+    config.is_from_default_location = True
+    return config
+
+
+def _mock_shell(config: Config, effort: str | None = "high", session_id: str = "sess-1") -> Mock:
+    """Mock Shell whose soul passes the KimiSoul isinstance check."""
+    soul = Mock(spec=KimiSoul)
+    soul.runtime.config = config
+    soul.runtime.session.id = session_id
+    soul.runtime.llm.model_config = config.models[_MODEL_NAME]
+    soul.runtime.llm.chat_provider.thinking_effort = effort
+    shell = Mock()
+    shell.soul = soul
+    return shell
+
+
+async def _invoke(command: SlashCommand[ShellSlashCmdFunc], shell: Any, args: str) -> None:
+    ret = command.func(shell, args)
+    if isinstance(ret, Awaitable):
+        await ret
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    """Wire load/save config to an in-memory Config."""
+    config = _make_config()
+    saved: list[Config] = []
+
+    monkeypatch.setattr(slash_module, "load_config", lambda: config)
+    monkeypatch.setattr(slash_module, "save_config", lambda cfg: saved.append(cfg))
+
+    shell = _mock_shell(config)
+    cmd = shell_slash_registry.find_command("effort")
+    assert cmd is not None
+    return shell, config, saved, cmd
+
+
+class TestEffortCommandRegistration:
+    def test_registered_in_shell_registry(self) -> None:
+        cmd = shell_slash_registry.find_command("effort")
+        assert cmd is not None
+        assert cmd.name == "effort"
+        assert "effort" in cmd.description
+
+    def test_not_in_shell_mode_registry(self) -> None:
+        assert shell_mode_registry.find_command("effort") is None
+
+
+class TestEffortCommandArgs:
+    async def test_set_level_saves_per_model_and_reloads(self, harness) -> None:
+        shell, config, saved, cmd = harness
+
+        with pytest.raises(Reload) as exc_info:
+            await _invoke(cmd, shell, "max")
+
+        assert exc_info.value.session_id == "sess-1"
+        assert len(saved) == 1
+        assert saved[0].models[_MODEL_NAME].thinking_effort == "max"
+        # thinking was already on — stays on
+        assert saved[0].default_thinking is True
+        # in-memory config stays in sync for this process
+        assert config.models[_MODEL_NAME].thinking_effort == "max"
+
+    async def test_set_level_enables_thinking_when_off(self, harness) -> None:
+        """Picking a level while thinking is off also flips default_thinking on,
+        so the level actually takes effect after the reload."""
+        shell, config, saved, cmd = harness
+        config.default_thinking = False
+
+        with pytest.raises(Reload):
+            await _invoke(cmd, shell, "low")
+
+        assert saved[0].models[_MODEL_NAME].thinking_effort == "low"
+        assert saved[0].default_thinking is True
+        assert config.default_thinking is True
+
+    async def test_off_switches_thinking_off(self, harness) -> None:
+        """/effort off persists default_thinking=false so it survives the reload."""
+        shell, config, saved, cmd = harness
+        assert config.default_thinking is True
+
+        with pytest.raises(Reload):
+            await _invoke(cmd, shell, "off")
+
+        assert saved[0].models[_MODEL_NAME].thinking_effort == "off"
+        assert saved[0].default_thinking is False
+        assert config.default_thinking is False
+
+    async def test_off_rejected_for_always_thinking_model(self, harness) -> None:
+        """A model that always thinks cannot be turned off via /effort off."""
+        shell, config, saved, cmd = harness
+        config.models[_MODEL_NAME].model = "test-model-thinking"  # name implies always-thinking
+
+        await _invoke(cmd, shell, "off")
+
+        assert saved == []
+        assert config.models[_MODEL_NAME].thinking_effort is None
+
+    async def test_default_clears_override(self, harness) -> None:
+        shell, config, saved, cmd = harness
+        config.models[_MODEL_NAME].thinking_effort = "max"
+        config.default_thinking = False
+
+        with pytest.raises(Reload):
+            await _invoke(cmd, shell, "default")
+
+        assert len(saved) == 1
+        assert saved[0].models[_MODEL_NAME].thinking_effort is None
+        # clearing the level leaves the thinking switch untouched
+        assert saved[0].default_thinking is False
+        assert config.default_thinking is False
+
+    async def test_invalid_level_is_rejected_without_save(self, harness) -> None:
+        shell, config, saved, cmd = harness
+
+        await _invoke(cmd, shell, "ultra")
+
+        assert saved == []
+        assert config.models[_MODEL_NAME].thinking_effort is None
+
+    async def test_noop_when_level_already_set(self, harness) -> None:
+        shell, config, saved, cmd = harness
+        config.models[_MODEL_NAME].thinking_effort = "max"
+
+        await _invoke(cmd, shell, "max")
+
+        assert saved == []
+
+    async def test_falls_back_to_global_default_when_model_unknown(
+        self, harness, monkeypatch
+    ) -> None:
+        shell, config, saved, cmd = harness
+        # runtime model does not match any configured model -> global default
+        shell.soul.runtime.llm.model_config = LLMModel(
+            provider="test-provider",
+            model="some-other-model",
+            max_context_size=8192,
+        )
+
+        with pytest.raises(Reload):
+            await _invoke(cmd, shell, "low")
+
+        assert len(saved) == 1
+        assert saved[0].default_thinking_effort == "low"
+        assert config.default_thinking_effort == "low"
+
+    async def test_requires_default_config_location(self, harness) -> None:
+        shell, config, saved, cmd = harness
+        config.is_from_default_location = False
+
+        await _invoke(cmd, shell, "max")
+
+        assert saved == []


### PR DESCRIPTION
## Related Issue

Resolve #2501

Related: #318 (closed — reasoning_effort support), #2499 (kept the explicit legacy `reasoning_effort` passthrough this PR builds on). Approach was announced in [#2501 (comment)](https://github.com/MoonshotAI/kimi-cli/issues/2501#issuecomment-5012680393).

## Description

Adds a first-class, quick way to view and switch the thinking effort level, implementing option 1 from #2501 (slash command) under the name `/effort` — chosen to avoid confusion with the existing thinking on/off switch (Tab). Happy to rename to `/thinking <level>` if preferred.

**User-facing surface**

- `/effort` — interactive picker (marks the current level); `/effort <level>` sets directly; `/effort default` clears the override. The level is persisted to `models.<name>.thinking_effort` (falling back to the global `default_thinking_effort` when the runtime model can't be matched to the config) and applied on reload.
- `--thinking-effort` CLI flag, plus `default_thinking_effort` (global) and `models.<name>.thinking_effort` (per-model) config. Precedence: CLI > per-model > global.

**Semantics (the part worth reviewing)**

- An *explicitly chosen* level implies the thinking switch: the CLI flag and `/effort` flip thinking on/off to match (`off` disables thinking). This avoids the "picked a level but thinking is off, so nothing happens" trap. `/effort off` is rejected for always-thinking models.
- Config-file levels never flip the switch by themselves — they apply only when thinking is already on, so a standing per-model level can't silently resurrect thinking after the user turned it off via `/model`.
- Kimi providers: an explicit level is forwarded via the legacy `reasoning_effort` passthrough (retained by #2499) so the server can actually honor it — `low`/`medium`/`high` genuinely reduce reasoning; `max` is forwarded verbatim and the server currently ignores it, falling back to the model default (its maximum thinking). The **default path sends no effort parameter at all**, preserving current behavior exactly unless a level is opted into.
- Other providers receive the level through the existing `with_thinking(effort)` state (e.g. Anthropic `xhigh`/`max`), unchanged.

Notes: typer can't resolve kosong's PEP 695 `type ThinkingEffort = Literal[...]` alias in option annotations, so the levels are spelled inline at `--thinking-effort` with an import-time assert guarding against drift. Changelog entries were added manually to `CHANGELOG.md` and the en/zh docs changelogs in the established format (I did not run the LLM-driven `make gen-changelog`/`gen-docs`). No new telemetry events are introduced.

## Testing

- `uv run pytest tests/core/test_thinking_effort_flag.py tests/ui_and_conv/test_shell_effort_slash.py tests/core/test_create_llm.py tests/core/test_config.py -q` — 78 passed (29 new tests: flag/config precedence & switch implication in `KimiCLI.create()`, `create_llm` effort application & Kimi passthrough, `/effort` registration/persistence/switch-sync/reload flow, config parsing & validation)
- `uv run pytest tests/core tests/ui_and_conv -q` — 1628 passed
- `uv run ruff check && uv run ruff format --check && uv run pyright` — clean

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `make gen-changelog` to update the changelog. *(updated `CHANGELOG.md` + en/zh docs changelogs manually instead)*
- [ ] I have run `make gen-docs` to update the user documentation. *(same as above)*
