### PR TITLE
fix(media): normalize ICO images to PNG

### DIFF
--- a/src/kimi_cli/tools/file/read_media.py
+++ b/src/kimi_cli/tools/file/read_media.py
@@ -38,6 +38,18 @@ def _extract_image_size(data: bytes) -> tuple[int, int] | None:
         return None
 
 
+def _normalize_image_payload(mime_type: str, data: bytes) -> tuple[str, bytes]:
+    if mime_type != "image/x-icon":
+        return mime_type, data
+
+    from PIL import Image
+
+    output = BytesIO()
+    with Image.open(BytesIO(data)) as image:
+        image.save(output, format="PNG")
+    return "image/png", output.getvalue()
+
+
 class Params(BaseModel):
     path: str = Field(
         description=(
@@ -112,10 +124,13 @@ class ReadMediaFile(CallableTool2[Params]):
         match file_type.kind:
             case "image":
                 data = await path.read_bytes()
-                data_url = _to_data_url(file_type.mime_type, data)
+                image_size = _extract_image_size(data)
+                payload_mime_type, payload_data = _normalize_image_payload(
+                    file_type.mime_type, data
+                )
+                data_url = _to_data_url(payload_mime_type, payload_data)
                 part = ImageURLPart(image_url=ImageURLPart.ImageURL(url=data_url))
                 wrapped = wrap_media_part(part, tag="image", attrs={"path": media_path})
-                image_size = _extract_image_size(data)
             case "video":
                 data = await path.read_bytes()
                 if (llm := self._runtime.llm) and isinstance(llm.chat_provider, Kimi):

--- a/tests/tools/test_read_media_file.py
+++ b/tests/tools/test_read_media_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from io import BytesIO
 from typing import cast
 
@@ -84,6 +85,35 @@ async def test_read_image_file_with_size(
     assert not result.is_error
     assert result.message == snapshot(
         f"Loaded image file `{image_file}` (image/png, {len(data)} bytes, original size 3x4px). "
+        "If you need to output coordinates, output relative coordinates first and "
+        "compute absolute coordinates using the original image size; if you generate or "
+        "edit images/videos via commands or scripts, read the result back immediately "
+        "before continuing."
+    )
+
+
+async def test_read_ico_file_as_png(read_media_file_tool: ReadMediaFile, temp_work_dir: KaosPath):
+    """ICO files are normalized to a model-supported PNG payload."""
+    Image = pytest.importorskip("PIL.Image")
+    image_file = temp_work_dir / "favicon.ico"
+    image = Image.new("RGBA", (16, 16), color=(255, 0, 0, 255))
+    buffer = BytesIO()
+    image.save(buffer, format="ICO")
+    data = buffer.getvalue()
+    await image_file.write_bytes(data)
+
+    result = await read_media_file_tool(Params(path=str(image_file)))
+
+    assert not result.is_error
+    assert isinstance(result.output, list)
+    part = result.output[1]
+    assert isinstance(part, ImageURLPart)
+    prefix, encoded = part.image_url.url.split(",", maxsplit=1)
+    assert prefix == "data:image/png;base64"
+    assert base64.b64decode(encoded).startswith(b"\x89PNG\r\n\x1a\n")
+    assert result.message == snapshot(
+        f"Loaded image file `{image_file}` "
+        f"(image/x-icon, {len(data)} bytes, original size 16x16px). "
         "If you need to output coordinates, output relative coordinates first and "
         "compute absolute coordinates using the original image size; if you generate or "
         "edit images/videos via commands or scripts, read the result back immediately "


### PR DESCRIPTION
## Summary

- normalize ICO image payloads to PNG before sending them to the model
- preserve the original MIME type, byte length, and dimensions in the user-facing metadata
- leave all other image formats unchanged

## Reproduction and verification

Before the fix, the regression test deterministically produced a `data:image/x-icon;base64` model payload. After the fix:

- `uv run pytest tests/tools/test_read_media_file.py -q` — 7 passed
- targeted Ruff check — passed
- targeted Pyright — 0 errors

Closes #2367
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->