### PR TITLE
fix(kaos): terminate local process trees

### DIFF
--- a/packages/kaos/src/kaos/local.py
+++ b/packages/kaos/src/kaos/local.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
+import subprocess
 from asyncio.subprocess import Process as AsyncioProcess
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if os.name == "nt":
     import ntpath as pathmodule
@@ -59,7 +62,36 @@ class LocalKaos:
             return await self._process.wait()
 
         async def kill(self) -> None:
-            self._process.kill()
+            if self._process.returncode is not None:
+                return
+
+            if os.name == "nt":
+                # The process has its own console process group, so Ctrl+Break
+                # cannot reach Kimi or another independently launched command.
+                try:
+                    os.kill(self.pid, signal.CTRL_BREAK_EVENT)
+                    await asyncio.sleep(0.1)
+                except OSError:
+                    pass
+                killer = await asyncio.create_subprocess_exec(
+                    "taskkill",
+                    "/PID",
+                    str(self.pid),
+                    "/T",
+                    "/F",
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await killer.wait()
+                if killer.returncode != 0 and self._process.returncode is None:
+                    self._process.kill()
+            else:
+                # exec() starts each command in a dedicated session. Its PID is
+                # therefore also the process-group ID and safe to target here.
+                with suppress(ProcessLookupError):
+                    os_module = cast(Any, os)
+                    signal_module = cast(Any, signal)
+                    os_module.killpg(self.pid, signal_module.SIGKILL)
 
     def pathclass(self) -> type[PurePath]:
         return PurePathClass
@@ -166,13 +198,26 @@ class LocalKaos:
         if not args:
             raise ValueError("At least one argument (the program to execute) is required.")
 
-        process = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
+        if os.name == "nt":
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                # Isolate console control events used by Process.kill().
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            )
+        else:
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                # Give Process.kill() an exact group containing only this tree.
+                start_new_session=True,
+            )
         return self.Process(process)
 
 

--- a/packages/kaos/tests/test_local_kaos.py
+++ b/packages/kaos/tests/test_local_kaos.py
@@ -196,3 +196,43 @@ async def test_exec_wait_timeout(local_kaos: LocalKaos):
         if process.returncode is None:
             await process.kill()
         await process.wait()
+
+
+async def test_kill_terminates_descendant_processes(local_kaos: LocalKaos, tmp_path: Path):
+    marker = tmp_path / "descendant-survived"
+    if os.name == "nt":
+        bash = Path(os.environ["PROGRAMFILES"]) / "Git" / "bin" / "bash.exe"
+        if not bash.exists():
+            pytest.skip("Git Bash is required for the Windows process-tree regression test")
+        marker_arg = marker.as_posix()
+        process = await local_kaos.exec(
+            str(bash),
+            "-c",
+            f'(sleep 0.5; echo alive > "{marker_arg}") & sleep 30',
+        )
+    else:
+        descendant_code = (
+            "import pathlib, sys, time; "
+            "time.sleep(0.5); "
+            "pathlib.Path(sys.argv[1]).write_text('alive', encoding='utf-8')"
+        )
+        parent_code = (
+            "import subprocess, sys, time; "
+            "subprocess.Popen([sys.executable, '-c', sys.argv[1], sys.argv[2]]); "
+            "time.sleep(30)"
+        )
+        process = await local_kaos.exec(
+            sys.executable,
+            "-c",
+            parent_code,
+            descendant_code,
+            str(marker),
+        )
+
+    await asyncio.sleep(0.1)
+    await process.kill()
+    await asyncio.wait_for(process.wait(), timeout=2)
+    await asyncio.gather(process.stdout.read(), process.stderr.read())
+    await asyncio.sleep(0.6)
+
+    assert not marker.exists()


### PR DESCRIPTION
## Summary

- isolate every local KAOS command in its own process group/session
- terminate the exact local process tree on cancellation or timeout
- keep SSH and ACP implementations unchanged

## Reproduction and verification

On Windows Git Bash, the regression test deterministically showed the old code killing only the Bash parent while a descendant survived and `wait()` timed out. The fixed test passed five consecutive runs.

- `uv run pytest packages/kaos/tests -q` — 25 passed, 29 platform-skipped
- targeted Ruff and Pyright — passed

This supersedes closed #2327 and avoids its reviewed platform-detection mismatch by using `os.name` consistently at both process creation and termination.

Closes #2310
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->