### PR TITLE
fix(hooks): fire PostToolUse hooks through fire_and_forget_trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Hooks: Fire `PostToolUse` and `PostToolUseFailure` through `fire_and_forget_trigger` so the hook task keeps a strong reference and failures are logged, instead of a bare `asyncio.create_task` whose handle is dropped
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/soul/toolset.py
+++ b/src/kimi_cli/soul/toolset.py
@@ -506,22 +506,17 @@ class KimiToolset:
                         call_id=tool_call.id,
                     )
                     # --- PostToolUseFailure (fire-and-forget) ---
-                    _hook_task = asyncio.create_task(
-                        self._hook_engine.trigger(
-                            "PostToolUseFailure",
-                            matcher_value=tool_name,
-                            input_data=events.post_tool_use_failure(
-                                session_id=_get_session_id(),
-                                cwd=str(Path.cwd()),
-                                tool_name=tool_name,
-                                tool_input=tool_input_dict,
-                                error=str(e),
-                                tool_call_id=tool_call.id,
-                            ),
-                        )
-                    )
-                    _hook_task.add_done_callback(
-                        lambda t: t.exception() if not t.cancelled() else None
+                    self._hook_engine.fire_and_forget_trigger(
+                        "PostToolUseFailure",
+                        matcher_value=tool_name,
+                        input_data=events.post_tool_use_failure(
+                            session_id=_get_session_id(),
+                            cwd=str(Path.cwd()),
+                            tool_name=tool_name,
+                            tool_input=tool_input_dict,
+                            error=str(e),
+                            tool_call_id=tool_call.id,
+                        ),
                     )
                     from kimi_cli.telemetry import track
 
@@ -574,21 +569,18 @@ class KimiToolset:
                     )
 
                 # --- PostToolUse (fire-and-forget) ---
-                _hook_task = asyncio.create_task(
-                    self._hook_engine.trigger(
-                        "PostToolUse",
-                        matcher_value=tool_name,
-                        input_data=events.post_tool_use(
-                            session_id=_get_session_id(),
-                            cwd=str(Path.cwd()),
-                            tool_name=tool_name,
-                            tool_input=tool_input_dict,
-                            tool_output=str(ret)[:2000],
-                            tool_call_id=tool_call.id,
-                        ),
-                    )
+                self._hook_engine.fire_and_forget_trigger(
+                    "PostToolUse",
+                    matcher_value=tool_name,
+                    input_data=events.post_tool_use(
+                        session_id=_get_session_id(),
+                        cwd=str(Path.cwd()),
+                        tool_name=tool_name,
+                        tool_input=tool_input_dict,
+                        tool_output=str(ret)[:2000],
+                        tool_call_id=tool_call.id,
+                    ),
                 )
-                _hook_task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
 
                 return ToolResult(tool_call_id=tool_call.id, return_value=ret)
 

--- a/tests/hooks/test_toolset_fire_and_forget.py
+++ b/tests/hooks/test_toolset_fire_and_forget.py
@@ -1,0 +1,79 @@
+"""PostToolUse hooks must go through the engine's tracked fire-and-forget path.
+
+`HookEngine.fire_and_forget_trigger` keeps a strong reference to the hook task
+(asyncio only holds tasks in a WeakSet) and logs failures. Firing hooks with a
+bare `asyncio.create_task` whose handle is discarded loses both.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from kosong.tooling import CallableTool2, ToolOk, ToolReturnValue
+from pydantic import BaseModel
+
+from kimi_cli.hooks.engine import HookEngine
+from kimi_cli.soul.toolset import KimiToolset
+from kimi_cli.wire.types import ToolCall
+
+
+class _Params(BaseModel):
+    value: str = ""
+
+
+class _OkTool(CallableTool2[_Params]):
+    name: str = "ToolA"
+    description: str = "Tool A"
+    params: type[_Params] = _Params
+
+    async def __call__(self, params: _Params) -> ToolReturnValue:
+        return ToolOk(output="a")
+
+
+class _FailingTool(CallableTool2[_Params]):
+    name: str = "ToolB"
+    description: str = "Tool B"
+    params: type[_Params] = _Params
+
+    async def __call__(self, params: _Params) -> ToolReturnValue:
+        raise RuntimeError("boom")
+
+
+class _RecordingHookEngine(HookEngine):
+    """Records which events were fired through the tracked helper."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fire_and_forget_events: list[str] = []
+
+    def fire_and_forget_trigger(self, event, *, matcher_value="", input_data):  # type: ignore[no-untyped-def]
+        self.fire_and_forget_events.append(event)
+        return super().fire_and_forget_trigger(
+            event, matcher_value=matcher_value, input_data=input_data
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "event"),
+    [(_OkTool(), "PostToolUse"), (_FailingTool(), "PostToolUseFailure")],
+)
+async def test_post_tool_use_hooks_use_tracked_fire_and_forget(
+    tool: CallableTool2[_Params], event: str
+) -> None:
+    engine = _RecordingHookEngine()
+    toolset = KimiToolset()
+    toolset.add(tool)
+    toolset.set_hook_engine(engine)
+
+    tool_call = ToolCall(
+        id="call-1",
+        function=ToolCall.FunctionBody(name=tool.name, arguments=json.dumps({"value": "x"})),
+    )
+    result = toolset.handle(tool_call)
+    if isinstance(result, asyncio.Task):
+        await result
+
+    assert engine.fire_and_forget_events == [event]


### PR DESCRIPTION
## Related Issue

Resolve #2564

## Description

`PostToolUse` and `PostToolUseFailure` fired their hooks with a bare `asyncio.create_task(...)` and then dropped the handle on the next line. Two problems with that:

1. asyncio only keeps tasks in a `WeakSet`, so a pending hook task that nothing else references can be collected before its subprocess finishes. This is the footgun the CPython docs warn about.
2. The inline done callback (`lambda t: t.exception() if not t.cancelled() else None`) retrieved the exception purely to silence the "never retrieved" warning, so a hook that failed did so silently.

`HookEngine.fire_and_forget_trigger` already exists for exactly this pattern, its docstring describes this bug, and `SubagentStop` in `subagents/runner.py` already uses it. It holds a strong reference in `_pending_fire_and_forget` until the task completes and logs failures via `_log_fire_and_forget_failure`. These two call sites just were not migrated. So this is a reuse of what is already here rather than anything new.

One honest caveat: I could not build a test that deterministically reproduces the collection itself. I tried forcing `gc.collect()` while a real hook subprocess was mid-flight and the hook still completed on unpatched code, since the task stays reachable through the loop's callback chain in that window. So the collection is a real but nondeterministic race, and I did not want to commit a test that passes for the wrong reason. The test I did add asserts the contract that actually differs: both hook events now route through the tracked helper. It fails on unpatched code for both events and passes after. The silent-failure-logging half of the fix is unconditional either way.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works. (see the caveat above on what exactly is asserted)
- [x] I have run `make gen-changelog` to update the changelog. (hand-edited CHANGELOG.md in the same style, I do not have the Kimi API setup the skill needs)
- [x] I have run `make gen-docs` to update the user documentation. (nothing in docs describes this internal behavior)

---

for transparency: freshman, and the issue author had already traced this one well so most of the credit is theirs. i verified the two call sites and the helper at HEAD myself before touching anything, and talked through the asyncio task lifetime bits with claude code since that part is genuinely subtle. if the test framing is not what you want here i am happy to change it :)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->