### PR TITLE
fix(shell): support numeric keypad input

### DIFF
--- a/src/kimi_cli/ui/shell/prompt.py
+++ b/src/kimi_cli/ui/shell/prompt.py
@@ -1250,6 +1250,16 @@ class CustomPromptSession:
         # Build key bindings
         _kb = KeyBindings()
 
+        # Windows Terminal can emit DEC application-keypad sequences while
+        # Num Lock is enabled. prompt_toolkit does not map these sequences to
+        # printable characters, so register them explicitly for the input
+        # buffer (SS3 ``p`` through ``y`` represent keypad 0 through 9).
+        for digit, suffix in enumerate("pqrstuvwxy"):
+
+            @_kb.add("escape", "O", suffix, eager=True)
+            def _insert_keypad_digit(event: KeyPressEvent, digit: int = digit) -> None:
+                event.current_buffer.insert_text(str(digit))
+
         def _accept_completion(buff: Buffer) -> None:
             """Accept the current or first completion, suppressing re-completion."""
             completion = buff.complete_state.current_completion  # type: ignore[union-attr]

--- a/tests/ui_and_conv/test_prompt_numeric_keypad.py
+++ b/tests/ui_and_conv/test_prompt_numeric_keypad.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from prompt_toolkit.application import create_app_session
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+from kimi_cli.ui.shell.prompt import CustomPromptSession, StatusSnapshot
+
+
+@pytest.mark.asyncio
+async def test_numeric_keypad_sequences_insert_digits() -> None:
+    with (
+        create_pipe_input() as pipe_input,
+        create_app_session(input=pipe_input, output=DummyOutput()),
+    ):
+        prompt = CustomPromptSession(
+            status_provider=lambda: StatusSnapshot(context_usage=0.0),
+            model_capabilities=set(),
+            model_name=None,
+            thinking=False,
+            agent_mode_slash_commands=[],
+            shell_mode_slash_commands=[],
+        )
+
+        result_task = asyncio.create_task(prompt._session.prompt_async())
+        pipe_input.send_text("".join(f"\x1bO{suffix}" for suffix in "pqrstuvwxy") + "\r")
+
+        assert await asyncio.wait_for(result_task, timeout=1) == "0123456789"


### PR DESCRIPTION
## Summary

- recognize DEC application-keypad SS3 sequences emitted by Windows Terminal
- insert keypad digits `0` through `9` into the active prompt buffer
- add an integration regression test covering all ten keypad digit sequences

## Validation

- `uv run pytest tests/ui_and_conv/test_prompt_numeric_keypad.py -q` (1 passed)
- `uv run ruff check src/kimi_cli/ui/shell tests/ui_and_conv/test_prompt_numeric_keypad.py`
- `uv run ruff format --check src/kimi_cli/ui/shell tests/ui_and_conv/test_prompt_numeric_keypad.py`

Closes #2529
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->