### PR TITLE
fix(shell): stop blocking until timeout when a detached child holds the pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Shell: Fix the shell tool blocking until the full command timeout when a detached child process inherits stdout/stderr, then wrongly reporting a timeout kill. The tool now returns shortly after the shell itself exits and drains remaining pipe output for a bounded grace period
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/tools/shell/__init__.py
+++ b/src/kimi_cli/tools/shell/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from collections.abc import Callable
 from pathlib import Path
 from typing import Self, override
@@ -21,6 +22,18 @@ from kimi_cli.utils.subprocess_env import get_noninteractive_env
 
 MAX_FOREGROUND_TIMEOUT = 5 * 60
 MAX_BACKGROUND_TIMEOUT = 24 * 60 * 60
+PIPE_DRAIN_GRACE = 2.0
+"""Seconds to keep draining stdout/stderr after the shell process exits.
+
+A detached child that inherited the pipes can keep them open long after the
+shell itself has exited; without a bound the tool would block until the full
+command timeout waiting for an EOF that may never come."""
+EXIT_POLL_INTERVAL = 0.05
+"""Seconds between exit checks while the shell process is running.
+
+`KaosProcess.wait()` may not resolve until all pipes close (asyncio gates its
+exit waiters on pipe disconnection), so process exit is observed by polling
+`returncode` instead."""
 
 
 class Params(BaseModel):
@@ -244,21 +257,39 @@ class Shell(CallableTool2[Params]):
         # EOF instead of hanging forever waiting for input that will never come.
         process.stdin.close()
 
+        async def _wait_exit() -> int:
+            while (exitcode := process.returncode) is None:
+                await asyncio.sleep(EXIT_POLL_INTERVAL)
+            return exitcode
+
+        def _consume_exception(task: asyncio.Future[tuple[None, None]]) -> None:
+            # When the read task is abandoned after cancel (user interrupt or
+            # command timeout), retrieve its outcome so the event loop does
+            # not report "exception was never retrieved".
+            if not task.cancelled():
+                task.exception()
+
+        read_task = asyncio.gather(
+            _read_stream(process.stdout, stdout_cb),
+            _read_stream(process.stderr, stderr_cb),
+        )
+        read_task.add_done_callback(_consume_exception)
         try:
-            await asyncio.wait_for(
-                asyncio.gather(
-                    _read_stream(process.stdout, stdout_cb),
-                    _read_stream(process.stderr, stderr_cb),
-                ),
-                timeout,
-            )
-            return await process.wait()
+            exitcode = await asyncio.wait_for(_wait_exit(), timeout)
         except asyncio.CancelledError:
+            read_task.cancel()
             await process.kill()
             raise
         except TimeoutError:
+            read_task.cancel()
             await process.kill()
             raise
+        # The shell has exited, but a detached child that inherited the
+        # pipes can keep them open indefinitely; drain what is left
+        # instead of waiting for an EOF that may never come.
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(read_task, PIPE_DRAIN_GRACE)
+        return exitcode
 
     def _shell_args(self, command: str) -> tuple[str, ...]:
         return (str(self._shell_path), "-c", command)

--- a/tests/tools/test_shell_bash.py
+++ b/tests/tools/test_shell_bash.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import platform
+import time
 
 import pytest
 from inline_snapshot import snapshot
@@ -95,6 +96,23 @@ async def test_command_timeout_expires(shell_tool: Shell):
     assert result.is_error
     assert result.message == snapshot("Command killed by timeout (1s)")
     assert result.brief == snapshot("Killed by timeout (1s)")
+
+
+async def test_detached_child_holding_pipes_does_not_block_until_timeout(shell_tool: Shell):
+    """A detached child that inherits stdout/stderr must not stall the tool.
+
+    The shell exits immediately, but the backgrounded sleep keeps the pipes
+    open; the tool should return shortly after the shell exits instead of
+    blocking until the command timeout waiting for pipe EOF.
+    """
+    start = time.monotonic()
+    result = await shell_tool(Params(command="sleep 30 & echo started", timeout=25))
+    elapsed = time.monotonic() - start
+    assert not result.is_error
+    assert "started" in result.output
+    # Shell exit plus PIPE_DRAIN_GRACE, with slack for slow CI; the old
+    # behavior would block for the full 25s timeout and report an error.
+    assert elapsed < 20
 
 
 async def test_environment_variables(shell_tool: Shell):
@@ -249,6 +267,7 @@ class _FakeProc:
     stdin = _NullStdin()
     stdout = _EmptyStream()
     stderr = _EmptyStream()
+    returncode: int | None = 0
 
     async def wait(self) -> int:
         return 0
@@ -375,12 +394,16 @@ async def test_cancelled_command_kills_process(shell_tool: Shell, monkeypatch: p
             self.stdout = BlockingReadable()
             self.stderr = BlockingReadable()
             self.kill_calls = 0
+            self.returncode: int | None = None
 
         async def wait(self) -> int:
-            return 0
+            while self.returncode is None:
+                await asyncio.sleep(0.01)
+            return self.returncode
 
         async def kill(self) -> None:
             self.kill_calls += 1
+            self.returncode = -9
 
     fake_process = FakeProcess()
 


### PR DESCRIPTION
## Related Issue

Resolve #2468

## Description

In the foreground shell path, `_run_shell_command` waits for stdout/stderr EOF (`asyncio.wait_for(gather(read stdout, read stderr), timeout)`) before ever checking the exit code. A command like `some_daemon & echo done` leaves a detached child holding the write ends of the pipes, so EOF never arrives: the tool blocks for the entire command timeout even though the shell exited immediately, then reports "Command killed by timeout" for a command that actually succeeded. That is the hang in #2468.

Two things I learned while fixing it, which shaped the implementation:

1. Waiting on `process.wait()` instead does not work: asyncio gates its subprocess exit waiters on pipe disconnection, so `wait()` blocks exactly the same way (verified empirically on macOS and Linux Python 3.14: `wait()` returned only when the detached child died, while `returncode` was set within 50ms of the shell exiting). So exit is observed by polling `returncode` at 50ms intervals, which the `KaosProcess` protocol guarantees on every backend.
2. Abandoning the reader `gather` after cancel triggers asyncio's "_GatheringFuture exception was never retrieved" loop-level error, which prompt_toolkit surfaces as a full-screen "Unhandled exception in event loop" banner that freezes the TUI. The existing PTY e2e tests (`test_ctrl_c_during_running_turn_interrupts`, `test_shell_cancel_running_command_kills_process_and_recovers`) caught this in my first attempt, hence the `_consume_exception` done callback.

Behavior after the fix:

- Shell exits while something still holds the pipes: remaining output is drained for a bounded `PIPE_DRAIN_GRACE` (2s), then the tool returns the real exit code. Output produced by a detached child after that grace is dropped, which I think is the right semantic: the shell finishing is what "the command finished" means.
- Genuinely long-running commands: unchanged, still killed at the timeout with the same error message.
- Ctrl-C cancel: unchanged (kill + raise), minus the event loop leak.
- Normal fast commands: unchanged output, worst case ~50ms added exit-detection latency.

Note this intentionally does not implement full child-process tracking/reaping that the issue mentions as the ideal. The detached child keeps running (same as before the fix); the change just stops it from stalling the agent loop. Figured the bigger cleanup story needs maintainer direction first.

Tests: new `test_detached_child_holding_pipes_does_not_block_until_timeout` (fails at 25s timeout before the fix, returns in ~2s after). The fake processes in existing tests grew a `returncode` attribute since the code now polls it, and the cancel-test fake now models "running until killed" to keep testing the same scenario it did before.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make gen-changelog` to update the changelog. (hand-edited CHANGELOG.md in the same style, i don't have the Kimi API setup the skill needs)
- [x] I have run `make gen-docs` to update the user documentation. (no user-facing docs describe the shell tool's pipe/timeout behavior, nothing to regenerate)

---

being upfront: freshman here, i dug through this one with claude code as a rubber duck for the asyncio semantics (the wait() thing surprised both of us). tested everything i could locally but if the approach is off i'm all ears, learning as i go :)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->