### PR TITLE
fix(tools): count StrReplaceFile replacements against running content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Tools: Fix the StrReplaceFile success message reporting the wrong replacement total when multiple edits interact; the count now follows the running content instead of the original file
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -78,12 +78,15 @@ class StrReplaceFile(CallableTool2[Params]):
             )
         return None
 
-    def _apply_edit(self, content: str, edit: Edit) -> str:
-        """Apply a single edit to the content."""
+    def _apply_edit(self, content: str, edit: Edit) -> tuple[str, int]:
+        """Apply a single edit, returning the new content and how many
+        replacements it made against the content passed in."""
         if edit.replace_all:
-            return content.replace(edit.old, edit.new)
+            count = content.count(edit.old)
+            return content.replace(edit.old, edit.new), count
         else:
-            return content.replace(edit.old, edit.new, 1)
+            count = 1 if edit.old in content else 0
+            return content.replace(edit.old, edit.new, 1), count
 
     @override
     async def __call__(self, params: Params) -> ToolReturnValue:
@@ -134,9 +137,14 @@ class StrReplaceFile(CallableTool2[Params]):
             original_content = content
             edits = [params.edit] if isinstance(params.edit, Edit) else params.edit
 
-            # Apply all edits
+            # Apply all edits, counting replacements as they actually happen.
+            # Edits apply sequentially, so a later edit sees the output of the
+            # earlier ones; counting against the running content keeps the
+            # reported total accurate when edits interact.
+            total_replacements = 0
             for edit in edits:
-                content = self._apply_edit(content, edit)
+                content, n_replacements = self._apply_edit(content, edit)
+                total_replacements += n_replacements
 
             # Check if any changes were made
             if content == original_content:
@@ -168,14 +176,6 @@ class StrReplaceFile(CallableTool2[Params]):
 
             # Write the modified content back to the file
             await p.write_text(content, errors="replace")
-
-            # Count changes for success message
-            total_replacements = 0
-            for edit in edits:
-                if edit.replace_all:
-                    total_replacements += original_content.count(edit.old)
-                else:
-                    total_replacements += 1 if edit.old in original_content else 0
 
             return ToolReturnValue(
                 is_error=False,

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -231,6 +231,49 @@ async def test_replace_mixed_multiple_edits(
     assert await file_path.read_text() == "fruit apple tasty apple cherry"
 
 
+async def test_replace_reports_replacement_count(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """A single replace_all edit reports the number of occurrences replaced."""
+    file_path = temp_work_dir / "test.txt"
+    await file_path.write_text("apple banana apple cherry apple")
+
+    result = await str_replace_file_tool(
+        Params(
+            path=str(file_path),
+            edit=Edit(old="apple", new="fruit", replace_all=True),
+        )
+    )
+
+    assert not result.is_error
+    assert "3 total replacement(s)" in result.message
+
+
+async def test_replace_count_accounts_for_interacting_edits(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """When an earlier edit changes how many times a later edit matches, the
+    reported count must follow the running content, not the original file."""
+    file_path = temp_work_dir / "test.txt"
+    await file_path.write_text("foo bar foo")
+
+    result = await str_replace_file_tool(
+        Params(
+            path=str(file_path),
+            edit=[
+                Edit(old="foo", new="foo bar", replace_all=True),
+                Edit(old="bar", new="baz", replace_all=True),
+            ],
+        )
+    )
+
+    assert not result.is_error
+    # foo->"foo bar" replaces 2, producing "foo bar bar foo bar"; bar->baz then
+    # replaces 3. Counting against the original file would wrongly report 3.
+    assert await file_path.read_text() == "foo baz baz foo baz"
+    assert "5 total replacement(s)" in result.message
+
+
 async def test_replace_empty_strings(
     str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
 ):


### PR DESCRIPTION
## Related Issue

No open issue for this one, I hit it while reading `StrReplaceFile`. It is a small self-contained correctness fix (well under the 100 LOC discussion threshold), happy to close if you would rather have an issue first.

## Description

The success message for `StrReplaceFile` counted replacements by summing `original_content.count(edit.old)` for each edit. But edits apply sequentially, so a later edit runs against the output of the earlier ones, not the original file. When edits interact, the reported total is wrong.

Example: file `foo bar foo`, two `replace_all` edits `foo -> "foo bar"` then `bar -> "baz"`:
- `foo -> "foo bar"` replaces 2, giving `foo bar bar foo bar`
- `bar -> "baz"` then replaces 3, giving `foo baz baz foo baz`
- actual total 5, but the message reported 3 (2 + 1 counted against the original)

The file edit itself was always correct; only the reported count was off. Fix counts each replacement as it actually happens by having `_apply_edit` return the count alongside the new content, which also lets the redundant second pass over the edits go away.

Single-edit cases are unchanged (a `replace_all` edit still reports its occurrence count, a single edit reports 1).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works. (two tests in `test_str_replace_file.py`: a single-edit count check and the interacting-edits case above, which reported 3 before)
- [x] I have run `make gen-changelog` to update the changelog. (hand-edited CHANGELOG.md in the same style, I do not have the Kimi API setup the skill needs)
- [x] I have run `make gen-docs` to update the user documentation. (no user docs describe this message, nothing to regenerate)

---

quick note: freshman here, found this reading the edit tool and figured a wrong count could quietly mislead. kept the change tiny and consulted claude code on the counting semantics to be sure str.count lines up with str.replace. if you would rather not touch it, no worries at all, still learning what is worth a PR :)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->