### PR TITLE
fix(web): make server banner encoding-safe

### DIFF
--- a/src/kimi_cli/utils/server.py
+++ b/src/kimi_cli/utils/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import socket
+import sys
 import textwrap
 
 
@@ -88,6 +89,11 @@ def get_network_addresses() -> list[str]:
 
 def print_banner(lines: list[str]) -> None:
     """Print a boxed banner with tag conventions (<center>, <nowrap>, <hr>)."""
+
+    def print_safe(text: str) -> None:
+        encoding = sys.stdout.encoding or "utf-8"
+        print(text.encode(encoding, errors="replace").decode(encoding))
+
     processed: list[str] = []
     for line in lines:
         if line == "<hr>":
@@ -106,16 +112,16 @@ def print_banner(lines: list[str]) -> None:
     width = max(60, *(len(line) for line in content_lines))
     top = "+" + "=" * (width + 2) + "+"
 
-    print(top)
+    print_safe(top)
     for line in processed:
         if line == "<hr>":
-            print("|" + "-" * (width + 2) + "|")
+            print_safe("|" + "-" * (width + 2) + "|")
         elif line.startswith("<center>"):
             content = line.removeprefix("<center>")
-            print(f"| {content.center(width)} |")
+            print_safe(f"| {content.center(width)} |")
         elif line.startswith("<nowrap>"):
             content = line.removeprefix("<nowrap>")
-            print(f"| {content.ljust(width)} |")
+            print_safe(f"| {content.ljust(width)} |")
         else:
-            print(f"| {line.ljust(width)} |")
-    print(top)
+            print_safe(f"| {line.ljust(width)} |")
+    print_safe(top)

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import io
+import sys
+
 import pytest
 
 from kimi_cli.utils.server import (
@@ -10,6 +13,7 @@ from kimi_cli.utils.server import (
     get_address_family,
     get_network_addresses,
     is_local_host,
+    print_banner,
 )
 
 # ---------------------------------------------------------------------------
@@ -119,3 +123,17 @@ class TestGetNetworkAddresses:
     def test_no_loopback(self) -> None:
         for addr in get_network_addresses():
             assert not addr.startswith("127.")
+
+
+class TestPrintBanner:
+    def test_replaces_characters_unsupported_by_stdout_encoding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output = io.BytesIO()
+        stdout = io.TextIOWrapper(output, encoding="gbk", errors="strict")
+        monkeypatch.setattr(sys, "stdout", stdout)
+
+        print_banner(["<nowrap>  ➜  Local http://127.0.0.1:5495"])
+        stdout.flush()
+
+        assert "?" in output.getvalue().decode("gbk")


### PR DESCRIPTION
## Summary

- encode banner lines using the active stdout encoding with replacement for unsupported characters
- preserve the existing banner output on UTF-8 terminals
- add a regression test using a strict GBK stdout stream

## Validation

- `uv run pytest tests/utils/test_server.py -q` (21 passed)
- `uv run ruff check` (passed)
- `uv run ruff format --check` (passed)

Full Windows-only checks still contain unrelated pre-existing POSIX compatibility failures in editor/file-filter tests and `pty`/`ioctl` type checks.

Closes #2532
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->