### PR TITLE
fix(mcp): normalize tools for Moonshot API

### DIFF
--- a/packages/kosong/src/kosong/chat_provider/kimi.py
+++ b/packages/kosong/src/kosong/chat_provider/kimi.py
@@ -44,6 +44,7 @@ from kosong.message import (
 )
 from kosong.tooling import Tool
 from kosong.utils.jsonschema import JsonDict, ensure_property_types
+from kosong.utils.typing import JsonType
 
 if TYPE_CHECKING:
 
@@ -383,9 +384,55 @@ def _convert_tool(tool: Tool) -> ChatCompletionToolParam:
     function = converted["function"]
     parameters = function.get("parameters")
     if isinstance(parameters, dict):
-        normalized = ensure_property_types(cast(JsonDict, parameters))
+        normalized = copy.deepcopy(cast(JsonDict, parameters))
+        if isinstance(normalized.get("properties"), dict):
+            normalized.setdefault("type", "object")
+        normalized = _normalize_object_any_of(normalized)
+        normalized = ensure_property_types(normalized)
         function["parameters"] = cast(dict[str, object], normalized)
     return converted
+
+
+def _normalize_object_any_of(schema: JsonDict) -> JsonDict:
+    """Distribute a simple object schema into ``anyOf`` required branches.
+
+    Moonshot rejects ``type`` beside ``anyOf``. MCP tools commonly use this
+    shape solely to require one of several object properties. Distributing the
+    shared object constraints into those branches preserves the schema's
+    meaning while satisfying Moonshot's stricter dialect.
+    """
+    branches = schema.get("anyOf")
+    if not (
+        schema.get("type") == "object"
+        and isinstance(schema.get("properties"), dict)
+        and isinstance(branches, list)
+        and branches
+        and all(
+            isinstance(branch, dict)
+            and set(branch).issubset({"required"})
+            and isinstance(branch.get("required", []), list)
+            for branch in branches
+        )
+    ):
+        return schema
+
+    common = copy.deepcopy(schema)
+    common.pop("anyOf")
+    common_required = common.pop("required", [])
+    if not isinstance(common_required, list):
+        return schema
+
+    distributed: list[JsonType] = []
+    for branch in branches:
+        assert isinstance(branch, dict)
+        branch_required = branch.get("required", [])
+        assert isinstance(branch_required, list)
+        branch_schema = copy.deepcopy(common)
+        required = list(dict.fromkeys([*common_required, *branch_required]))
+        if required:
+            branch_schema["required"] = required
+        distributed.append(branch_schema)
+    return {"anyOf": distributed}
 
 
 class KimiStreamedMessage:

--- a/packages/kosong/tests/test_kimi_tool_conversion.py
+++ b/packages/kosong/tests/test_kimi_tool_conversion.py
@@ -81,3 +81,55 @@ def test_convert_tool_passes_through_already_typed_schema() -> None:
         "properties": {"msg": {"type": "string"}},
         "required": ["msg"],
     }
+
+
+def test_convert_tool_distributes_object_constraints_into_any_of() -> None:
+    tool = Tool(
+        name="api_impact",
+        description="Find an API route or file.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "route": {"type": "string"},
+                "file": {"type": "string"},
+            },
+            "required": [],
+            "anyOf": [{"required": ["route"]}, {"required": ["file"]}],
+        },
+    )
+
+    parameters = _convert_tool(tool)["function"].get("parameters")
+
+    assert parameters == {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "route": {"type": "string"},
+                    "file": {"type": "string"},
+                },
+                "required": ["route"],
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "route": {"type": "string"},
+                    "file": {"type": "string"},
+                },
+                "required": ["file"],
+            },
+        ]
+    }
+
+
+def test_convert_tool_adds_missing_root_object_type() -> None:
+    tool = Tool(
+        name="echo",
+        description="Echo input.",
+        parameters={"properties": {"message": {"type": "string"}}},
+    )
+
+    assert _convert_tool(tool)["function"].get("parameters") == {
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+    }

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -5,10 +5,12 @@ import contextlib
 import importlib
 import inspect
 import json
+import re
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import timedelta
+from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
@@ -60,6 +62,20 @@ current_tool_call = ContextVar[ToolCall | None]("current_tool_call", default=Non
 _current_step_no: ContextVar[int | None] = ContextVar("current_step_no", default=None)
 
 _current_session_id: ContextVar[str] = ContextVar("_current_session_id", default="")
+
+_MOONSHOT_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+
+
+def _safe_mcp_tool_name(server_name: str, tool_name: str) -> str:
+    """Return a stable Moonshot-compatible alias for an MCP tool name."""
+    if len(tool_name) <= 64 and _MOONSHOT_TOOL_NAME_RE.fullmatch(tool_name):
+        return tool_name
+
+    stem = re.sub(r"[^A-Za-z0-9_-]", "_", tool_name)
+    if not stem or not stem[0].isalpha() or not stem[0].isascii():
+        stem = f"m_{stem}"
+    digest = sha256(f"{server_name}\0{tool_name}".encode()).hexdigest()[:8]
+    return f"{stem[:55]}_{digest}"
 
 
 def set_session_id(sid: str) -> None:
@@ -915,7 +931,7 @@ class MCPTool[T: ClientTransport](CallableTool):
         **kwargs: Any,
     ):
         super().__init__(
-            name=mcp_tool.name,
+            name=_safe_mcp_tool_name(server_name, mcp_tool.name),
             description=(
                 f"This is an MCP (Model Context Protocol) tool from MCP server `{server_name}`.\n\n"
                 f"{mcp_tool.description or 'No description provided.'}"

--- a/tests/core/test_mcp_tool_names.py
+++ b/tests/core/test_mcp_tool_names.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+from mcp.types import Tool
+
+from kimi_cli.soul.toolset import MCPTool, _safe_mcp_tool_name
+
+
+def test_safe_mcp_tool_name_preserves_compatible_name() -> None:
+    assert _safe_mcp_tool_name("magic", "component_builder") == "component_builder"
+
+
+def test_safe_mcp_tool_name_rewrites_invalid_name_stably() -> None:
+    first = _safe_mcp_tool_name("magic", "21st.magic component builder")
+    second = _safe_mcp_tool_name("magic", "21st.magic component builder")
+
+    assert first == second
+    assert first.startswith("m_21st_magic_component_builder_")
+    assert len(first) <= 64
+
+
+def test_mcp_tool_keeps_original_name_for_server_routing() -> None:
+    upstream = Tool(
+        name="21st_magic_component_builder",
+        description="Build a component.",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(
+            mcp=SimpleNamespace(client=SimpleNamespace(tool_call_timeout_ms=60_000))
+        )
+    )
+
+    tool = MCPTool("magic", upstream, cast(Any, object()), runtime=cast(Any, runtime))
+
+    assert tool.name.startswith("m_21st_magic_component_builder_")
+    assert tool._mcp_tool.name == "21st_magic_component_builder"


### PR DESCRIPTION
## Summary

- generate stable Moonshot-compatible aliases for MCP tool names while retaining original names for upstream call routing
- add a missing root `object` type when an MCP schema defines object properties
- distribute the exact object `anyOf`/required schema shape reported in the issue into equivalent Moonshot-compatible branches
- leave unsupported complex combinator schemas unchanged

## Validation

- `uv run pytest packages/kosong/tests/test_kimi_tool_conversion.py tests/core/test_mcp_tool_names.py -q` (9 passed)
- targeted Ruff check and format check passed
- targeted Pyright check passed with 0 errors
- remote compare verified: 1 commit, 4 intended files, 154 additions / 2 deletions

Closes #2531
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->