### PR TITLE
fix(tools): count StrReplaceFile replacements against the running content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Tool: Fix StrReplaceFile reporting the wrong replacement count when edits are chained. The total was counted against the original file content, so a later edit whose target text was produced by an earlier edit was counted as zero; the count now tracks the running content
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -134,9 +134,18 @@ class StrReplaceFile(CallableTool2[Params]):
             original_content = content
             edits = [params.edit] if isinstance(params.edit, Edit) else params.edit
 
-            # Apply all edits
+            # Apply all edits, counting replacements against the running content.
+            # Edits apply sequentially, so counting against the original content
+            # miscounts chained edits (e.g. one edit whose `old` is produced by an
+            # earlier edit is not found in the original and would be counted 0).
+            total_replacements = 0
             for edit in edits:
+                before = content
                 content = self._apply_edit(content, edit)
+                if edit.replace_all:
+                    total_replacements += before.count(edit.old)
+                elif edit.old in before:
+                    total_replacements += 1
 
             # Check if any changes were made
             if content == original_content:
@@ -168,14 +177,6 @@ class StrReplaceFile(CallableTool2[Params]):
 
             # Write the modified content back to the file
             await p.write_text(content, errors="replace")
-
-            # Count changes for success message
-            total_replacements = 0
-            for edit in edits:
-                if edit.replace_all:
-                    total_replacements += original_content.count(edit.old)
-                else:
-                    total_replacements += 1 if edit.old in original_content else 0
 
             return ToolReturnValue(
                 is_error=False,

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -75,6 +75,31 @@ async def test_replace_multiple_edits(
     assert await file_path.read_text() == "Hi world! See you world!"
 
 
+async def test_replace_chained_edits_report_correct_count(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """Chained edits (a later edit's `old` is produced by an earlier one) must
+    report the true number of replacements, not the count against the original."""
+    file_path = temp_work_dir / "test.txt"
+    await file_path.write_text("hello world")
+
+    result = await str_replace_file_tool(
+        Params(
+            path=str(file_path),
+            edit=[
+                Edit(old="hello", new="goodbye"),
+                Edit(old="goodbye", new="farewell"),
+            ],
+        )
+    )
+
+    assert not result.is_error
+    assert await file_path.read_text() == "farewell world"
+    # Both edits replaced text, so the message must say 2 replacements (the old
+    # code counted "goodbye" against the original and reported 1).
+    assert "2 total replacement(s)" in result.message
+
+
 async def test_replace_multiline_content(
     str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
 ):


### PR DESCRIPTION
## Related Issue

Resolves #2526

## Description

`StrReplaceFile` applies its edits sequentially, but it computed the reported replacement count against the *original* file content. A chained edit whose `old` string is produced by an earlier edit is not present in the original, so it was counted as zero.

For example, on a file containing `hello world`:

    edits = [
        Edit(old="hello",   new="goodbye"),
        Edit(old="goodbye", new="farewell"),
    ]

both edits replace text and the file correctly becomes `farewell world`, but the tool reported:

    File successfully edited. Applied 2 edit(s) with 1 total replacement(s).

because `"goodbye"` was not found in the original content. This counts each edit against the content it is actually applied to (the running content), so the reported number matches what happened (`2 total replacement(s)` above).

The file output itself is unchanged; only the reported count is corrected. A regression test is added that fails on the current code.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any. (#2526)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog. (Entry added to the Unreleased section by hand in the existing style; `make gen-changelog` drives Kimi CLI itself, which I could not run locally.)
- [ ] I have run `make gen-docs` to update the user documentation. (N/A: no user-facing docs change.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->