### PR TITLE
fix(StrReplaceFile): refuse to edit files that are not valid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Only write entries that are worth mentioning to users.
 ## Unreleased
 
 - Kosong: Stop sending an empty `anthropic-beta` header when no beta features are declared — adaptive thinking removes the interleaved-thinking beta, which previously left an empty header value that some backends reject
+- Tools: `StrReplaceFile` now refuses to edit a file that is not valid UTF-8 instead of silently corrupting it — the whole-file round trip replaced every undecodable byte with U+FFFD, anywhere in the file, including bytes far from the edit and invisible in the approval diff
 
 ## 1.49.0 (2026-07-16)
 

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -131,6 +131,29 @@ class StrReplaceFile(CallableTool2[Params]):
             # Read the file content
             content = await p.read_text(errors="replace")
 
+            # This tool reads the whole file, edits the string, and writes the whole
+            # string back, so every undecodable byte in the file — including bytes
+            # nowhere near the edit — would come back as U+FFFD and be written out as
+            # EF BF BD. Refuse rather than silently rewrite bytes the edit never asked
+            # to touch. A U+FFFD present in the decoded text is only a symptom: it may
+            # equally be a real U+FFFD stored in the file, so confirm against the raw
+            # bytes before rejecting. The strict decode below is deliberate and is
+            # caught, not propagated, so it cannot panic on malformed UTF-8.
+            if "�" in content:
+                try:
+                    (await p.read_bytes()).decode("utf-8")
+                except UnicodeDecodeError as decode_error:
+                    return ToolError(
+                        message=(
+                            f"`{params.path}` is not valid UTF-8 "
+                            f"(byte 0x{decode_error.object[decode_error.start]:02x} at offset "
+                            f"{decode_error.start}). Editing it with StrReplaceFile would "
+                            "replace that byte, and every other undecodable byte in the file, "
+                            "with U+FFFD. No changes were made."
+                        ),
+                        brief="File is not valid UTF-8",
+                    )
+
             original_content = content
             edits = [params.edit] if isinstance(params.edit, Edit) else params.edit
 

--- a/src/kimi_cli/tools/file/replace.py
+++ b/src/kimi_cli/tools/file/replace.py
@@ -139,14 +139,15 @@ class StrReplaceFile(CallableTool2[Params]):
             # equally be a real U+FFFD stored in the file, so confirm against the raw
             # bytes before rejecting. The strict decode below is deliberate and is
             # caught, not propagated, so it cannot panic on malformed UTF-8.
-            if "�" in content:
+            if "\ufffd" in content:
+                raw_bytes = await p.read_bytes()
                 try:
-                    (await p.read_bytes()).decode("utf-8")
+                    raw_bytes.decode("utf-8")
                 except UnicodeDecodeError as decode_error:
                     return ToolError(
                         message=(
                             f"`{params.path}` is not valid UTF-8 "
-                            f"(byte 0x{decode_error.object[decode_error.start]:02x} at offset "
+                            f"(byte 0x{raw_bytes[decode_error.start]:02x} at offset "
                             f"{decode_error.start}). Editing it with StrReplaceFile would "
                             "replace that byte, and every other undecodable byte in the file, "
                             "with U+FFFD. No changes were made."

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -246,3 +246,59 @@ async def test_replace_empty_strings(
     assert not result.is_error
     assert "successfully edited" in result.message
     assert await file_path.read_text() == "Hello !"
+
+
+async def test_replace_refuses_file_with_undecodable_bytes(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """A file that is not valid UTF-8 is left byte-for-byte alone."""
+    file_path = temp_work_dir / "invalid.txt"
+    # The undecodable byte is nowhere near the edit, on a line the edit never mentions.
+    original_bytes = b"alpha\nbeta \xff gamma\ndelta\n"
+    await file_path.write_bytes(original_bytes)
+
+    result = await str_replace_file_tool(
+        Params(path=str(file_path), edit=Edit(old="alpha", new="ALPHA"))
+    )
+
+    assert result.is_error
+    assert "not valid UTF-8" in result.message
+    # Without the guard the file is rewritten with \xff replaced by \xef\xbf\xbd,
+    # growing by two bytes on an edit that only asked to touch "alpha".
+    assert await file_path.read_bytes() == original_bytes
+
+
+async def test_replace_allows_file_containing_real_replacement_character(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """U+FFFD stored in the file is legitimate content, not a failed decode."""
+    file_path = temp_work_dir / "fffd.txt"
+    original_content = "alpha\nbeta � gamma\ndelta\n"
+    await file_path.write_text(original_content)
+
+    result = await str_replace_file_tool(
+        Params(path=str(file_path), edit=Edit(old="alpha", new="ALPHA"))
+    )
+
+    assert not result.is_error
+    assert await file_path.read_text() == "ALPHA\nbeta � gamma\ndelta\n"
+
+
+async def test_replace_allows_crlf_file(
+    str_replace_file_tool: StrReplaceFile, temp_work_dir: KaosPath
+):
+    """CRLF files must not be mistaken for undecodable ones.
+
+    Reads translate CRLF to LF, so any detection that compares the decoded text
+    against the raw bytes would reject every Windows-line-ending file. (That the
+    write then normalizes the endings to LF is a separate bug, #2191.)
+    """
+    file_path = temp_work_dir / "crlf.txt"
+    await file_path.write_bytes(b"alpha\r\nbeta\r\n")
+
+    result = await str_replace_file_tool(
+        Params(path=str(file_path), edit=Edit(old="alpha", new="ALPHA"))
+    )
+
+    assert not result.is_error
+    assert b"ALPHA" in await file_path.read_bytes()

--- a/tests/tools/test_str_replace_file.py
+++ b/tests/tools/test_str_replace_file.py
@@ -273,7 +273,7 @@ async def test_replace_allows_file_containing_real_replacement_character(
 ):
     """U+FFFD stored in the file is legitimate content, not a failed decode."""
     file_path = temp_work_dir / "fffd.txt"
-    original_content = "alpha\nbeta � gamma\ndelta\n"
+    original_content = "alpha\nbeta \ufffd gamma\ndelta\n"
     await file_path.write_text(original_content)
 
     result = await str_replace_file_tool(
@@ -281,7 +281,7 @@ async def test_replace_allows_file_containing_real_replacement_character(
     )
 
     assert not result.is_error
-    assert await file_path.read_text() == "ALPHA\nbeta � gamma\ndelta\n"
+    assert await file_path.read_text() == "ALPHA\nbeta \ufffd gamma\ndelta\n"
 
 
 async def test_replace_allows_crlf_file(


### PR DESCRIPTION
## Related Issue

Resolve #2591

## Description

`StrReplaceFile` decodes the whole file with `errors="replace"`, applies the edit to the string, and writes the whole string back. Any byte that is not valid UTF-8, including bytes nowhere near the edit, comes back as U+FFFD and is written out as `EF BF BD`. The file changes outside the requested edit, and the approval diff cannot show it because the diff is built from the already-lossy string.

```
before: b'alpha\nbeta \xff gamma\ndelta\n'          25 bytes
after:  b'ALPHA\nbeta \xef\xbf\xbd gamma\ndelta\n'  27 bytes   # edit only asked to touch "alpha"
```

This PR detects the lossy decode and returns a `ToolError` instead of writing. The check runs before the approval request, so a corrupting edit is never offered for approval.

This is option 2 from #2591, refuse the edit. `surrogateescape` on both ends needs the `errors` type in `kaos.path` widened and is an exception to the convention in `tests_ai/test_encoding_error_handling.md`; byte-level splicing is a rewrite of how the tool applies edits. Refusing is small, cannot panic, and turns silent corruption into an error the user can see. The cost is that the tool now declines edits it currently performs by corrupting the file. If you would rather have option 1 or 3, say so and I will rewrite this.

Two design notes:

- U+FFFD in the decoded text is only a symptom, since the file may legitimately contain one. When U+FFFD is present, the raw bytes are re-read and strictly decoded to tell an original U+FFFD from a failed decode. A file without one still costs exactly one read. The strict decode is caught, not propagated, so it cannot panic on malformed UTF-8, and the read that produces the content the tool uses still passes `errors="replace"`.
- Detection cannot be `content.encode() != raw_bytes`. `kaos.local.readtext` opens without `newline=""`, so reads translate CRLF to LF, while `writetext` passes `newline=""`. That comparison would reject every CRLF file. `test_replace_allows_crlf_file` locks this down. The write normalizing those endings to LF is the separate bug in #2191 and is untouched here.

Not in this PR: `replace.py:170` writes with `errors="replace"`, which the project's own rule says is not needed on writes and which `write.py:158` does not do. After this guard it is a no-op, since the content is known to round-trip. Happy to drop it in a follow-up.

## Testing

Three tests added to `tests/tools/test_str_replace_file.py`:

| Test | Guards |
|---|---|
| `test_replace_refuses_file_with_undecodable_bytes` | The bug. Asserts the file is byte-for-byte unchanged. Fails on `main` (the edit succeeds and the file grows by two bytes). |
| `test_replace_allows_file_containing_real_replacement_character` | No false positive on a file that genuinely contains U+FFFD. |
| `test_replace_allows_crlf_file` | No false positive on CRLF files. |

Full suite: 2933 passed on this branch vs 2930 on `cbc15c07`, with the same 26 pre-existing failures (`tests/ui/test_usage.py`, `tests/utils/test_editor.py`) before and after. `ruff check`, `ruff format --check`, and `pyright` are clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog (added the entry by hand under `## Unreleased`; `make gen-changelog` shells out to `kimi` itself, which I did not want to run against your repo).
- [ ] I have run `make gen-docs` to update the user documentation. No user-facing docs describe this behavior, so there was nothing to regenerate.
