### PR TITLE
fix(app): refresh stale frozen system prompt on session resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Fixed resumed sessions keeping a stale frozen system prompt, so newly added skills, `AGENTS.md` edits, and prompt-affecting config changes now take effect after resume.
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/src/kimi_cli/app.py
+++ b/src/kimi_cli/app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import dataclasses
 import sys
 import time
 import warnings
@@ -305,9 +304,11 @@ class KimiCLI:
         context = Context(session.context_file)
         await context.restore()
 
-        if context.system_prompt is not None:
-            agent = dataclasses.replace(agent, system_prompt=context.system_prompt)
-        else:
+        if context.system_prompt != agent.system_prompt:
+            # A frozen prompt from a previous run can be stale: skills added to
+            # ~/.kimi/skills, AGENTS.md edits, or config changes would otherwise
+            # never reach a resumed session (#2420). Adopt the freshly generated
+            # prompt and persist it so the context file matches what is sent.
             await context.write_system_prompt(agent.system_prompt)
 
         soul = KimiSoul(agent, context=context)

--- a/src/kimi_cli/soul/context.py
+++ b/src/kimi_cli/soul/context.py
@@ -92,9 +92,11 @@ class Context:
         """Write the system prompt as the first record of the context file.
 
         If the file is empty, writes it directly. If the file already has content
-        (e.g. a legacy session without system prompt), prepends it atomically via a
-        temporary file to avoid corruption on crash and avoid loading the entire file
-        into memory.
+        (e.g. a legacy session, or a resumed session whose prompt is being
+        refreshed), rewrites it atomically via a temporary file, dropping any
+        previous ``_system_prompt`` record so the file always holds a single,
+        current system prompt. Restoration takes the last ``_system_prompt``
+        record, so a leftover stale record would win over the refreshed one.
         """
         prompt_line = json.dumps({"role": "_system_prompt", "content": prompt}) + "\n"
 
@@ -105,15 +107,19 @@ class Context:
 
             tmp_path = self._file_backend.with_suffix(".tmp")
             with (
-                tmp_path.open("w", encoding="utf-8") as tmp_f,
-                self._file_backend.open(encoding="utf-8") as src_f,
+                tmp_path.open("wb") as tmp_f,
+                self._file_backend.open("rb") as src_f,
             ):
-                tmp_f.write(prompt_line)
-                while True:
-                    chunk = src_f.read(64 * 1024)
-                    if not chunk:
-                        break
-                    tmp_f.write(chunk)
+                tmp_f.write(prompt_line.encode("utf-8"))
+                for raw_line in src_f:
+                    stripped = raw_line.strip()
+                    if stripped:
+                        try:
+                            if json.loads(stripped).get("role") == "_system_prompt":
+                                continue
+                        except (json.JSONDecodeError, UnicodeDecodeError):
+                            pass
+                    tmp_f.write(raw_line)
             tmp_path.replace(self._file_backend)
 
         await asyncio.to_thread(_write_system_prompt_sync)

--- a/src/kimi_cli/subagents/core.py
+++ b/src/kimi_cli/subagents/core.py
@@ -9,7 +9,7 @@ implemented once.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from kimi_cli.soul.context import Context
@@ -61,10 +61,10 @@ async def prepare_soul(
     if on_stage:
         on_stage("context_restored")
 
-    # 3. System prompt: reuse persisted prompt on resume, persist on first run
-    if context.system_prompt is not None:
-        agent = replace(agent, system_prompt=context.system_prompt)
-    else:
+    # 3. System prompt: refresh a stale persisted prompt on resume (skills or
+    # AGENTS.md may have changed since the subagent last ran, #2420), persist
+    # on first run. Matches the root-session behavior in KimiCLI.create.
+    if context.system_prompt != agent.system_prompt:
         await context.write_system_prompt(agent.system_prompt)
     if on_stage:
         on_stage("context_ready")

--- a/tests/background/test_manager.py
+++ b/tests/background/test_manager.py
@@ -285,7 +285,8 @@ async def test_create_agent_task_persists_starting_state(runtime, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_background_agent_resume_restores_system_prompt_from_context(runtime, monkeypatch):
+async def test_background_agent_resume_refreshes_stale_system_prompt(runtime, monkeypatch):
+    """Resume adopts the freshly built prompt when the frozen one is stale (#2420)."""
     runtime.labor_market.add_builtin_type(
         AgentTypeDefinition(
             name="coder",
@@ -344,7 +345,7 @@ async def test_background_agent_resume_restores_system_prompt_from_context(runti
     task = runtime.background_tasks._live_agent_tasks[view.spec.id]
     await task
 
-    assert seen_prompts == ["old system prompt"]
+    assert seen_prompts == ["new system prompt"]
     record = runtime.subagent_store.require_instance("aexisting")
     assert record.status == "idle"
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -365,6 +365,38 @@ async def test_revert_skips_truncated_utf8_line_before_checkpoint(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_write_system_prompt_replaces_existing_record(tmp_path: Path) -> None:
+    """Rewriting the prompt must drop the old record, not accumulate them (#2420).
+
+    Restoration takes the last ``_system_prompt`` record, so a leftover stale
+    record after the refreshed one would silently win on the next restore.
+    """
+    path = tmp_path / "context.jsonl"
+    msg = _message_dict("user", "Hello")
+    _write_lines(
+        path,
+        [
+            {"role": "_system_prompt", "content": "Stale prompt"},
+            msg,
+        ],
+    )
+
+    ctx = Context(file_backend=path)
+    await ctx.restore()
+    await ctx.write_system_prompt("Fresh prompt")
+
+    lines = _read_lines(path)
+    assert lines == [
+        {"role": "_system_prompt", "content": "Fresh prompt"},
+        msg,
+    ]
+
+    ctx2 = Context(file_backend=path)
+    await ctx2.restore()
+    assert ctx2.system_prompt == "Fresh prompt"
+
+
+@pytest.mark.asyncio
 async def test_write_system_prompt_then_restore(tmp_path: Path) -> None:
     path = tmp_path / "context.jsonl"
     path.touch()

--- a/tests/core/test_prepare_soul.py
+++ b/tests/core/test_prepare_soul.py
@@ -82,14 +82,15 @@ async def test_prepare_soul_writes_prompt_file(runtime, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_prepare_soul_restores_system_prompt_on_resume(runtime, monkeypatch):
-    """When context already has a system prompt, prepare_soul uses it
-    instead of the agent's default."""
+async def test_prepare_soul_refreshes_stale_system_prompt_on_resume(runtime, monkeypatch):
+    """A frozen prompt differing from the freshly built one is replaced and
+    persisted on resume, so skills/AGENTS.md changes reach resumed subagents
+    (#2420)."""
     _register_coder(runtime)
     _patch_load_agent(monkeypatch, system_prompt="new system prompt")
     _create_instance(runtime, "aresume1")
 
-    # Pre-write a system prompt to simulate a previous run
+    # Pre-write a stale system prompt to simulate a previous run
     context = Context(runtime.subagent_store.context_path("aresume1"))
     await context.write_system_prompt("old system prompt")
 
@@ -97,7 +98,11 @@ async def test_prepare_soul_restores_system_prompt_on_resume(runtime, monkeypatc
     builder = SubagentBuilder(runtime)
     soul, _ = await prepare_soul(spec, runtime, builder, runtime.subagent_store)
 
-    assert soul.agent.system_prompt == "old system prompt"
+    assert soul.agent.system_prompt == "new system prompt"
+
+    restored = Context(runtime.subagent_store.context_path("aresume1"))
+    await restored.restore()
+    assert restored.system_prompt == "new system prompt"
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_resume_system_prompt.py
+++ b/tests/core/test_resume_system_prompt.py
@@ -1,0 +1,100 @@
+"""Tests for system prompt refresh on session resume (#2420).
+
+Resuming a session must not let a frozen, stale system prompt override the
+freshly generated one — otherwise skills added to ``~/.kimi/skills``,
+``AGENTS.md`` edits, and prompt-affecting config changes never take effect.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import kimi_cli.app as app_module
+from kimi_cli.app import KimiCLI
+
+
+class _FakeSoul:
+    def __init__(self, agent, context):
+        self.agent = agent
+        self.plan_mode = False
+
+    async def set_plan_mode_from_manual(self, enabled: bool) -> bool:
+        return enabled
+
+    def schedule_plan_activation_reminder(self) -> None:
+        pass
+
+    def set_hook_engine(self, engine) -> None:
+        pass
+
+
+def _patch_create_deps(monkeypatch, *, frozen_prompt: str | None, fresh_prompt: str):
+    """Patch heavy KimiCLI.create() dependencies; return the fake context."""
+    fake_context = SimpleNamespace(system_prompt=frozen_prompt)
+    fake_context.restore = AsyncMock()
+
+    async def write_system_prompt(prompt: str) -> None:
+        fake_context.system_prompt = prompt
+
+    fake_context.write_system_prompt = AsyncMock(side_effect=write_system_prompt)
+
+    async def fake_runtime_create(config, _oauth, _llm, session, yolo, **kwargs):
+        return SimpleNamespace(
+            session=session,
+            config=config,
+            llm=None,
+            approval=SimpleNamespace(is_yolo=lambda: yolo, is_afk=lambda: False),
+            notifications=SimpleNamespace(recover=lambda: None),
+            background_tasks=SimpleNamespace(reconcile=lambda: None),
+        )
+
+    monkeypatch.setattr(app_module, "load_config", lambda conf: conf)
+    monkeypatch.setattr(app_module, "augment_provider_with_env_vars", lambda p, m: {})
+    monkeypatch.setattr(app_module, "create_llm", lambda *a, **kw: None)
+    monkeypatch.setattr(app_module.Runtime, "create", fake_runtime_create)
+    monkeypatch.setattr(
+        app_module,
+        "load_agent",
+        AsyncMock(return_value=SimpleNamespace(name="test", system_prompt=fresh_prompt)),
+    )
+    monkeypatch.setattr(app_module, "Context", lambda _path: fake_context)
+    monkeypatch.setattr(app_module, "KimiSoul", _FakeSoul)
+    return fake_context
+
+
+@pytest.mark.asyncio
+async def test_resume_refreshes_stale_system_prompt(session, config, monkeypatch):
+    """A frozen prompt differing from the fresh one is replaced and persisted."""
+    fake_context = _patch_create_deps(
+        monkeypatch, frozen_prompt="old prompt without new skill", fresh_prompt="fresh prompt"
+    )
+
+    await KimiCLI.create(session, config=config, resumed=True)
+
+    fake_context.write_system_prompt.assert_awaited_once_with("fresh prompt")
+    assert fake_context.system_prompt == "fresh prompt"
+
+
+@pytest.mark.asyncio
+async def test_resume_keeps_prompt_when_unchanged(session, config, monkeypatch):
+    """An up-to-date frozen prompt is left alone (no rewrite)."""
+    fake_context = _patch_create_deps(
+        monkeypatch, frozen_prompt="same prompt", fresh_prompt="same prompt"
+    )
+
+    await KimiCLI.create(session, config=config, resumed=True)
+
+    fake_context.write_system_prompt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_new_session_writes_system_prompt(session, config, monkeypatch):
+    """A session without a frozen prompt gets the fresh one written."""
+    fake_context = _patch_create_deps(monkeypatch, frozen_prompt=None, fresh_prompt="fresh prompt")
+
+    await KimiCLI.create(session, config=config, resumed=False)
+
+    fake_context.write_system_prompt.assert_awaited_once_with("fresh prompt")


### PR DESCRIPTION
## Related Issue

Resolve #2420

## Description

Resuming a session unconditionally adopts the `_system_prompt` record frozen in `context.jsonl` (`KimiCLI.create`, introduced in #1417), so:

- skills added to `~/.kimi/skills/` never appear in resumed sessions,
- `AGENTS.md` edits never reach resumed sessions,
- prompt-affecting config changes are silently ignored after resume,
- and `/fork` copies the stale prompt along, so forking can't recover either.

This implements Option A from #2420: when the freshly generated prompt differs from the frozen one, adopt the fresh prompt and persist it; when they're equal, the frozen record is left untouched. The `context.jsonl` invariant from #1417 — the file always carries the prompt actually in use, readable by frontends/vis tools — is preserved.

**Latent bug fixed along the way:** `Context.write_system_prompt()` *prepended* a new `_system_prompt` record without removing the existing one, while `restore()` applies the **last** `_system_prompt` record seen — so a refreshed prompt would silently lose to the stale leftover on the very next restore. The rewrite now drops previous `_system_prompt` records (streaming, byte-preserving for non-prompt lines, atomic via temp file as before).

## Real-behavior proof (deterministic, local mock provider)

1. Create `~/.kimi/skills/skill-one/`, run `kimi --print -p "first session"` → request system prompt lists `skill-one`. ✅
2. Add `~/.kimi/skills/skill-two/`, run `kimi --print -C -p "resumed"`:
   - on `main`: `skill-one: True, skill-two: False` ❌ (bug reproduced)
   - on this branch: `skill-one: True, skill-two: True` ✅

## Verification

- New tests (fail on `main`):
  - `tests/core/test_context.py::test_write_system_prompt_replaces_existing_record`
  - `tests/core/test_resume_system_prompt.py` — stale prompt refreshed & persisted / unchanged prompt untouched / new session written.
- `uv run pytest tests/core` → 862 passed; full `tests/` suite green.
- `ruff` / `pyright` clean.

## Notes for reviewers

The generated prompt includes volatile builtins (`KIMI_NOW`, `KIMI_WORK_DIR_LS`), so in practice the prompt is rewritten on most resumes. That refreshes the stale timestamp/directory listing too (previously the model was told the session's original creation time as "now"). If you'd rather compare only the stable sections to preserve cross-restart provider prompt caching, happy to adjust — see #2420 discussion.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue.
- [x] I have added tests that prove my fix is effective.
- [x] Changelog updated (manual `## Unreleased` entry; `make gen-changelog` needs kimi API auth).
- [x] `make gen-docs` — N/A: no user-facing docs change.
