### PR TITLE
fix(web): persist uploads .sent marker so restarts do not re-send files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Fixed `kimi web` re-sending previously uploaded files (including images) to the model after a server restart, which polluted resumed sessions.
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/src/kimi_cli/web/runner/process.py
+++ b/src/kimi_cli/web/runner/process.py
@@ -500,9 +500,14 @@ class SessionProcess:
                     # Skip files that fail to decode - don't block the upload
                     pass
 
-        # Mark files as sent
+        # Mark files as sent and persist the marker so a restarted server
+        # does not attach previously sent uploads to the next prompt (#2413).
         for file in files:
             self._sent_files.add(file.name)
+        try:
+            sent_marker.write_text(json.dumps(sorted(self._sent_files)), encoding="utf-8")
+        except OSError:
+            logger.warning("Failed to persist uploads .sent marker", exc_info=True)
 
     async def _handle_in_message(self, message: JSONRPCInMessage) -> str | None:
         """Handle inbound message to worker, encoding uploaded files."""

--- a/tests/web/test_uploads_sent_marker.py
+++ b/tests/web/test_uploads_sent_marker.py
@@ -1,0 +1,77 @@
+"""Tests for upload re-send prevention across server restarts (#2413).
+
+``SessionProcess._encode_uploaded_files`` must persist which uploads were
+already sent, so a restarted ``kimi web`` server does not attach previously
+sent files to the next prompt again.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from kosong.message import ContentPart
+
+import kimi_cli.web.runner.process as process_module
+from kimi_cli.web.runner.process import SessionProcess
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A fake session dir with one uploaded text file, wired into the module."""
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    (uploads / "notes.txt").write_text("hello upload", encoding="utf-8")
+
+    session = MagicMock()
+    session.kimi_cli_session.dir = tmp_path
+    monkeypatch.setattr(process_module, "load_session_by_id", lambda _id: session)
+
+    config = MagicMock()
+    config.default_model = None
+    monkeypatch.setattr(process_module, "load_config", lambda: config)
+    return tmp_path
+
+
+async def _encode(sp: SessionProcess) -> list[ContentPart]:
+    return [part async for part in sp._encode_uploaded_files()]
+
+
+async def test_sent_files_marker_persisted_to_disk(session_dir: Path) -> None:
+    """After encoding, the .sent marker must record the sent file names."""
+    sp = SessionProcess(uuid4())
+    parts = await _encode(sp)
+    assert any("notes.txt" in getattr(p, "text", "") for p in parts)
+
+    marker = session_dir / "uploads" / ".sent"
+    assert marker.exists()
+    assert json.loads(marker.read_text(encoding="utf-8")) == ["notes.txt"]
+
+
+async def test_restarted_process_does_not_resend_uploads(session_dir: Path) -> None:
+    """A new SessionProcess (server restart) must not re-encode sent uploads."""
+    first = SessionProcess(uuid4())
+    parts = await _encode(first)
+    assert parts, "first prompt should include the uploaded file"
+
+    restarted = SessionProcess(uuid4())
+    assert await _encode(restarted) == []
+
+
+async def test_new_upload_after_restart_is_sent_once(session_dir: Path) -> None:
+    """Files added after a restart are sent, previously sent ones are not."""
+    first = SessionProcess(uuid4())
+    await _encode(first)
+
+    (session_dir / "uploads" / "later.txt").write_text("second", encoding="utf-8")
+    restarted = SessionProcess(uuid4())
+    parts = await _encode(restarted)
+    texts = [getattr(p, "text", "") for p in parts]
+    assert any("later.txt" in t for t in texts)
+    assert not any("notes.txt" in t for t in texts)
+
+    marker = session_dir / "uploads" / ".sent"
+    assert json.loads(marker.read_text(encoding="utf-8")) == ["later.txt", "notes.txt"]


### PR DESCRIPTION
## Related Issue

Resolve #2413

## Description

`kimi web` re-sends every previously uploaded file (including images) with the next prompt after any server restart, polluting the session — exactly as reported in #2413 ("every time the session is restarted, the pictures previously sent to Kimi will be sent again").

**Root cause:** `SessionProcess._encode_uploaded_files()` skips files recorded in `self._sent_files`, but that set lives only in memory. The on-disk `uploads/.sent` marker it reads at startup is written **only** by `session_fork.py` (fork inheritance, #1004) — the normal send path never persists it. So after a restart the set is empty, the marker doesn't exist, and every file in `uploads/` is re-encoded and re-attached; the pile grows with each restart because the files are (deliberately) kept on disk.

**Fix (5 lines):** after marking files as sent, write the sorted set to the existing `uploads/.sent` marker (same JSON format the fork path already writes and the loader already reads). An `OSError` is logged and non-fatal, preserving current behavior on read-only filesystems.

## Verification

- New regression tests in `tests/web/test_uploads_sent_marker.py` (all fail on `main`):
  - `.sent` marker is persisted after encoding,
  - a fresh `SessionProcess` (simulated restart) sends nothing,
  - files added after a restart are sent exactly once and merged into the marker.
- `uv run pytest tests/web` → 18 passed; full `tests/` suite green.
- `ruff check` / `ruff format --check` / `pyright` clean on touched files.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue.
- [x] I have added tests that prove my fix is effective.
- [x] Changelog updated (manual `## Unreleased` entry in house style; `make gen-changelog` runs kimi itself, which needs API auth not available in this environment).
- [x] `make gen-docs` — N/A: no user-facing docs change (internal web-runner behavior fix).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->