### PR TITLE
perf(kosong): buffer stream merges and avoid deep-copying every delta

### DIFF
--- a/packages/kosong/src/kosong/_generate.py
+++ b/packages/kosong/src/kosong/_generate.py
@@ -61,7 +61,7 @@ async def generate(
     async for part in stream:
         logger.trace("Received part: {part}", part=part)
         if on_message_part:
-            await callback(on_message_part, part.model_copy(deep=True))
+            await callback(on_message_part, _copy_stream_part(part))
 
         if pending_part is None:
             pending_part = part
@@ -117,7 +117,20 @@ class GenerateResult:
     """The ``x-trace-id`` response header of the request, if the provider exposes it."""
 
 
+def _copy_stream_part(part: StreamedMessagePart) -> StreamedMessagePart:
+    """Copy a stream delta for UI callbacks without a full deep copy.
+
+    Most parts only hold immutable strings. ``ToolCall`` nests a mutable
+    ``FunctionBody`` that later merges mutate, so that nested model is copied.
+    """
+    if isinstance(part, ToolCall):
+        return part.model_copy(update={"function": part.function.model_copy()})
+    return part.model_copy()
+
+
 def _message_append(message: Message, part: StreamedMessagePart) -> None:
+    # Flush buffered stream merges before the part becomes readable/persisted.
+    part.finalize_merge()
     match part:
         case ContentPart():
             message.content.append(part)

--- a/packages/kosong/src/kosong/message.py
+++ b/packages/kosong/src/kosong/message.py
@@ -104,6 +104,16 @@ class TextPart(ContentPart):
             self.text = "".join(self._merge_buf)
             self._merge_buf = None
 
+    @override
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        self.finalize_merge()
+        return super().model_dump(**kwargs)
+
+    @override
+    def model_dump_json(self, **kwargs: Any) -> str:
+        self.finalize_merge()
+        return super().model_dump_json(**kwargs)
+
 
 class ThinkPart(ContentPart):
     """
@@ -135,6 +145,16 @@ class ThinkPart(ContentPart):
         if self._merge_buf is not None:
             self.think = "".join(self._merge_buf)
             self._merge_buf = None
+
+    @override
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        self.finalize_merge()
+        return super().model_dump(**kwargs)
+
+    @override
+    def model_dump_json(self, **kwargs: Any) -> str:
+        self.finalize_merge()
+        return super().model_dump_json(**kwargs)
 
 
 class ImageURLPart(ContentPart):
@@ -248,6 +268,16 @@ class ToolCall(BaseModel, MergeableMixin):
             self.function.arguments = "".join(self._merge_buf)
             self._merge_buf = None
 
+    @override
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        self.finalize_merge()
+        return super().model_dump(**kwargs)
+
+    @override
+    def model_dump_json(self, **kwargs: Any) -> str:
+        self.finalize_merge()
+        return super().model_dump_json(**kwargs)
+
 
 class ToolCallPart(BaseModel, MergeableMixin):
     """A part of the tool call."""
@@ -277,6 +307,16 @@ class ToolCallPart(BaseModel, MergeableMixin):
         if self._merge_buf is not None:
             self.arguments_part = "".join(self._merge_buf)
             self._merge_buf = None
+
+    @override
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        self.finalize_merge()
+        return super().model_dump(**kwargs)
+
+    @override
+    def model_dump_json(self, **kwargs: Any) -> str:
+        self.finalize_merge()
+        return super().model_dump_json(**kwargs)
 
 
 type Role = Literal[
@@ -317,6 +357,7 @@ class Message(BaseModel):
     @field_serializer("content")
     def _serialize_content(self, content: list[ContentPart]) -> str | list[dict[str, Any]] | None:
         if len(content) == 1 and isinstance(content[0], TextPart):
+            content[0].finalize_merge()
             return content[0].text
         return [part.model_dump() for part in content]
 
@@ -352,4 +393,9 @@ class Message(BaseModel):
 
     def extract_text(self, sep: str = "") -> str:
         """Extract and concatenate all text parts in the message content."""
-        return sep.join(part.text for part in self.content if isinstance(part, TextPart))
+        texts: list[str] = []
+        for part in self.content:
+            if isinstance(part, TextPart):
+                part.finalize_merge()
+                texts.append(part.text)
+        return sep.join(texts)

--- a/packages/kosong/src/kosong/message.py
+++ b/packages/kosong/src/kosong/message.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Any, ClassVar, Literal, cast, override
 
-from pydantic import BaseModel, GetCoreSchemaHandler, field_serializer, field_validator
+from pydantic import BaseModel, GetCoreSchemaHandler, PrivateAttr, field_serializer, field_validator
 from pydantic_core import core_schema
 
 from kosong.utils.typing import JsonType
@@ -11,6 +11,14 @@ class MergeableMixin:
     def merge_in_place(self, other: Any) -> bool:
         """Merge the other part into the current part. Return True if the merge is successful."""
         return False
+
+    def finalize_merge(self) -> None:
+        """Flush deferred merge buffers into public fields.
+
+        Streaming merges buffer string chunks to avoid O(n²) concatenation; call this
+        before reading the accumulated text or persisting the part.
+        """
+        return
 
 
 class ContentPart(BaseModel, ABC, MergeableMixin):
@@ -79,13 +87,22 @@ class TextPart(ContentPart):
 
     type: str = "text"
     text: str
+    _merge_buf: list[str] | None = PrivateAttr(default=None)
 
     @override
     def merge_in_place(self, other: Any) -> bool:
         if not isinstance(other, TextPart):
             return False
-        self.text += other.text
+        if self._merge_buf is None:
+            self._merge_buf = [self.text]
+        self._merge_buf.append(other.text)
         return True
+
+    @override
+    def finalize_merge(self) -> None:
+        if self._merge_buf is not None:
+            self.text = "".join(self._merge_buf)
+            self._merge_buf = None
 
 
 class ThinkPart(ContentPart):
@@ -98,6 +115,7 @@ class ThinkPart(ContentPart):
     think: str
     encrypted: str | None = None
     """Encrypted thinking content, or signature."""
+    _merge_buf: list[str] | None = PrivateAttr(default=None)
 
     @override
     def merge_in_place(self, other: Any) -> bool:
@@ -105,10 +123,18 @@ class ThinkPart(ContentPart):
             return False
         if self.encrypted:
             return False
-        self.think += other.think
+        if self._merge_buf is None:
+            self._merge_buf = [self.think]
+        self._merge_buf.append(other.think)
         if other.encrypted:
             self.encrypted = other.encrypted
         return True
+
+    @override
+    def finalize_merge(self) -> None:
+        if self._merge_buf is not None:
+            self.think = "".join(self._merge_buf)
+            self._merge_buf = None
 
 
 class ImageURLPart(ContentPart):
@@ -198,16 +224,29 @@ class ToolCall(BaseModel, MergeableMixin):
     """The function body of the tool call."""
     extras: dict[str, JsonType] | None = None
     """Extra information about the tool call."""
+    _merge_buf: list[str] | None = PrivateAttr(default=None)
 
     @override
     def merge_in_place(self, other: Any) -> bool:
         if not isinstance(other, ToolCallPart):
             return False
-        if self.function.arguments is None:
-            self.function.arguments = other.arguments_part
+        piece = other.arguments_part
+        if self._merge_buf is None:
+            if self.function.arguments is None:
+                if piece is None:
+                    return True
+                self._merge_buf = [piece]
+            else:
+                self._merge_buf = [self.function.arguments, piece or ""]
         else:
-            self.function.arguments += other.arguments_part or ""
+            self._merge_buf.append(piece or "")
         return True
+
+    @override
+    def finalize_merge(self) -> None:
+        if self._merge_buf is not None:
+            self.function.arguments = "".join(self._merge_buf)
+            self._merge_buf = None
 
 
 class ToolCallPart(BaseModel, MergeableMixin):
@@ -215,16 +254,29 @@ class ToolCallPart(BaseModel, MergeableMixin):
 
     arguments_part: str | None = None
     """A part of the arguments of the tool call."""
+    _merge_buf: list[str] | None = PrivateAttr(default=None)
 
     @override
     def merge_in_place(self, other: Any) -> bool:
         if not isinstance(other, ToolCallPart):
             return False
-        if self.arguments_part is None:
-            self.arguments_part = other.arguments_part
+        piece = other.arguments_part
+        if self._merge_buf is None:
+            if self.arguments_part is None:
+                if piece is None:
+                    return True
+                self._merge_buf = [piece]
+            else:
+                self._merge_buf = [self.arguments_part, piece or ""]
         else:
-            self.arguments_part += other.arguments_part or ""
+            self._merge_buf.append(piece or "")
         return True
+
+    @override
+    def finalize_merge(self) -> None:
+        if self._merge_buf is not None:
+            self.arguments_part = "".join(self._merge_buf)
+            self._merge_buf = None
 
 
 type Role = Literal[

--- a/packages/kosong/tests/test_message.py
+++ b/packages/kosong/tests/test_message.py
@@ -7,6 +7,7 @@ from kosong.message import (
     TextPart,
     ThinkPart,
     ToolCall,
+    ToolCallPart,
     VideoURLPart,
 )
 
@@ -297,3 +298,39 @@ Hello, \n\
 world
 !\
 """)
+
+
+def test_text_part_merge_buffer_requires_finalize():
+    part = TextPart(text="Hello, ")
+    assert part.merge_in_place(TextPart(text="world"))
+    assert part.merge_in_place(TextPart(text="!"))
+    # Buffered merges leave the public field stale until finalize.
+    assert part.text == "Hello, "
+    part.finalize_merge()
+    assert part.text == "Hello, world!"
+
+
+def test_text_part_model_dump_finalizes_merge_buffer():
+    part = TextPart(text="Hello, ")
+    assert part.merge_in_place(TextPart(text="world!"))
+    assert part.model_dump()["text"] == "Hello, world!"
+    assert part.text == "Hello, world!"
+
+
+def test_tool_call_merge_buffer_finalizes_arguments():
+    call = ToolCall(
+        id="1",
+        function=ToolCall.FunctionBody(name="fn", arguments=None),
+    )
+    assert call.merge_in_place(ToolCallPart(arguments_part='{"a":'))
+    assert call.merge_in_place(ToolCallPart(arguments_part="1}"))
+    assert call.function.arguments is None
+    call.finalize_merge()
+    assert call.function.arguments == '{"a":1}'
+
+
+def test_message_extract_text_finalizes_merged_parts():
+    part = TextPart(text="Hello, ")
+    assert part.merge_in_place(TextPart(text="world!"))
+    message = Message(role="assistant", content=[part])
+    assert message.extract_text() == "Hello, world!"

--- a/src/kimi_cli/ui/print/visualize.py
+++ b/src/kimi_cli/ui/print/visualize.py
@@ -1,7 +1,8 @@
+from collections.abc import Sequence
 from typing import Protocol
 
 import rich
-from kosong.message import Message
+from kosong.message import MergeableMixin, Message
 
 from kimi_cli.cli import OutputFormat
 from kimi_cli.soul.message import tool_result_to_message
@@ -28,7 +29,14 @@ class Printer(Protocol):
 
 def _merge_content(buffer: list[ContentPart], part: ContentPart) -> None:
     if not buffer or not buffer[-1].merge_in_place(part):
+        if buffer:
+            buffer[-1].finalize_merge()
         buffer.append(part)
+
+
+def _finalize_parts(parts: Sequence[MergeableMixin]) -> None:
+    for part in parts:
+        part.finalize_merge()
 
 
 class TextPrinter(Printer):
@@ -95,6 +103,9 @@ class JsonPrinter(Printer):
         if not self._content_buffer and not self._tool_call_buffer:
             return
 
+        _finalize_parts(self._content_buffer)
+        _finalize_parts(self._tool_call_buffer)
+
         message = Message(
             role="assistant",
             content=self._content_buffer,
@@ -135,6 +146,7 @@ class FinalOnlyTextPrinter(Printer):
     def flush(self) -> None:
         if not self._content_buffer:
             return
+        _finalize_parts(self._content_buffer)
         message = Message(role="assistant", content=self._content_buffer)
         text = message.extract_text()
         if text:
@@ -158,6 +170,7 @@ class FinalOnlyJsonPrinter(Printer):
     def flush(self) -> None:
         if not self._content_buffer:
             return
+        _finalize_parts(self._content_buffer)
         message = Message(role="assistant", content=self._content_buffer)
         text = message.extract_text()
         if text:

--- a/src/kimi_cli/wire/__init__.py
+++ b/src/kimi_cli/wire/__init__.py
@@ -101,6 +101,9 @@ class WireSoulSide:
         buffer = self._merge_buffer
         if buffer is None:
             return
+        # merge_in_place may defer string joins into a private buffer; flush them
+        # before consumers (recorder, print UI, subagent transcripts) read fields.
+        buffer.finalize_merge()
         assert is_wire_message(buffer)
         self._send_merged(buffer)
         self._merge_buffer = None

--- a/tests/core/test_wire_merge_finalize.py
+++ b/tests/core/test_wire_merge_finalize.py
@@ -1,0 +1,45 @@
+"""Regression: merged wire messages must flush deferred merge buffers."""
+
+from __future__ import annotations
+
+import asyncio
+
+from kimi_cli.wire import Wire
+from kimi_cli.wire.types import TextPart, ToolCall, ToolCallPart
+
+
+async def test_wire_merged_text_includes_all_stream_fragments() -> None:
+    wire = Wire()
+    ui = wire.ui_side(merge=True)
+
+    wire.soul_side.send(TextPart(text="Hello, "))
+    wire.soul_side.send(TextPart(text="world"))
+    wire.soul_side.send(TextPart(text="!"))
+    wire.soul_side.flush()
+
+    msg = await asyncio.wait_for(ui.receive(), timeout=1)
+    assert isinstance(msg, TextPart)
+    assert msg.text == "Hello, world!"
+
+    wire.shutdown()
+
+
+async def test_wire_merged_tool_call_includes_all_argument_fragments() -> None:
+    wire = Wire()
+    ui = wire.ui_side(merge=True)
+
+    wire.soul_side.send(
+        ToolCall(
+            id="call_1",
+            function=ToolCall.FunctionBody(name="Shell", arguments=None),
+        )
+    )
+    wire.soul_side.send(ToolCallPart(arguments_part='{"command":'))
+    wire.soul_side.send(ToolCallPart(arguments_part='"ls"}'))
+    wire.soul_side.flush()
+
+    msg = await asyncio.wait_for(ui.receive(), timeout=1)
+    assert isinstance(msg, ToolCall)
+    assert msg.function.arguments == '{"command":"ls"}'
+
+    wire.shutdown()

--- a/tests/ui_and_conv/test_print_merge_finalize.py
+++ b/tests/ui_and_conv/test_print_merge_finalize.py
@@ -1,0 +1,45 @@
+"""Regression: print/stream-json must emit fully merged streamed content."""
+
+from __future__ import annotations
+
+import json
+
+from kimi_cli.ui.print.visualize import FinalOnlyTextPrinter, JsonPrinter
+from kimi_cli.wire.types import TextPart, ToolCall, ToolCallPart
+
+
+def test_json_printer_emits_fully_merged_text(capsys) -> None:
+    printer = JsonPrinter()
+    printer.feed(TextPart(text="Hello, "))
+    printer.feed(TextPart(text="world"))
+    printer.feed(TextPart(text="!"))
+    printer.flush()
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["role"] == "assistant"
+    assert payload["content"] == "Hello, world!"
+
+
+def test_json_printer_emits_fully_merged_tool_arguments(capsys) -> None:
+    printer = JsonPrinter()
+    printer.feed(
+        ToolCall(
+            id="call_1",
+            function=ToolCall.FunctionBody(name="Shell", arguments=None),
+        )
+    )
+    printer.feed(ToolCallPart(arguments_part='{"command":'))
+    printer.feed(ToolCallPart(arguments_part='"echo hi"}'))
+    printer.flush()
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["tool_calls"][0]["function"]["arguments"] == '{"command":"echo hi"}'
+
+
+def test_final_only_text_printer_emits_fully_merged_text(capsys) -> None:
+    printer = FinalOnlyTextPrinter()
+    printer.feed(TextPart(text="Hello, "))
+    printer.feed(TextPart(text="world!"))
+    printer.flush()
+
+    assert capsys.readouterr().out.strip() == "Hello, world!"


### PR DESCRIPTION
LLM streams often emit tiny text/tool-argument chunks. Concatenating with str += on each merge is quadratic, and model_copy(deep=True) on every callback was needlessly expensive on long responses.

## Related Issue

N/A — performance improvement on the streaming merge path in `kosong`.

## Description

### Problem

While streaming a model response, kosong merges consecutive deltas (text, thinking, and tool-call argument fragments) into a single part. That path was doing two expensive things on every chunk:

1. Quadratic string growth — `TextPart`, `ThinkPart`, `ToolCall`, and `ToolCallPart` used `str +=` inside `merge_in_place`. Providers usually send very small chunks, so a long answer (or large tool args) kept copying the whole accumulated string over and over.

2. Deep-copy on every callback — `_generate` called `part.model_copy(deep=True)` before passing each delta to `on_message_part`. Most stream parts are just short immutable strings, so a full deep copy per token was unnecessary work on the event loop.

Both run on every streamed turn, so the cost grows with response length.

### Fix

In `packages/kosong/src/kosong/message.py`:
- Stream merges now buffer chunks in a private `_merge_buf` list during `merge_in_place`.
- Added `finalize_merge()` to join the buffer once into the public field.
- `_message_append` calls `finalize_merge()` before the part is added to the message, so the final content stays the same as before.

In `packages/kosong/src/kosong/_generate.py`:
- Replaced `model_copy(deep=True)` with `_copy_stream_part()`.
- Most parts use a shallow `model_copy()`.
- For `ToolCall`, the nested `FunctionBody` is also copied so later argument merges do not mutate the copy already sent to the callback.

### Impact

- Final merged messages and tool-call arguments are unchanged.
- Less CPU and fewer allocations while streaming long text or chunked tool arguments.
- UI still gets per-delta callbacks; only merge buffering and copy strategy changed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->