### PR TITLE
fix(mcp): continue after deferred startup failure

### DIFF
--- a/src/kimi_cli/soul/kimisoul.py
+++ b/src/kimi_cli/soul/kimisoul.py
@@ -31,6 +31,7 @@ from kimi_cli.approval_runtime import (
     set_current_approval_source,
 )
 from kimi_cli.background import build_active_task_snapshot
+from kimi_cli.exception import MCPRuntimeError
 from kimi_cli.hooks.engine import HookEngine
 from kimi_cli.llm import (
     DEFAULT_COMPLETION_TOKEN_SAFETY_MARGIN,
@@ -614,7 +615,13 @@ class KimiSoul:
         """Wait for any in-flight MCP startup to finish."""
         if not isinstance(self._agent.toolset, KimiToolset):
             return
-        await self._agent.toolset.wait_for_mcp_tools()
+        try:
+            await self._agent.toolset.wait_for_mcp_tools()
+        except MCPRuntimeError as exc:
+            logger.warning(
+                "MCP startup failed; continuing without unavailable servers: {error}",
+                error=exc,
+            )
 
     async def _checkpoint(self):
         await self._context.checkpoint(self._checkpoint_with_user_message)

--- a/tests/core/test_kimisoul_mcp.py
+++ b/tests/core/test_kimisoul_mcp.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from kimi_cli.exception import MCPRuntimeError
+from kimi_cli.soul.kimisoul import KimiSoul
+from kimi_cli.soul.toolset import KimiToolset
+
+
+async def test_background_mcp_failure_does_not_abort_the_turn() -> None:
+    """A failed optional MCP server must not make the whole CLI unusable."""
+    toolset = KimiToolset()
+
+    async def fail_to_connect() -> None:
+        raise MCPRuntimeError("Failed to connect MCP servers: {'slow': timeout}")
+
+    toolset._mcp_loading_task = asyncio.create_task(fail_to_connect())
+    soul = KimiSoul.__new__(KimiSoul)
+    cast(Any, soul)._agent = SimpleNamespace(toolset=toolset)
+
+    await soul.wait_for_background_mcp_loading()
+
+    assert toolset._mcp_loading_task is None
+
+
+async def test_background_mcp_wait_does_not_hide_unexpected_errors() -> None:
+    toolset = KimiToolset()
+
+    async def fail_unexpectedly() -> None:
+        raise ValueError("broken loader invariant")
+
+    toolset._mcp_loading_task = asyncio.create_task(fail_unexpectedly())
+    soul = KimiSoul.__new__(KimiSoul)
+    cast(Any, soul)._agent = SimpleNamespace(toolset=toolset)
+
+    with pytest.raises(ValueError, match="broken loader invariant"):
+        await soul.wait_for_background_mcp_loading()
+
+    assert toolset._mcp_loading_task is None


### PR DESCRIPTION
## Summary

- prevent an optional/background MCP startup failure from aborting the interactive turn
- catch only `MCPRuntimeError` at the deferred wait boundary
- keep unexpected loader errors visible

## Reproduction and verification

A real `KimiToolset` regression test deterministically failed on current `main` when its background MCP task raised `MCPRuntimeError`. After the fix:

- `uv run pytest tests/core/test_kimisoul_mcp.py tests/core/test_load_agent.py -q` — 16 passed
- targeted Ruff and Pyright — passed

This revives #2355, which was closed during contributor backlog cleanup rather than after a technical rejection.

Closes #2343
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->