### PR TITLE
fix(soul): name the config fix in the unsupported-capability error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Core: Point the unsupported-capability error at the fix, naming the `capabilities` setting to declare on the model entry instead of only reporting which capability was missing
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/soul/__init__.py
+++ b/src/kimi_cli/soul/__init__.py
@@ -34,9 +34,13 @@ class LLMNotSupported(Exception):
         self.llm = llm
         self.capabilities = capabilities
         capabilities_str = "capability" if len(capabilities) == 1 else "capabilities"
+        declared = ", ".join(f'"{c}"' for c in sorted(capabilities))
         super().__init__(
             f"LLM model '{llm.model_name}' does not support required {capabilities_str}: "
-            f"{', '.join(capabilities)}."
+            f"{', '.join(capabilities)}. "
+            f"If the model does support this, declare `capabilities = [{declared}]` "
+            "on its entry in your config file; input capabilities are only taken from "
+            "that setting for manually configured models."
         )
 
 

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -15,7 +15,7 @@ def test_soul_exceptions(llm: LLM):
         raise LLMNotSupported(llm, ["image_in"])
     except LLMNotSupported as e:
         assert str(e) == snapshot(
-            "LLM model 'mock' does not support required capability: image_in."
+            "LLM model 'mock' does not support required capability: image_in. If the model does support this, declare `capabilities = [\"image_in\"]` on its entry in your config file; input capabilities are only taken from that setting for manually configured models."
         )
 
     try:

--- a/tests/core/test_llm_not_supported_message.py
+++ b/tests/core/test_llm_not_supported_message.py
@@ -1,0 +1,34 @@
+"""The capability error must name the config setting that fixes it.
+
+Capabilities like `image_in` are only picked up from a model's `capabilities`
+entry for manually configured models, so an error that just states the missing
+capability leaves the user with no way to act on it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kimi_cli.soul import LLMNotSupported
+
+
+def _message(*capabilities: str) -> str:
+    llm = MagicMock()
+    llm.model_name = "Qwen3.6-27B"
+    return str(LLMNotSupported(llm, list(capabilities)))  # type: ignore[arg-type]
+
+
+def test_single_capability_message_points_at_the_config_fix() -> None:
+    message = _message("image_in")
+
+    assert "Qwen3.6-27B" in message
+    assert "does not support required capability: image_in" in message
+    assert 'capabilities = ["image_in"]' in message
+
+
+def test_multiple_capabilities_are_listed_in_the_suggested_setting() -> None:
+    message = _message("video_in", "image_in")
+
+    assert "does not support required capabilities:" in message
+    # Sorted so the suggestion is stable regardless of set iteration order.
+    assert 'capabilities = ["image_in", "video_in"]' in message

--- a/tests_e2e/test_wire_errors.py
+++ b/tests_e2e/test_wire_errors.py
@@ -164,7 +164,7 @@ def test_llm_not_supported(tmp_path) -> None:
             {
                 "error": {
                     "code": -32002,
-                    "message": "LLM model 'scripted_echo' does not support required capability: image_in.",
+                    "message": "LLM model 'scripted_echo' does not support required capability: image_in. If the model does support this, declare `capabilities = [\"image_in\"]` on its entry in your config file; input capabilities are only taken from that setting for manually configured models.",
                     "data": None,
                 }
             }


### PR DESCRIPTION
## Related Issue

Partially addresses #2588 (the "no hint at the fix" half).

## Description

#2588 reports two separate problems. This PR only tackles the smaller, self-contained one: the error tells you which capability is missing but never tells you what to change.

Before:

```
LLM model 'Qwen3.6-27B' does not support required capability: image_in.
```

After:

```
LLM model 'Qwen3.6-27B' does not support required capability: image_in. If the model
does support this, declare `capabilities = ["image_in"]` on its entry in your config
file; input capabilities are only taken from that setting for manually configured models.
```

The wording is deliberately conditional. `derive_model_capabilities` (`llm.py:532`) only infers thinking-related capabilities, from the model name and a couple of hardcoded Kimi models, so `image_in` and `video_in` for a custom model come solely from the `capabilities` entry that is already documented in `docs/en/configuration/config-files.md`. The error should not claim the model is capable, only point at the setting if it is.

What this PR does **not** do: the bigger half of #2588 is that the abort happens after tool side effects have landed, and the argument there is that a statically knowable capability should be checked before the run starts rather than when the offending message appears. That is a real design question about where the check belongs, so it seemed better left to you than guessed at by a drive-by.

Two existing inline snapshots pinned the old string (`tests/core/test_exceptions.py`, `tests_e2e/test_wire_errors.py`); both were regenerated with `--inline-snapshot=fix` rather than hand-edited.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works. (new `tests/core/test_llm_not_supported_message.py` covering the single and multiple capability wording; both fail on current main)
- [x] I have run `make gen-changelog` to update the changelog. (hand-edited CHANGELOG.md in the same style, I do not have the Kimi API setup the skill needs)
- [x] I have run `make gen-docs` to update the user documentation. (the `capabilities` setting is already documented, nothing to regenerate)

---

usual disclosure: freshman, so i deliberately took only the part of that issue i could be confident about and left the "check capabilities before running" design call to you. checked the capability resolution path myself and talked the wording through with claude code so the message would not overclaim. happy to reword or drop it :)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonshotai/kimi-cli/pull/2590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->