### PR TITLE
fix(skill): ignore stray markdown in plugins container during skill discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Skills: Stop discovering stray top-level markdown files (e.g. a packaging-artifact CHANGELOG.md) in the plugins container (`~/.kimi/plugins/`) as skills — plugins are documented as independent subdirectories (`plugin.json` + scripts), so only the subdirectory form (`<plugin>/SKILL.md`) is honored at the plugins origin; generic skills roots keep their flat-`.md` support (#2491)
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/src/kimi_cli/skill/__init__.py
+++ b/src/kimi_cli/skill/__init__.py
@@ -38,6 +38,12 @@ class ScopedSkillsRoot:
 
     root: KaosPath
     scope: SkillScope
+    skip_flat_md: bool = False
+    """When True, only the subdirectory form
+    (``<root>/<name>/SKILL.md``) is discovered; flat ``.md`` files directly in
+    ``root`` are ignored. Used for the plugins container origin, where stray
+    packaging markdown (CHANGELOG.md, README.md) must not be treated as
+    skills."""
 
 
 def get_builtin_skills_dir() -> Path:
@@ -214,7 +220,7 @@ async def resolve_skills_roots(
     scoped: list[ScopedSkillsRoot] = []
     seen: set[str] = set()
 
-    def _append(root: KaosPath, scope: SkillScope) -> None:
+    def _append(root: KaosPath, scope: SkillScope, *, skip_flat_md: bool = False) -> None:
         # Dedupe so symlinks, ``..`` segments, and trailing slashes don't
         # produce phantom duplicate entries in the system prompt. Note that
         # ``KaosPath.canonical()`` only normalizes path segments; it does NOT
@@ -240,7 +246,7 @@ async def resolve_skills_roots(
         if key in seen:
             return
         seen.add(key)
-        scoped.append(ScopedSkillsRoot(root=canon, scope=scope))
+        scoped.append(ScopedSkillsRoot(root=canon, scope=scope, skip_flat_md=skip_flat_md))
 
     if skills_dirs:
         # --skills-dir overrides user/project auto-discovery, but runs at the
@@ -281,7 +287,7 @@ async def resolve_skills_roots(
     except OSError:
         plugins_is_dir = False
     if plugins_is_dir:
-        _append(KaosPath.unsafe_from_local_path(plugins_path), "extra")
+        _append(KaosPath.unsafe_from_local_path(plugins_path), "extra", skip_flat_md=True)
 
     if _supports_builtin_skills():
         _append(
@@ -332,7 +338,9 @@ async def discover_skills_from_roots(
     """
     skills_by_name: dict[str, Skill] = {}
     for scoped in scoped_roots:
-        for skill in await discover_skills(scoped.root, scope=scoped.scope):
+        for skill in await discover_skills(
+            scoped.root, scope=scoped.scope, skip_flat_md=scoped.skip_flat_md
+        ):
             skills_by_name.setdefault(normalize_skill_name(skill.name), skill)
     return sorted(skills_by_name.values(), key=lambda s: s.name)
 
@@ -428,6 +436,7 @@ async def discover_skills(
     skills_dir: KaosPath,
     *,
     scope: SkillScope,
+    skip_flat_md: bool = False,
 ) -> list[Skill]:
     """Discover all skills in the given directory.
 
@@ -444,6 +453,11 @@ async def discover_skills(
     *scope* is stamped onto each discovered :class:`Skill` so the system-prompt
     renderer can group skills by where they came from (user / project / extra /
     builtin).
+
+    *skip_flat_md* disables Pass 2 (the flat ``.md`` scan) for this root, so
+    only the subdirectory form is discovered. Used for the plugins container
+    origin, where stray packaging markdown (CHANGELOG.md, README.md) directly
+    in the container must not be treated as skills.
     """
     try:
         is_dir = await skills_dir.is_dir()
@@ -493,54 +507,59 @@ async def discover_skills(
         return sorted(skills_by_name.values(), key=lambda s: s.name)
 
     # Pass 2: flat ``.md`` form, skipping names already claimed by a subdir.
-    try:
-        async for entry in skills_dir.iterdir():
-            try:
-                if await entry.is_dir():
+    # Gated on ``skip_flat_md`` — the plugins container origin sets it True so
+    # stray packaging markdown (CHANGELOG.md, README.md) directly in the
+    # container is not treated as skills. Every other origin keeps the default
+    # (False) and runs both passes, preserving generic flat-``.md`` support.
+    if not skip_flat_md:
+        try:
+            async for entry in skills_dir.iterdir():
+                try:
+                    if await entry.is_dir():
+                        continue
+                except OSError as exc:
+                    logger.info(
+                        "Skipping unstattable entry {path}: {error}",
+                        path=entry,
+                        error=exc,
+                    )
                     continue
-            except OSError as exc:
-                logger.info(
-                    "Skipping unstattable entry {path}: {error}",
-                    path=entry,
-                    error=exc,
-                )
-                continue
-            if not entry.name.lower().endswith(".md"):
-                continue
-            # A bare ``SKILL.md`` at the top of skills_dir is a stray marker file,
-            # not a skill — it has no per-skill directory to associate with.
-            if entry.name.upper() == "SKILL.MD":
-                continue
+                if not entry.name.lower().endswith(".md"):
+                    continue
+                # A bare ``SKILL.md`` at the top of skills_dir is a stray marker file,
+                # not a skill — it has no per-skill directory to associate with.
+                if entry.name.upper() == "SKILL.MD":
+                    continue
 
-            try:
-                content = await entry.read_text(encoding="utf-8")
-                skill = parse_skill_text(
-                    content,
-                    dir_path=skills_dir,
-                    skill_md_file=entry,
-                    scope=scope,
-                    flat_file=entry,
-                )
-            except Exception as exc:
-                logger.info("Skipping invalid flat skill at {}: {}", entry, exc)
-                continue
+                try:
+                    content = await entry.read_text(encoding="utf-8")
+                    skill = parse_skill_text(
+                        content,
+                        dir_path=skills_dir,
+                        skill_md_file=entry,
+                        scope=scope,
+                        flat_file=entry,
+                    )
+                except Exception as exc:
+                    logger.info("Skipping invalid flat skill at {}: {}", entry, exc)
+                    continue
 
-            key = normalize_skill_name(skill.name)
-            if key in skills_by_name:
-                logger.warning(
-                    "Flat skill {flat} shadowed by subdirectory skill of the same "
-                    "name at {sub}; the subdirectory version is used.",
-                    flat=entry,
-                    sub=skills_by_name[key].dir,
-                )
-                continue
-            skills_by_name[key] = skill
-    except OSError as exc:
-        logger.warning(
-            "Failed to iterate skills directory for flat scan {path}: {error}",
-            path=skills_dir,
-            error=exc,
-        )
+                key = normalize_skill_name(skill.name)
+                if key in skills_by_name:
+                    logger.warning(
+                        "Flat skill {flat} shadowed by subdirectory skill of the same "
+                        "name at {sub}; the subdirectory version is used.",
+                        flat=entry,
+                        sub=skills_by_name[key].dir,
+                    )
+                    continue
+                skills_by_name[key] = skill
+        except OSError as exc:
+            logger.warning(
+                "Failed to iterate skills directory for flat scan {path}: {error}",
+                path=skills_dir,
+                error=exc,
+            )
 
     return sorted(skills_by_name.values(), key=lambda s: s.name)
 

--- a/tests/core/test_skill.py
+++ b/tests/core/test_skill.py
@@ -1839,3 +1839,114 @@ async def test_discover_subdir_skill_malformed_frontmatter_opener_not_used_as_de
     assert len(skills) == 1
     assert skills[0].description != "---"
     assert skills[0].description == "# Heading"
+
+
+# ---------------------------------------------------------------------------
+# #2491: plugins container must not leak stray top-level .md as skills
+# ---------------------------------------------------------------------------
+#
+# The plugins origin (`~/.kimi/plugins/`) is documented as a container of
+# independent plugin subdirectories (each a `plugin.json` + scripts). The
+# generic flat-`.md` Pass 2 was being applied to it too, so stray packaging
+# markdown (CHANGELOG.md, README.md) dropped directly at the container level
+# was discovered as skills. The per-root `skip_flat_md` flag scopes the flat
+# scan to non-plugin origins only.
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_plugins_root_skips_flat_md(tmp_path):
+    """At a plugins-shaped root with ``skip_flat_md=True``, only the
+    subdirectory form is discovered — stray top-level ``CHANGELOG.md`` and
+    ``README.md`` are ignored (F1/F2).
+    """
+    root = tmp_path / "plugins"
+    root.mkdir()
+
+    # Real plugin: subdir form with a SKILL.md (kimi-datasource happy path).
+    _write_skill(
+        root / "kimi-datasource",
+        "---\nname: kimi-datasource\ndescription: Datasource plugin\n---\n",
+    )
+
+    # Stray packaging markdown dropped at the container level (the leak).
+    (root / "CHANGELOG.md").write_text("# Changelog\nbody\n", encoding="utf-8")
+    (root / "README.md").write_text("# Read me\nbody\n", encoding="utf-8")
+
+    skills = await discover_skills(
+        KaosPath.unsafe_from_local_path(root), scope="extra", skip_flat_md=True
+    )
+
+    names = [s.name for s in skills]
+    assert names == ["kimi-datasource"]
+    assert "CHANGELOG" not in names
+    assert "README" not in names
+
+
+@pytest.mark.asyncio
+async def test_discover_skills_generic_root_keeps_flat_md(tmp_path):
+    """A generic skills root (default ``skip_flat_md=False``) still discovers
+    both forms — the fix must not weaken flat-``.md`` support for non-plugin
+    origins (F4/I4).
+    """
+    root = tmp_path / "skills"
+    root.mkdir()
+
+    _write_skill(
+        root / "kimi-datasource",
+        "---\nname: kimi-datasource\ndescription: Datasource plugin\n---\n",
+    )
+    (root / "CHANGELOG.md").write_text("# Changelog\nbody\n", encoding="utf-8")
+    (root / "README.md").write_text("# Read me\nbody\n", encoding="utf-8")
+
+    skills = await discover_skills(KaosPath.unsafe_from_local_path(root), scope="extra")
+
+    names = sorted(s.name for s in skills)
+    assert names == ["CHANGELOG", "README", "kimi-datasource"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_skills_roots_marks_plugins_root_skip_flat_md(monkeypatch, tmp_path):
+    """``resolve_skills_roots`` marks the plugins-origin root with
+    ``skip_flat_md=True`` and every other root with the default ``False``
+    (I2/I3). This keeps the scope label and priority position unchanged while
+    scoping the flat-``.md`` pass to non-plugin origins only.
+    """
+    import kimi_cli.skill as skill_mod
+
+    # Suppress built-in skills so the assertion list is tight and unambiguous.
+    monkeypatch.setattr(skill_mod, "_supports_builtin_skills", lambda: False)
+
+    # Deterministic, isolated home so find_user_skills_dirs can't see the real
+    # user dirs. Create one user skills dir so there's a concrete "other" root
+    # to assert carries the default skip_flat_md=False.
+    home_dir = tmp_path / "home"
+    user_brand = home_dir / ".kimi" / "skills"
+    user_brand.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    # Point the plugins container at a tmp dir holding a stray CHANGELOG.md
+    # (as a sibling of a plugin subdir) — this is the leak reproduction shape.
+    plugins_path = tmp_path / "plugins"
+    plugins_path.mkdir()
+    (plugins_path / "CHANGELOG.md").write_text("# Changelog\nbody\n", encoding="utf-8")
+    monkeypatch.setattr("kimi_cli.plugin.manager.get_plugins_dir", lambda: plugins_path)
+
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+
+    scoped = await resolve_skills_roots(KaosPath.unsafe_from_local_path(work_dir))
+
+    # Exactly one root (the plugins container) and it is marked skip_flat_md.
+    plugins_root = KaosPath.unsafe_from_local_path(plugins_path)
+    plugins_entries = [s for s in scoped if s.root == plugins_root]
+    assert len(plugins_entries) == 1
+    assert plugins_entries[0].skip_flat_md is True
+    assert plugins_entries[0].scope == "extra"
+
+    # No other root carries skip_flat_md — generic origins keep flat-.md support.
+    others = [s for s in scoped if s.root != plugins_root]
+    user_root = KaosPath.unsafe_from_local_path(user_brand)
+    assert any(s.root == user_root for s in others), (
+        "expected the user-scope root to be present as a non-plugin root"
+    )
+    assert all(s.skip_flat_md is False for s in others)


### PR DESCRIPTION
## Summary
- Plugins are documented (customization/plugins.md) as independent subdirectories — each containing a `plugin.json` and its tool scripts — not as a flat-`.md` skills directory. Flat-`.md` skill discovery is a generic-skills-root feature documented separately in customization/skills.md for `~/.kimi/skills` and the like.
- However, the generic flat-`.md` discovery pass was also applied to the plugins container (`~/.kimi/plugins/`), so any stray markdown (a packaging-artifact `CHANGELOG.md` or `README.md` dropped at the container level) was discovered as a skill and appeared in `/skill` autocomplete.
- This adds a per-root `skip_flat_md` flag (set `True` only for the plugins origin) so only the subdirectory form (`<plugin>/SKILL.md`) is honored there. Non-plugin roots keep flat-`.md` support.

## Reproduction
A stray `CHANGELOG.md` placed directly in `~/.kimi/plugins/` (as a sibling of plugin subdirectories) was discovered as a flat skill named `CHANGELOG`. After this fix it is ignored, while `<plugin>/SKILL.md` continues to be discovered.

## Notes on the reporter's environment
The reporter (CLI 0.23.5) saw `CHANGELOG` in `/skill` autocomplete after installing `kimi-datasource`. The current `install_plugin` path places `CHANGELOG.md` inside the plugin subdir (where the non-recursive scan never sees it), so the reporter's exact trigger was likely a manual unzip, an older install path, or a different plugin whose zip extracts flat. This fix is defensive hardening of the plugins origin so that only plugin subdirectories (each an independent unit per plugins.md) contribute skills, regardless of how stray markdown reaches the container level.

Closes #2491

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->