### PR TITLE
fix(session): align fork/undo context truncation to wire turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Only write entries that are worth mentioning to users.
 
 ## Unreleased
 
+- Fixed `/undo` and `/fork` truncating the conversation context at the wrong turn in sessions that had been compacted or steered, which could silently keep turns the user rewound past (or drop turns they kept).
+
 ## 1.49.0 (2026-07-16)
 
 **Highlights**: The completion-token budget for Kimi providers now adapts to the model's remaining context window, reducing context-length overflow errors on long turns

--- a/src/kimi_cli/session_fork.py
+++ b/src/kimi_cli/session_fork.py
@@ -195,6 +195,15 @@ def truncate_context_at_turn(
     Unlike wire truncation, this is best-effort: if context has fewer user turns
     than ``turn_index`` (e.g. slash-command turns that did not mutate context),
     return all available context lines instead of failing.
+
+    Known limitations of text alignment (both need an explicit turn-marker
+    record in context.jsonl to resolve, and both predate this alignment):
+
+    - A context-mutating slash turn (e.g. ``/init``) injects a user record
+      whose text differs from the wire turn text, so it cannot be attributed
+      to its (possibly cut) turn and is conservatively kept.
+    - A steer whose text is exactly equal to a later turn's user text is
+      indistinguishable from that turn's start and aligns to it.
     """
     if not context_path.exists():
         return []

--- a/src/kimi_cli/session_fork.py
+++ b/src/kimi_cli/session_fork.py
@@ -10,6 +10,7 @@ import json
 import mimetypes
 import re
 import shutil
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -169,11 +170,27 @@ def _is_checkpoint_user_message(record: dict[str, Any]) -> bool:
     return False
 
 
-def truncate_context_at_turn(context_path: Path, turn_index: int) -> list[str]:
+def truncate_context_at_turn(
+    context_path: Path,
+    turn_index: int,
+    turn_texts: Sequence[str] | None = None,
+) -> list[str]:
     """Read context.jsonl and return all lines up to and including the given turn.
 
     Turn detection is based on real user messages, excluding synthetic checkpoint
     user entries like ``<system>CHECKPOINT N</system>``.
+
+    ``turn_index`` counts *wire* turns, but the context file is not 1:1 with the
+    wire: compaction rewrites earlier turns into a single user-role summary,
+    steers and notifications append extra user-role messages, and slash-command
+    turns never touch the context at all. When ``turn_texts`` (the user text of
+    every wire turn, index-aligned, from :func:`enumerate_turns`) is provided,
+    context user records are aligned to wire turns by matching text, and records
+    that match no wire turn do not advance the turn counter. Plain positional
+    counting — kept as the fallback when ``turn_texts`` is None — treats every
+    user record as a turn boundary and truncates at the wrong record after any
+    compaction or steer, silently keeping turns the user rewound past (or
+    dropping turns they kept).
 
     Unlike wire truncation, this is best-effort: if context has fewer user turns
     than ``turn_index`` (e.g. slash-command turns that did not mutate context),
@@ -184,6 +201,7 @@ def truncate_context_at_turn(context_path: Path, turn_index: int) -> list[str]:
 
     lines: list[str] = []
     current_turn = -1  # Will become 0 on first real user message
+    next_wire_turn = 0  # Alignment cursor into turn_texts
 
     with open(context_path, encoding="utf-8") as f:
         for line in f:
@@ -197,14 +215,39 @@ def truncate_context_at_turn(context_path: Path, turn_index: int) -> list[str]:
                 continue
 
             if record.get("role") == "user" and not _is_checkpoint_user_message(record):
-                current_turn += 1
-                if current_turn > turn_index:
-                    break
+                if turn_texts is None:
+                    current_turn += 1
+                    if current_turn > turn_index:
+                        break
+                else:
+                    matched = _match_wire_turn(record, turn_texts, next_wire_turn)
+                    if matched is not None:
+                        if matched > turn_index:
+                            break
+                        next_wire_turn = matched + 1
 
-            if current_turn <= turn_index:
-                lines.append(stripped)
+            lines.append(stripped)
 
     return lines
+
+
+def _match_wire_turn(
+    record: dict[str, Any], turn_texts: Sequence[str], next_wire_turn: int
+) -> int | None:
+    """Return the wire turn index a context user record starts, if any.
+
+    Scans forward from ``next_wire_turn`` (turns are consumed in order) and
+    matches by extracted user text. Records that match no remaining wire turn
+    (compaction summaries, steer injections, notification messages) return None.
+    """
+    content = record.get("content")
+    if not isinstance(content, str | list):
+        return None
+    text = _extract_user_text(cast("str | list[Any]", content)).strip()
+    for j in range(next_wire_turn, len(turn_texts)):
+        if text == turn_texts[j].strip():
+            return j
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +284,10 @@ async def fork_session(
 
     if turn_index is not None:
         truncated_wire_lines = truncate_wire_at_turn(wire_path, turn_index)
-        truncated_context_lines = truncate_context_at_turn(context_path, turn_index)
+        turn_texts = [turn.user_text for turn in enumerate_turns(wire_path)]
+        truncated_context_lines = truncate_context_at_turn(
+            context_path, turn_index, turn_texts=turn_texts
+        )
     else:
         # Copy all content
         truncated_wire_lines = _read_all_lines(wire_path)

--- a/tests/core/test_session_fork.py
+++ b/tests/core/test_session_fork.py
@@ -558,3 +558,25 @@ class TestTruncateContextAlignment:
         forked_context = (new_session.dir / "context.jsonl").read_text(encoding="utf-8")
         assert "turn two" in forked_context
         assert "turn three" not in forked_context
+
+    def test_slash_command_turns_do_not_consume_context_records(self, session_dir: Path):
+        """Wire-only turns (slash commands) must not shift the context cut (#1974)."""
+        wire_turns = ["real 0", "/usage", "/sessions", "real 1", "real 2"]
+        context_path = _write_raw_context(
+            session_dir,
+            [
+                _user_record("real 0"),
+                _assistant_record(),
+                _user_record("real 1"),
+                _assistant_record(),
+                _user_record("real 2"),
+                _assistant_record(),
+            ],
+        )
+
+        lines = truncate_context_at_turn(context_path, 3, turn_texts=wire_turns)
+
+        texts = "\n".join(lines)
+        assert "real 0" in texts
+        assert "real 1" in texts
+        assert "real 2" not in texts

--- a/tests/core/test_session_fork.py
+++ b/tests/core/test_session_fork.py
@@ -421,3 +421,140 @@ class TestForkSession:
         new_video = new_session.dir / "uploads" / "test.mp4"
         assert new_video.exists()
         assert new_video.read_text() == "fake video"
+
+
+# ---------------------------------------------------------------------------
+# Tests: wire/context turn alignment (compaction, steers)
+# ---------------------------------------------------------------------------
+
+
+def _user_record(text: str) -> str:
+    return Message(role="user", content=[TextPart(text=text)]).model_dump_json(exclude_none=True)
+
+
+def _assistant_record(text: str = "response") -> str:
+    return Message(role="assistant", content=text).model_dump_json(exclude_none=True)
+
+
+def _write_raw_context(session_dir: Path, records: list[str]) -> Path:
+    context_path = session_dir / "context.jsonl"
+    context_path.write_text("".join(r + "\n" for r in records), encoding="utf-8")
+    return context_path
+
+
+_COMPACTION_SUMMARY = (
+    "<system>Previous context has been compacted. Here is the compaction output:</system> "
+    "The user asked about turn one and got an answer."
+)
+
+
+class TestTruncateContextAlignment:
+    """Context truncation must align to wire turns, not count user records.
+
+    Compaction rewrites earlier turns into one user-role summary record, and
+    steers inject extra user-role records mid-turn, so positional counting
+    truncates at the wrong record.
+    """
+
+    def test_compaction_summary_not_counted_as_turn(self, session_dir: Path):
+        """Rewinding past a turn must drop it even after compaction."""
+        wire_turns = ["turn one", "turn two", "/compact", "turn three"]
+        context_path = _write_raw_context(
+            session_dir,
+            [
+                _user_record(_COMPACTION_SUMMARY),
+                _user_record("turn two"),
+                _assistant_record(),
+                _user_record("turn three"),
+                _assistant_record(),
+            ],
+        )
+
+        lines = truncate_context_at_turn(context_path, 2, turn_texts=wire_turns)
+
+        texts = "\n".join(lines)
+        assert "turn two" in texts
+        assert "compacted" in texts
+        assert "turn three" not in texts
+
+    def test_steer_message_not_counted_as_turn(self, session_dir: Path):
+        """A steer injected mid-turn must not shift the turn boundary."""
+        wire_turns = ["first", "second"]
+        context_path = _write_raw_context(
+            session_dir,
+            [
+                _user_record("first"),
+                _user_record("actually, focus on the tests"),
+                _assistant_record("steered response"),
+                _user_record("second"),
+                _assistant_record(),
+            ],
+        )
+
+        lines = truncate_context_at_turn(context_path, 0, turn_texts=wire_turns)
+
+        texts = "\n".join(lines)
+        assert "focus on the tests" in texts
+        assert "steered response" in texts
+        assert "second" not in texts
+
+    def test_duplicate_turn_texts_align_in_order(self, session_dir: Path):
+        wire_turns = ["continue", "continue"]
+        context_path = _write_raw_context(
+            session_dir,
+            [
+                _user_record("continue"),
+                _assistant_record("one"),
+                _user_record("continue"),
+                _assistant_record("two"),
+            ],
+        )
+
+        lines = truncate_context_at_turn(context_path, 0, turn_texts=wire_turns)
+
+        texts = "\n".join(lines)
+        assert '"one"' in texts
+        assert '"two"' not in texts
+
+    def test_positional_fallback_without_turn_texts(self, session_dir: Path):
+        """Without turn_texts the legacy positional behavior is unchanged."""
+        context_path = _write_context_file(session_dir, ["a", "b", "c"])
+
+        lines = truncate_context_at_turn(context_path, 1)
+
+        texts = "\n".join(lines)
+        assert '"b"' in texts
+        assert '"c"' not in texts
+
+    @pytest.mark.asyncio
+    async def test_fork_after_compaction_drops_undone_turn(
+        self, isolated_share_dir: Path, work_dir: KaosPath
+    ):
+        """End-to-end: forking past a post-compaction turn must not leak it."""
+        from kimi_cli.session import Session
+
+        source = await Session.create(work_dir=work_dir)
+        _write_wire_file(source.dir, ["turn one", "turn two", "/compact", "turn three"])
+        _write_raw_context(
+            source.dir,
+            [
+                _user_record(_COMPACTION_SUMMARY),
+                _user_record("turn two"),
+                _assistant_record(),
+                _user_record("turn three"),
+                _assistant_record(),
+            ],
+        )
+
+        new_id = await fork_session(
+            source_session_dir=source.dir,
+            work_dir=work_dir,
+            turn_index=2,
+            source_title="Compacted Session",
+        )
+
+        new_session = await Session.find(work_dir, new_id)
+        assert new_session is not None
+        forked_context = (new_session.dir / "context.jsonl").read_text(encoding="utf-8")
+        assert "turn two" in forked_context
+        assert "turn three" not in forked_context


### PR DESCRIPTION
## Related Issue

Resolve #2517

Also resolves #1974 (wire-only slash turns shifting the undo cut — covered by a dedicated regression test) and likely the root cause of #2049 (history mismatch after forks/undos).

**Relation to open PR #2386:** that PR maps wire turns to context turns for the slash-command case (credit to its author for identifying that direction). It does not handle synthetic user-role records in the context — compaction summaries, steers, notifications — so compacted/steered sessions still cut at the wrong record, and the compaction case leaks "undone" turns into the model's context. This PR covers both directions with tests for each; happy to instead rebase the additional coverage on top of #2386 if the maintainers prefer to land that one first.

## Description

`truncate_context_at_turn()` counts non-checkpoint `role="user"` records to find the cut point for `/undo` and `/fork`, but the context file is not 1:1 with wire turns: compaction rewrites earlier turns into one user-role summary record, steers and notifications inject extra user-role records, and slash-command turns produce no context record at all. After any of these, the context is truncated at the wrong record:

- rewinding past a post-compaction turn **keeps that turn in the model's context** while the UI no longer shows it;
- forking a steered session cuts **too early**, so the agent is missing turns the resumed UI still displays (the #2049 symptom).

**Fix:** when the wire turn texts are available (from `enumerate_turns`, which `fork_session` already computes for wire truncation), align context user records to wire turns by matching extracted user text, consuming turns in order. Records that match no remaining wire turn (summaries, steers, notifications) no longer advance the turn counter, and turns with no context record (slash commands, compacted-away turns) no longer consume a user record. Positional counting is kept as an explicit fallback when wire texts are unavailable, preserving the existing best-effort semantics.

## Real-behavior proof (deterministic, local mock provider)

Build a real session: `turn one` → `turn two` → `/compact` → `turn three`; then `fork_session(dir, work_dir, turn_index=2)` (the exact `/undo` code path):

- on `main`: forked wire shows turns 0–2, but forked `context.jsonl` **still contains `user: "turn three"` and its assistant reply** ❌
- on this branch: forked context ends after the `turn two` block ✅

## Verification

- New tests in `tests/core/test_session_fork.py::TestTruncateContextAlignment` (4 fail on `main`):
  compaction summary not counted as a turn; steer not counted; duplicate turn texts align in order; end-to-end `fork_session` after compaction drops the undone turn; positional fallback unchanged.
- `uv run pytest tests/core/test_session_fork.py` → 34 passed; full `tests/` suite green.
- `ruff` / `pyright` clean.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked the related issue (file the draft issue first).
- [x] I have added tests that prove my fix is effective.
- [x] Changelog updated (manual `## Unreleased` entry; `make gen-changelog` needs kimi API auth).
- [x] `make gen-docs` — N/A: no user-facing docs change.
