### PR TITLE
fix(web,vis): do not crash printing the startup banner on legacy console codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Web/Vis: Fix `kimi web` and `kimi vis` dying at startup on consoles whose codec cannot encode the banner arrow (GBK on Chinese Windows, for example). The banner is printed before the server binds its port, so the crash left nothing listening; unsupported characters are now replaced instead of raising
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/utils/server.py
+++ b/src/kimi_cli/utils/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import socket
+import sys
 import textwrap
 
 
@@ -86,8 +87,28 @@ def get_network_addresses() -> list[str]:
     return addresses
 
 
+def _encodable(text: str) -> str:
+    """Drop characters stdout cannot encode, so printing never raises.
+
+    The banner uses characters like U+279C that a legacy console codec (GBK on
+    Chinese Windows, for example) cannot represent. Printing those raises
+    UnicodeEncodeError, and since the banner is printed before the server binds
+    its port, an unhandled error there takes the whole process down.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        text.encode(encoding)
+    except UnicodeEncodeError:
+        return text.encode(encoding, errors="replace").decode(encoding, errors="replace")
+    except LookupError:
+        return text
+    return text
+
+
 def print_banner(lines: list[str]) -> None:
     """Print a boxed banner with tag conventions (<center>, <nowrap>, <hr>)."""
+    # Sanitize before measuring so the box borders still line up.
+    lines = [_encodable(line) for line in lines]
     processed: list[str] = []
     for line in lines:
         if line == "<hr>":

--- a/tests/core/test_print_banner_encoding.py
+++ b/tests/core/test_print_banner_encoding.py
@@ -1,0 +1,39 @@
+"""print_banner must not raise on consoles whose codec lacks banner glyphs.
+
+The banner is printed before the web/vis server binds its port, so an
+unhandled UnicodeEncodeError there kills the process and the server never
+starts.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+from kimi_cli.utils.server import print_banner
+
+# U+279C is what web/app.py and vis/app.py put in front of each URL.
+_BANNER_LINE = "<nowrap>  ➜  Local    http://127.0.0.1:8000"
+
+
+def _render(encoding: str) -> str:
+    """Render the banner to a stream using the given console encoding."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors="strict", newline="")
+    with contextlib.redirect_stdout(stream):
+        print_banner([_BANNER_LINE])
+    stream.flush()
+    return stream.buffer.getvalue().decode(encoding)  # type: ignore[attr-defined]
+
+
+def test_print_banner_survives_unencodable_glyph() -> None:
+    # gbk is the Chinese-locale Windows console codec and cannot encode U+279C.
+    assert "http://127.0.0.1:8000" in _render("gbk")
+
+
+def test_print_banner_box_stays_aligned() -> None:
+    lines = [line for line in _render("gbk").splitlines() if line]
+    assert len({len(line) for line in lines}) == 1, lines
+
+
+def test_print_banner_keeps_glyph_when_encoding_supports_it() -> None:
+    assert "➜" in _render("utf-8")


### PR DESCRIPTION
## Related Issue

Resolve #2532

## Description

`print_banner` in `src/kimi_cli/utils/server.py` writes the banner with a bare `print()`, and both callers put U+279C in front of each URL (`web/app.py:374,376` and `vis/app.py:128`). On a console whose codec cannot represent that character, GBK on Chinese Windows being the reported case, the print raises `UnicodeEncodeError`.

The part that makes it more than cosmetic: the banner is printed before the server binds its port, so the unhandled error takes the process down and nothing ends up listening. From the user side that shows up as a Web UI stuck on WebSocket errors rather than as a crash, which makes it a confusing one to diagnose.

Characters the current stdout encoding cannot represent are now replaced instead of raising. Two details worth mentioning:

- The substitution happens before the box width is measured, otherwise the replacement changes the line length and the box borders stop lining up.
- Terminals that can encode the glyph are unaffected, so this does not downgrade normal output. There is a test covering that.

I deliberately did not touch `sys.stdout` reconfiguration or add an env var. Both would fix the symptom globally but change behavior well outside this banner, and the crash only needs the one guard where both callers already funnel through.

The issue was filed against 1.43.0; I verified the same code path is still there at HEAD (4a550eff, 1.49.0).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works. (renders the banner through a gbk stream, which raises on current main; plus a box alignment check and a utf-8 case asserting the arrow survives)
- [x] I have run `make gen-changelog` to update the changelog. (hand-edited CHANGELOG.md in the same style, I do not have the Kimi API setup the skill needs)
- [x] I have run `make gen-docs` to update the user documentation. (nothing in docs covers banner rendering)

Note on gates: `make check-kimi-cli` is clean and `make test-kimi-cli` passes. One PTY e2e test (`test_shell_mode_toggle_roundtrip`) flaked once under full suite load on my machine; it passes in isolation on both this branch and unmodified main, and the full e2e suite passes on re-run, so it looks like timing rather than anything from this change.

---

small disclosure as usual: freshman, no Windows machine to hand so I reproduced the encoding failure by rendering the banner through a gbk stream rather than on real hardware. logic decisions talked through with claude code. if you would rather just swap the arrow for an ascii character and skip the helper entirely, that is a totally fair call and i am happy to redo it that way :)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->