### PR TITLE
fix(print): escape markup in echoed stdin prompts

### DIFF
--- a/src/kimi_cli/ui/print/__init__.py
+++ b/src/kimi_cli/ui/print/__init__.py
@@ -16,6 +16,7 @@ from kosong.chat_provider import (
 )
 from kosong.message import Message
 from rich import print
+from rich.markup import escape
 
 from kimi_cli.background.models import is_terminal_status
 from kimi_cli.cli import ExitCode, InputFormat, OutputFormat
@@ -88,7 +89,7 @@ class Print:
                 if command:
                     logger.info("Running agent with command: {command}", command=command)
                     if self.output_format == "text" and not self.final_only:
-                        print(command)
+                        print(escape(command))
                     runtime = self.soul.runtime if isinstance(self.soul, KimiSoul) else None
                     await run_soul(
                         self.soul,

--- a/tests/ui_and_conv/test_print_exit_code.py
+++ b/tests/ui_and_conv/test_print_exit_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -111,6 +112,29 @@ class TestPrintRunExitCode:
         p = _make_print(soul, tmp_path)
         code = asyncio.run(p.run(command="hello"))
         assert code == ExitCode.SUCCESS
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "hello",
+            '* WRONG: `A[/login]` or `B[/ home]`\n* CORRECT: `A["/login"]`',
+        ],
+    )
+    def test_stdin_prompt_is_printed_literally_and_sent_unchanged(
+        self, command: str, tmp_path: Path, monkeypatch, capsys
+    ):
+        soul = _make_soul()
+        p = _make_print(soul, tmp_path)
+        run_soul = AsyncMock()
+        monkeypatch.setattr("kimi_cli.ui.print.run_soul", run_soul)
+        monkeypatch.setattr("sys.stdin", io.StringIO(command))
+
+        code = asyncio.run(p.run())
+
+        assert code == ExitCode.SUCCESS
+        assert capsys.readouterr().out.rstrip("\n") == command
+        assert run_soul.await_args is not None
+        assert run_soul.await_args.args[1] == command
 
     def test_llm_not_set_returns_failure(self, tmp_path: Path, monkeypatch):
         soul = _make_soul()


### PR DESCRIPTION
## Summary

- render stdin prompts literally instead of interpreting user text as Rich markup
- keep the prompt passed to the model byte-for-byte unchanged
- cover normal and markup-like stdin input

## Reproduction and verification

Before the fix, the issue example containing `[/login]` deterministically raised `rich.errors.MarkupError`. After the fix:

- `uv run pytest tests/ui_and_conv/test_print_exit_code.py -q` — 25 passed
- targeted Ruff and Pyright — passed

Closes #1291
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->